### PR TITLE
Extract dataset setup / teardown

### DIFF
--- a/datasetAPI/get_dataset_test.go
+++ b/datasetAPI/get_dataset_test.go
@@ -2,30 +2,17 @@ package datasetAPI
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
-	mgo "gopkg.in/mgo.v2"
-
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
-	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSuccessfullyGetADataset(t *testing.T) {
 
-	if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
-
-	if err := mongo.Setup(database, collection, "_id", datasetID, validPublishedDatasetData); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
+	setupDataset(datasetID, validPublishedDatasetData)
+	defer removeDataset(datasetID)
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
@@ -51,22 +38,12 @@ func TestSuccessfullyGetADataset(t *testing.T) {
 			checkDatasetDoc(response)
 		})
 	})
-
-	if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
-		if err != mgo.ErrNotFound {
-			os.Exit(1)
-		}
-	}
 }
 
 func TestFailureToGetADataset(t *testing.T) {
 
-	if err := mongo.Teardown(database, collection, "_id", "133"); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
+	removeExistingDataset(datasetID)
+	defer removeDataset(datasetID)
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
@@ -83,12 +60,6 @@ func TestFailureToGetADataset(t *testing.T) {
 			})
 		})
 	})
-
-	if err := mongo.Teardown(database, collection, "_id", "133"); err != nil {
-		if err != mgo.ErrNotFound {
-			os.Exit(1)
-		}
-	}
 }
 
 func checkDatasetDoc(response *httpexpect.Object) {

--- a/datasetAPI/post_dataset_test.go
+++ b/datasetAPI/post_dataset_test.go
@@ -2,24 +2,16 @@ package datasetAPI
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
-	mgo "gopkg.in/mgo.v2"
-
-	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
-	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSuccessfullyPostDataset(t *testing.T) {
-	if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
+
+	removeExistingDataset(datasetID)
+	defer removeDataset(datasetID)
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
@@ -61,12 +53,6 @@ func TestSuccessfullyPostDataset(t *testing.T) {
 		response.Value("next").Object().Value("theme").Equal("Goods and services")
 		response.Value("next").Object().Value("title").Equal("CPI")
 		response.Value("next").Object().Value("uri").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation")
-
-		if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
-			if err != mgo.ErrNotFound {
-				os.Exit(1)
-			}
-		}
 	})
 }
 

--- a/datasetAPI/setup_datasets.go
+++ b/datasetAPI/setup_datasets.go
@@ -1,0 +1,41 @@
+package datasetAPI
+
+import (
+	"gopkg.in/mgo.v2/bson"
+	"os"
+	"gopkg.in/mgo.v2"
+	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
+	"github.com/ONSdigital/go-ns/log"
+)
+
+// setupDataset cleans existing stale test data and creates a new test dataset.
+func setupDataset(datasetID string, datasetData bson.M) {
+
+	removeExistingDataset(datasetID)
+
+	if err := mongo.Setup(database, "datasets", "_id", datasetID, datasetData); err != nil {
+		log.ErrorC("Was unable to run test", err, nil)
+		os.Exit(1)
+	}
+}
+
+// removeExistingDataset clears out any existing dataset.
+func removeExistingDataset(datasetID string) {
+	if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
+		if err != mgo.ErrNotFound {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+	}
+}
+
+// removeDataset removes the dataset that was created in a test.
+func removeDataset(datasetID string) {
+	if err := mongo.Teardown(database, "datasets", "_id", datasetID); err != nil {
+		if err != mgo.ErrNotFound {
+			os.Exit(1)
+		}
+	}
+}
+
+


### PR DESCRIPTION
### What

Extract dataset setup / teardown into functions for reuse across dataset related tests. 

Just a bit of refactoring to try and centralise setup and teardown code. Does not have to be merged in as is, especially if it clashes a lot with other changes. I wonder if its worth having subdirectories under each api to further group the files. Something like this:

* setup
* datasets
* editions
* versions

I also used a defer on the teardown function so it can sit alongside the setup. Let me know what you think.

### How to review

See changes

### Who can review

@nshumoogum 