### PR TITLE
Update the PUT dataset test to set the state to associated

### DIFF
--- a/datasetAPI/json.go
+++ b/datasetAPI/json.go
@@ -477,7 +477,7 @@ var validPUTUpdateDatasetJSON string = `{
 			}
 		],
 		"release_frequency": "Quaterly",
-		"state": "created",
+		"state": "associated",
 		"theme": "Price movement of goods",
 		"title": "RPI",
 		"uri": "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/producerpriceindex"

--- a/datasetAPI/put_dataset_test.go
+++ b/datasetAPI/put_dataset_test.go
@@ -67,7 +67,7 @@ func TestSuccessfulyUpdateDataset(t *testing.T) {
 		response.Value("next").Object().Value("related_datasets").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/producerpriceindex")
 		response.Value("next").Object().Value("related_datasets").Array().Element(0).Object().Value("title").Equal("Producer Price Index time series dataset")
 		response.Value("next").Object().Value("release_frequency").Equal("Quaterly")
-		response.Value("next").Object().Value("state").Equal("created")
+		response.Value("next").Object().Value("state").Equal("associated")
 		response.Value("next").Object().Value("theme").Equal("Price movement of goods")
 		response.Value("next").Object().Value("title").Equal("RPI")
 		response.Value("next").Object().Value("uri").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/producerpriceindex")


### PR DESCRIPTION
### What

Update the PUT dataset test to set the state to associated and check that it gets set as expected.

Part of adding a dataset to a collection in florence involves setting the dataset status to associated and adding a collection ID. Currently the state is not updated to 'associated' when a PUT is sent. The state stays as 'created' 

### How to review

See that the test is reasonable

### Who can review

@nshumoogum @pathimanoj 
