### PR TITLE
Feature/extend dataset tests

### DIFF
--- a/datasetAPI/get_dataset_dimensions_test.go
+++ b/datasetAPI/get_dataset_dimensions_test.go
@@ -109,124 +109,125 @@ func TestGetDimensions_ReturnsAllDimensionsFromADataset(t *testing.T) {
 	}
 }
 
-// TODO Reinstate these tests when code has been fixed
-// func TestGetDimensions_Failed(t *testing.T) {
-// 	datasetID := uuid.NewV4().String()
-// 	editionID := uuid.NewV4().String()
-// 	instanceID := uuid.NewV4().String()
-//
-// 	edition := "2017"
-//
-// 	var docs []mongo.Doc
-//
-// 	datasetDoc := mongo.Doc{
-// 		Database:   "datasets",
-// 		Collection: "datasets",
-// 		Key:        "_id",
-// 		Value:      datasetID,
-// 		Update:     validPublishedDatasetData(datasetID),
-// 	}
-//
-// 	editionDoc := mongo.Doc{
-// 		Database:   "datasets",
-// 		Collection: "editions",
-// 		Key:        "_id",
-// 		Value:      editionID,
-// 		Update:     validPublishedEditionData(datasetID, editionID, edition),
-// 	}
-//
-// 	instanceOneDoc := mongo.Doc{
-// 		Database:   "datasets",
-// 		Collection: "instances",
-// 		Key:        "_id",
-// 		Value:      instanceID,
-// 		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
-// 	}
-//
-// 	docs = append(docs, datasetDoc, editionDoc, instanceOneDoc)
-//
-// 	d := &mongo.ManyDocs{
-// 		Docs: docs,
-// 	}
-//
-// 	if err := mongo.TeardownMany(d); err != nil {
-// 		if err != mgo.ErrNotFound {
-// 			log.ErrorC("Was unable to run test", err, nil)
-// 			os.Exit(1)
-// 		}
-// 	}
-//
-// 	if err := mongo.SetupMany(d); err != nil {
-// 		log.ErrorC("Was unable to run test", err, nil)
-// 		os.Exit(1)
-// 	}
-//
-// 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-//
-// 	Convey("Fail to get a list of Dimensions for a dataset", t, func() {
-//Convey("When authenticated", func() {
-// Convey("When the dataset does not exist", func() {
-// 	datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").WithHeader(internalToken, internalTokenID).
-// 		Expect().Status(http.StatusBadRequest)
-// })
-//
-// Convey("When the edition does not exist", func() {
-// 	datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").WithHeader(internalToken, internalTokenID).
-// 		Expect().Status(http.StatusBadRequest)
-// })
-//
-// Convey("When there are no versions", func() {
-// 	datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-// 		Expect().Status(http.StatusBadRequest)
-// })
-//})
-//Convey("When unauthenticated", func() {
-// 	Convey("When the dataset does not exist", func() {
-// 		datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").
-// 			Expect().Status(http.StatusBadRequest)
-// 	})
-//
-// Convey("When the edition does not exist", func() {
-// 	datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").
-// 		Expect().Status(http.StatusBadRequest)
-// })
-//
-// 	Convey("When there are no published versions", func() {
-// 		// Create an unpublished instance document
-// 		mongo.Teardown(database, "instances", "_id", "799")
-// 		mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID))
-// 		datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).
-// 			Expect().Status(http.StatusBadRequest)
-//
-// 		mongo.Teardown(database, "instances", "_id", "799")
-// 	})
-//})
-//})
-//
-// Convey("Given a valid dataset id, edition and version with no dimensions", t, func() {
-// 	Convey("When authenticated and get the dimensions", func() {
-// 		Convey("Then the error code should be 404", func() {
-// 			datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-// 				Expect().Status(http.StatusNotFound)
-// 		})
-//
-// 	})
-// 	Convey("When unauthenticated and get the dimensions", func() {
-// 		Convey("Then the error code should be 404", func() {
-// 			datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).
-// 				Expect().Status(http.StatusNotFound)
-// 		})
-//
-// 	})
-// })
-//
-// 	if err := mongo.TeardownMany(d); err != nil {
-// 		if err != mgo.ErrNotFound {
-// 			log.ErrorC("Failed to tear down test data", err, nil)
-// 			os.Exit(1)
-// 		}
-// 	}
-// }
+// TODO Remove skipped tests when code has been refactored (and hence fixed)
+// 2 tests skipped
+func TestGetDimensions_Failed(t *testing.T) {
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2017"
+
+	var docs []mongo.Doc
+
+	datasetDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     validPublishedDatasetData(datasetID),
+	}
+
+	editionDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "editions",
+		Key:        "_id",
+		Value:      editionID,
+		Update:     validPublishedEditionData(datasetID, editionID, edition),
+	}
+
+	instanceOneDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "instances",
+		Key:        "_id",
+		Value:      instanceID,
+		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
+	}
+
+	docs = append(docs, datasetDoc, editionDoc, instanceOneDoc)
+
+	d := &mongo.ManyDocs{
+		Docs: docs,
+	}
+
+	if err := mongo.TeardownMany(d); err != nil {
+		if err != mgo.ErrNotFound {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+	}
+
+	if err := mongo.SetupMany(d); err != nil {
+		log.ErrorC("Was unable to run test", err, nil)
+		os.Exit(1)
+	}
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	SkipConvey("Fail to get a list of Dimensions for a dataset", t, func() {
+		Convey("When authenticated", func() {
+			Convey("When the dataset does not exist", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusBadRequest)
+			})
+
+			Convey("When the edition does not exist", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusBadRequest)
+			})
+
+			Convey("When there are no versions", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusBadRequest)
+			})
+		})
+		Convey("When unauthenticated", func() {
+			Convey("When the dataset does not exist", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").
+					Expect().Status(http.StatusBadRequest)
+			})
+
+			Convey("When the edition does not exist", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").
+					Expect().Status(http.StatusBadRequest)
+			})
+
+			Convey("When there are no published versions", func() {
+				// Create an unpublished instance document
+				mongo.Teardown(database, "instances", "_id", "799")
+				mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID))
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).
+					Expect().Status(http.StatusBadRequest)
+
+				mongo.Teardown(database, "instances", "_id", "799")
+			})
+		})
+	})
+
+	SkipConvey("Given a valid dataset id, edition and version with no dimensions", t, func() {
+		Convey("When authenticated and get the dimensions", func() {
+			Convey("Then the error code should be 404", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound)
+			})
+
+		})
+		Convey("When unauthenticated and get the dimensions", func() {
+			Convey("Then the error code should be 404", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).
+					Expect().Status(http.StatusNotFound)
+			})
+
+		})
+	})
+
+	if err := mongo.TeardownMany(d); err != nil {
+		if err != mgo.ErrNotFound {
+			log.ErrorC("Failed to tear down test data", err, nil)
+			os.Exit(1)
+		}
+	}
+}
 
 func checkDimensionsResponse(datasetID, edition, instanceID string, response *httpexpect.Object) {
 

--- a/datasetAPI/get_dataset_test.go
+++ b/datasetAPI/get_dataset_test.go
@@ -22,8 +22,6 @@ func TestSuccessfullyGetADataset(t *testing.T) {
 		log.ErrorC("Was unable to run test", err, nil)
 		os.Exit(1)
 	}
-	//setupDataset(datasetID, validPublishedDatasetData)
-	//defer removeDataset(datasetID)
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 

--- a/datasetAPI/get_datasets_test.go
+++ b/datasetAPI/get_datasets_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -17,7 +18,9 @@ import (
 // (which could be many)
 func TestSuccessfulGetAListOfDatasets(t *testing.T) {
 
-	d, err := setupTestDataForGetAListOfDatasets()
+	datasetID := uuid.NewV4().String()
+
+	d, err := setupTestDataForGetAListOfDatasets(datasetID)
 	if err != nil {
 		log.ErrorC("Was unable to run test", err, nil)
 		os.Exit(1)
@@ -39,7 +42,7 @@ func TestSuccessfulGetAListOfDatasets(t *testing.T) {
 				if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == datasetID {
 					// check the published test dataset document has the expected returned fields and values
 					response.Value("items").Array().Element(i).Object().Value("id").Equal(datasetID)
-					checkDatasetResponse(response.Value("items").Array().Element(i).Object())
+					checkDatasetResponse(datasetID, response.Value("items").Array().Element(i).Object())
 				}
 			}
 		})
@@ -54,7 +57,7 @@ func TestSuccessfulGetAListOfDatasets(t *testing.T) {
 
 				if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == datasetID {
 					// check the published test dataset document has the expected returned fields and values
-					checkDatasetResponse(response.Value("items").Array().Element(i).Object().Value("current").Object())
+					checkDatasetResponse(datasetID, response.Value("items").Array().Element(i).Object().Value("current").Object())
 					response.Value("items").Array().Element(i).Object().Value("next").Object().NotEmpty()
 				}
 
@@ -74,8 +77,7 @@ func TestSuccessfulGetAListOfDatasets(t *testing.T) {
 	}
 }
 
-func checkDatasetResponse(response *httpexpect.Object) {
-	response.Value("access_right").Equal("http://ons.gov.uk/accessrights")
+func checkDatasetResponse(datasetID string, response *httpexpect.Object) {
 	response.Value("collection_id").Equal("108064B3-A808-449B-9041-EA3A2F72CFAA")
 	response.Value("contacts").Array().Element(0).Object().Value("email").Equal("cpi@onstest.gov.uk")
 	response.Value("contacts").Array().Element(0).Object().Value("name").Equal("Automation Tester")
@@ -84,6 +86,7 @@ func checkDatasetResponse(response *httpexpect.Object) {
 	response.Value("keywords").Array().Element(0).String().Equal("cpi")
 	response.Value("keywords").Array().Element(1).String().Equal("boy")
 	response.Value("license").Equal("ONS license")
+	response.Value("links").Object().Value("access_rights").Object().Value("href").Equal("http://ons.gov.uk/accessrights")
 	response.Value("links").Object().Value("editions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions$")
 	response.Value("links").Object().Value("latest_version").Object().Value("id").Equal("1")
 	response.Value("links").Object().Value("latest_version").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/2017/versions/1$")
@@ -111,7 +114,7 @@ func checkDatasetResponse(response *httpexpect.Object) {
 	response.Value("uri").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation")
 }
 
-func setupTestDataForGetAListOfDatasets() (*mongo.ManyDocs, error) {
+func setupTestDataForGetAListOfDatasets(datasetID string) (*mongo.ManyDocs, error) {
 	var docs []mongo.Doc
 
 	publishedDatasetDoc := mongo.Doc{
@@ -119,7 +122,7 @@ func setupTestDataForGetAListOfDatasets() (*mongo.ManyDocs, error) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedDatasetData,
+		Update:     validPublishedDatasetData(datasetID),
 	}
 
 	unpublishedDatasetDoc := mongo.Doc{
@@ -127,7 +130,7 @@ func setupTestDataForGetAListOfDatasets() (*mongo.ManyDocs, error) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      "133",
-		Update:     validUnpublishedDatasetData,
+		Update:     validAssociatedDatasetData(datasetID),
 	}
 
 	docs = append(docs, publishedDatasetDoc, unpublishedDatasetDoc)

--- a/datasetAPI/get_dimension_options_test.go
+++ b/datasetAPI/get_dimension_options_test.go
@@ -131,132 +131,133 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 	}
 }
 
-// TODO Reinstate these tests when code has been fixed
-// func TestGetDimensionOptions_Failed(t *testing.T) {
-// 	datasetID := uuid.NewV4().String()
-// 	editionID := uuid.NewV4().String()
-// 	instanceID := uuid.NewV4().String()
-//
-// 	edition := "2017"
-//
-// 	var docs []mongo.Doc
-//
-// 	datasetDoc := mongo.Doc{
-// 		Database:   "datasets",
-// 		Collection: "datasets",
-// 		Key:        "_id",
-// 		Value:      datasetID,
-// 		Update:     validPublishedDatasetData(datasetID),
-// 	}
-//
-// 	editionDoc := mongo.Doc{
-// 		Database:   "datasets",
-// 		Collection: "editions",
-// 		Key:        "_id",
-// 		Value:      editionID,
-// 		Update:     validPublishedEditionData(datasetID, editionID, edition),
-// 	}
-//
-// 	instanceOneDoc := mongo.Doc{
-// 		Database:   "datasets",
-// 		Collection: "instances",
-// 		Key:        "_id",
-// 		Value:      instanceID,
-// 		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
-// 	}
-//
-// 	dimensionOneDoc := mongo.Doc{
-// 		Database:   "datasets",
-// 		Collection: "dimension.options",
-// 		Key:        "_id",
-// 		Value:      "9811",
-// 		Update:     validTimeDimensionsDataWithOutOptions(instanceID),
-// 	}
-//
-// 	docs = append(docs, datasetDoc, editionDoc, instanceOneDoc, dimensionOneDoc)
-//
-// 	d := &mongo.ManyDocs{
-// 		Docs: docs,
-// 	}
-//
-// 	if err := mongo.TeardownMany(d); err != nil {
-// 		if err != mgo.ErrNotFound {
-// 			log.ErrorC("Was unable to run test", err, nil)
-// 			os.Exit(1)
-// 		}
-// 	}
-//
-// 	if err := mongo.SetupMany(d); err != nil {
-// 		log.ErrorC("Was unable to run test", err, nil)
-// 		os.Exit(1)
-// 	}
-//
-// 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-//
-// 	Convey("Fail to get a list of time dimension options for a dataset", t, func() {
-// 		Convey("When authenticated", func() {
-// 			Convey("When the dataset does not exist", func() {
-// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).WithHeader(internalToken, internalTokenID).
-// 					Expect().Status(http.StatusBadRequest)
-// 			})
-//
-// 			Convey("When the edition does not exist", func() {
-// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").WithHeader(internalToken, internalTokenID).
-// 					Expect().Status(http.StatusBadRequest)
-// 			})
-//
-// 			Convey("When there are no versions", func() {
-// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
-// 					Expect().Status(http.StatusBadRequest)
-// 			})
-// 		})
-// 		Convey("When unauthenticated", func() {
-// 			Convey("When the dataset does not exist", func() {
-// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).
-// 					Expect().Status(http.StatusBadRequest)
-// 			})
-//
-// 			Convey("When the edition does not exist", func() {
-// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").
-// 					Expect().Status(http.StatusBadRequest)
-// 			})
-//
-// 			Convey("When there are no published versions", func() {
-// 				// Create an unpublished instance document
-// 				mongo.Teardown(database, "instances", "_id", "799")
-// 				mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID))
-// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).
-// 					Expect().Status(http.StatusBadRequest)
-//
-// 				mongo.Teardown(database, "instances", "_id", "799")
-// 			})
-// 		})
-// 	})
-//
-// 	Convey("Given a valid dataset id, edition and version with no dimensions", t, func() {
-// 		Convey("When authenticated and get the time dimension options", func() {
-// 			Convey("Then the error code should be 404", func() {
-// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
-// 					Expect().Status(http.StatusNotFound)
-// 			})
-//
-// 		})
-// 		Convey("When unauthenticated and get the time dimension options", func() {
-// 			Convey("Then the error code should be 404", func() {
-// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).
-// 					Expect().Status(http.StatusNotFound)
-// 			})
-//
-// 		})
-// 	})
-//
-// 	if err := mongo.TeardownMany(d); err != nil {
-// 		if err != mgo.ErrNotFound {
-// 			log.ErrorC("Failed to tear down test data", err, nil)
-// 			os.Exit(1)
-// 		}
-// 	}
-// }
+// TODO Remove skipped tests when code has been refactored (and hence fixed)
+// 2 tests skipped
+func TestGetDimensionOptions_Failed(t *testing.T) {
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2017"
+
+	var docs []mongo.Doc
+
+	datasetDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     validPublishedDatasetData(datasetID),
+	}
+
+	editionDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "editions",
+		Key:        "_id",
+		Value:      editionID,
+		Update:     validPublishedEditionData(datasetID, editionID, edition),
+	}
+
+	instanceOneDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "instances",
+		Key:        "_id",
+		Value:      instanceID,
+		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
+	}
+
+	dimensionOneDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "dimension.options",
+		Key:        "_id",
+		Value:      "9811",
+		Update:     validTimeDimensionsDataWithOutOptions(instanceID),
+	}
+
+	docs = append(docs, datasetDoc, editionDoc, instanceOneDoc, dimensionOneDoc)
+
+	d := &mongo.ManyDocs{
+		Docs: docs,
+	}
+
+	if err := mongo.TeardownMany(d); err != nil {
+		if err != mgo.ErrNotFound {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+	}
+
+	if err := mongo.SetupMany(d); err != nil {
+		log.ErrorC("Was unable to run test", err, nil)
+		os.Exit(1)
+	}
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	SkipConvey("Fail to get a list of time dimension options for a dataset", t, func() {
+		Convey("When authenticated", func() {
+			Convey("When the dataset does not exist", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusBadRequest)
+			})
+
+			Convey("When the edition does not exist", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusBadRequest)
+			})
+
+			Convey("When there are no versions", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusBadRequest)
+			})
+		})
+		Convey("When unauthenticated", func() {
+			Convey("When the dataset does not exist", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).
+					Expect().Status(http.StatusBadRequest)
+			})
+
+			Convey("When the edition does not exist", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").
+					Expect().Status(http.StatusBadRequest)
+			})
+
+			Convey("When there are no published versions", func() {
+				// Create an unpublished instance document
+				mongo.Teardown(database, "instances", "_id", "799")
+				mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID))
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).
+					Expect().Status(http.StatusBadRequest)
+
+				mongo.Teardown(database, "instances", "_id", "799")
+			})
+		})
+	})
+
+	SkipConvey("Given a valid dataset id, edition and version with no dimensions", t, func() {
+		Convey("When authenticated and get the time dimension options", func() {
+			Convey("Then the error code should be 404", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound)
+			})
+
+		})
+		Convey("When unauthenticated and get the time dimension options", func() {
+			Convey("Then the error code should be 404", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).
+					Expect().Status(http.StatusNotFound)
+			})
+
+		})
+	})
+
+	if err := mongo.TeardownMany(d); err != nil {
+		if err != mgo.ErrNotFound {
+			log.ErrorC("Failed to tear down test data", err, nil)
+			os.Exit(1)
+		}
+	}
+}
 
 func checkTimeDimensionResponse(instanceID string, response *httpexpect.Object) {
 

--- a/datasetAPI/get_dimension_options_test.go
+++ b/datasetAPI/get_dimension_options_test.go
@@ -8,11 +8,18 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 	mgo "gopkg.in/mgo.v2"
 )
 
 func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T) {
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2017"
+
 	var docs []mongo.Doc
 
 	datasetDoc := mongo.Doc{
@@ -20,7 +27,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedDatasetData,
+		Update:     validPublishedDatasetData(datasetID),
 	}
 
 	editionDoc := mongo.Doc{
@@ -28,7 +35,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData,
+		Update:     validPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceOneDoc := mongo.Doc{
@@ -36,7 +43,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 		Collection: "instances",
 		Key:        "_id",
 		Value:      instanceID,
-		Update:     validPublishedInstanceData,
+		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
 	}
 
 	dimensionOneDoc := mongo.Doc{
@@ -44,14 +51,14 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9811",
-		Update:     validTimeDimensionsData,
+		Update:     validTimeDimensionsData(instanceID),
 	}
 	dimensionTwoDoc := mongo.Doc{
 		Database:   "datasets",
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9812",
-		Update:     validAggregateDimensionsData,
+		Update:     validAggregateDimensionsData(instanceID),
 	}
 
 	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)
@@ -79,7 +86,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 			response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/{version}/dimensions/time/options", datasetID, edition, 1).WithHeader(internalToken, internalTokenID).
 				Expect().Status(http.StatusOK).JSON().Object()
 
-			checkTimeDimensionResponse(response)
+			checkTimeDimensionResponse(instanceID, response)
 
 		})
 
@@ -89,7 +96,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 
 			response.Value("items").Array().Length().Equal(1)
 
-			checkTimeDimensionResponse(response)
+			checkTimeDimensionResponse(instanceID, response)
 
 		})
 	})
@@ -101,7 +108,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 				Expect().Status(http.StatusOK).JSON().Object()
 			response.Value("items").Array().Length().Equal(1)
 
-			checkAggregateDimensionResponse(response)
+			checkAggregateDimensionResponse(instanceID, response)
 
 		})
 
@@ -111,7 +118,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 
 			response.Value("items").Array().Length().Equal(1)
 
-			checkAggregateDimensionResponse(response)
+			checkAggregateDimensionResponse(instanceID, response)
 
 		})
 	})
@@ -124,129 +131,134 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 	}
 }
 
-// These tests will fail due to bugs in the code.
-// Raised bugs in trello card.
-func TestGetDimensionOptions_Failed(t *testing.T) {
-	var docs []mongo.Doc
+// TODO Reinstate these tests when code has been fixed
+// func TestGetDimensionOptions_Failed(t *testing.T) {
+// 	datasetID := uuid.NewV4().String()
+// 	editionID := uuid.NewV4().String()
+// 	instanceID := uuid.NewV4().String()
+//
+// 	edition := "2017"
+//
+// 	var docs []mongo.Doc
+//
+// 	datasetDoc := mongo.Doc{
+// 		Database:   "datasets",
+// 		Collection: "datasets",
+// 		Key:        "_id",
+// 		Value:      datasetID,
+// 		Update:     validPublishedDatasetData(datasetID),
+// 	}
+//
+// 	editionDoc := mongo.Doc{
+// 		Database:   "datasets",
+// 		Collection: "editions",
+// 		Key:        "_id",
+// 		Value:      editionID,
+// 		Update:     validPublishedEditionData(datasetID, editionID, edition),
+// 	}
+//
+// 	instanceOneDoc := mongo.Doc{
+// 		Database:   "datasets",
+// 		Collection: "instances",
+// 		Key:        "_id",
+// 		Value:      instanceID,
+// 		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
+// 	}
+//
+// 	dimensionOneDoc := mongo.Doc{
+// 		Database:   "datasets",
+// 		Collection: "dimension.options",
+// 		Key:        "_id",
+// 		Value:      "9811",
+// 		Update:     validTimeDimensionsDataWithOutOptions(instanceID),
+// 	}
+//
+// 	docs = append(docs, datasetDoc, editionDoc, instanceOneDoc, dimensionOneDoc)
+//
+// 	d := &mongo.ManyDocs{
+// 		Docs: docs,
+// 	}
+//
+// 	if err := mongo.TeardownMany(d); err != nil {
+// 		if err != mgo.ErrNotFound {
+// 			log.ErrorC("Was unable to run test", err, nil)
+// 			os.Exit(1)
+// 		}
+// 	}
+//
+// 	if err := mongo.SetupMany(d); err != nil {
+// 		log.ErrorC("Was unable to run test", err, nil)
+// 		os.Exit(1)
+// 	}
+//
+// 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+//
+// 	Convey("Fail to get a list of time dimension options for a dataset", t, func() {
+// 		Convey("When authenticated", func() {
+// 			Convey("When the dataset does not exist", func() {
+// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).WithHeader(internalToken, internalTokenID).
+// 					Expect().Status(http.StatusBadRequest)
+// 			})
+//
+// 			Convey("When the edition does not exist", func() {
+// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").WithHeader(internalToken, internalTokenID).
+// 					Expect().Status(http.StatusBadRequest)
+// 			})
+//
+// 			Convey("When there are no versions", func() {
+// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
+// 					Expect().Status(http.StatusBadRequest)
+// 			})
+// 		})
+// 		Convey("When unauthenticated", func() {
+// 			Convey("When the dataset does not exist", func() {
+// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).
+// 					Expect().Status(http.StatusBadRequest)
+// 			})
+//
+// 			Convey("When the edition does not exist", func() {
+// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").
+// 					Expect().Status(http.StatusBadRequest)
+// 			})
+//
+// 			Convey("When there are no published versions", func() {
+// 				// Create an unpublished instance document
+// 				mongo.Teardown(database, "instances", "_id", "799")
+// 				mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID))
+// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).
+// 					Expect().Status(http.StatusBadRequest)
+//
+// 				mongo.Teardown(database, "instances", "_id", "799")
+// 			})
+// 		})
+// 	})
+//
+// 	Convey("Given a valid dataset id, edition and version with no dimensions", t, func() {
+// 		Convey("When authenticated and get the time dimension options", func() {
+// 			Convey("Then the error code should be 404", func() {
+// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
+// 					Expect().Status(http.StatusNotFound)
+// 			})
+//
+// 		})
+// 		Convey("When unauthenticated and get the time dimension options", func() {
+// 			Convey("Then the error code should be 404", func() {
+// 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).
+// 					Expect().Status(http.StatusNotFound)
+// 			})
+//
+// 		})
+// 	})
+//
+// 	if err := mongo.TeardownMany(d); err != nil {
+// 		if err != mgo.ErrNotFound {
+// 			log.ErrorC("Failed to tear down test data", err, nil)
+// 			os.Exit(1)
+// 		}
+// 	}
+// }
 
-	datasetDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "datasets",
-		Key:        "_id",
-		Value:      datasetID,
-		Update:     validPublishedDatasetData,
-	}
-
-	editionDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "editions",
-		Key:        "_id",
-		Value:      editionID,
-		Update:     validPublishedEditionData,
-	}
-
-	instanceOneDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "instances",
-		Key:        "_id",
-		Value:      instanceID,
-		Update:     validPublishedInstanceData,
-	}
-
-	dimensionOneDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "dimension.options",
-		Key:        "_id",
-		Value:      "9811",
-		Update:     validTimeDimensionsDataWithOutOptions,
-	}
-
-	docs = append(docs, datasetDoc, editionDoc, instanceOneDoc, dimensionOneDoc)
-
-	d := &mongo.ManyDocs{
-		Docs: docs,
-	}
-
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
-
-	if err := mongo.SetupMany(d); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
-
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-
-	Convey("Fail to get a list of time dimension options for a dataset", t, func() {
-		Convey("When authenticated", func() {
-			Convey("When the dataset does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When the edition does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When there are no versions", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-		})
-		Convey("When unauthenticated", func() {
-			Convey("When the dataset does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When the edition does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When there are no published versions", func() {
-				// Create an unpublished instance document
-				mongo.Teardown(database, "instances", "_id", "799")
-				mongo.Setup(database, "instances", "_id", "799", validUnpublishedInstanceData)
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).
-					Expect().Status(http.StatusBadRequest)
-
-				mongo.Teardown(database, "instances", "_id", "799")
-			})
-		})
-	})
-
-	Convey("Given a valid dataset id, edition and version with no dimensions", t, func() {
-		Convey("When authenticated and get the time dimension options", func() {
-			Convey("Then the error code should be 404", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound)
-			})
-
-		})
-		Convey("When unauthenticated and get the time dimension options", func() {
-			Convey("Then the error code should be 404", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).
-					Expect().Status(http.StatusNotFound)
-			})
-
-		})
-	})
-
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Failed to tear down test data", err, nil)
-			os.Exit(1)
-		}
-	}
-}
-
-func checkTimeDimensionResponse(response *httpexpect.Object) {
+func checkTimeDimensionResponse(instanceID string, response *httpexpect.Object) {
 
 	response.Value("items").Array().Element(0).Object().Value("dimension_id").Equal("time")
 
@@ -264,7 +276,7 @@ func checkTimeDimensionResponse(response *httpexpect.Object) {
 
 }
 
-func checkAggregateDimensionResponse(response *httpexpect.Object) {
+func checkAggregateDimensionResponse(instanceID string, response *httpexpect.Object) {
 
 	response.Value("items").Array().Element(0).Object().Value("dimension_id").Equal("aggregate")
 

--- a/datasetAPI/get_editions_test.go
+++ b/datasetAPI/get_editions_test.go
@@ -52,7 +52,7 @@ func TestSuccessfullyGetListOfDatasetEditions(t *testing.T) {
 		Docs: docs,
 	}
 
-	Convey("Given a dataset has and edition that is published and one that is unpublished", t, func() {
+	Convey("Given a dataset has an edition that is published and one that is unpublished", t, func() {
 
 		if err := mongo.SetupMany(d); err != nil {
 			log.ErrorC("Was unable to run test", err, nil)

--- a/datasetAPI/get_instance_dimensions_test.go
+++ b/datasetAPI/get_instance_dimensions_test.go
@@ -111,49 +111,50 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 	}
 }
 
-// TODO Reinstate tests once endpoint is fixed
-// func TestFailureToGetInstanceDimensions(t *testing.T) {
-// 	datasetID := uuid.NewV4().String()
-// 	instanceID := uuid.NewV4().String()
-//
-// 	edition := "2017"
-//
-// 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-//
-// 	Convey("Fail to get instance document", t, func() {
-// 		Convey("and return status not found", func() {
-// 			Convey("when instance document does not exist", func() {
-// 				datasetAPI.GET("/instances/{id}/dimensions", "7990").WithHeader(internalToken, internalTokenID).
-// 					Expect().Status(http.StatusNotFound)
-// 			})
-// 		})
-// 		Convey("and return status request is forbidden", func() {
-// 			Convey("when an unauthorised user sends a GET request", func() {
-// 				if err := mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID)); err != nil {
-// 					log.ErrorC("Was unable to run test", err, nil)
-// 					os.Exit(1)
-// 				}
-//
-// 				datasetAPI.GET("/instances/{id}/dimensions", "789").
-// 					Expect().Status(http.StatusForbidden)
-// 			})
-// 		})
-//
-// 		Convey("and return status not unauthorised", func() {
-// 			Convey("when an invalid token is provided", func() {
-// 				datasetAPI.GET("/instances/{id}/dimensions", "789").WithHeader(internalToken, invalidInternalTokenID).
-// 					Expect().Status(http.StatusUnauthorized)
-// 			})
-// 		})
-// 	})
-//
-// 	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
-// 		if err != mgo.ErrNotFound {
-// 			log.ErrorC("Failed to tear down test data", err, nil)
-// 			os.Exit(1)
-// 		}
-// 	}
-// }
+// TODO Remove skipped tests when code has been refactored (and hence fixed)
+// 1 test skipped
+func TestFailureToGetInstanceDimensions(t *testing.T) {
+	datasetID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2017"
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	SkipConvey("Fail to get instance document", t, func() {
+		Convey("and return status not found", func() {
+			Convey("when instance document does not exist", func() {
+				datasetAPI.GET("/instances/{id}/dimensions", "7990").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound)
+			})
+		})
+		Convey("and return status request is forbidden", func() {
+			Convey("when an unauthorised user sends a GET request", func() {
+				if err := mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID)); err != nil {
+					log.ErrorC("Was unable to run test", err, nil)
+					os.Exit(1)
+				}
+
+				datasetAPI.GET("/instances/{id}/dimensions", "789").
+					Expect().Status(http.StatusForbidden)
+			})
+		})
+
+		Convey("and return status not unauthorised", func() {
+			Convey("when an invalid token is provided", func() {
+				datasetAPI.GET("/instances/{id}/dimensions", "789").WithHeader(internalToken, invalidInternalTokenID).
+					Expect().Status(http.StatusUnauthorized)
+			})
+		})
+	})
+
+	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
+		if err != mgo.ErrNotFound {
+			log.ErrorC("Failed to tear down test data", err, nil)
+			os.Exit(1)
+		}
+	}
+}
 
 func checkInstanceDimensionsResponse(response *httpexpect.Object) {
 

--- a/datasetAPI/get_instance_dimensions_test.go
+++ b/datasetAPI/get_instance_dimensions_test.go
@@ -8,11 +8,18 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 	mgo "gopkg.in/mgo.v2"
 )
 
 func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) {
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2017"
+
 	var docs []mongo.Doc
 
 	datasetDoc := mongo.Doc{
@@ -20,7 +27,7 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedDatasetData,
+		Update:     validPublishedDatasetData(datasetID),
 	}
 
 	editionDoc := mongo.Doc{
@@ -28,7 +35,7 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData,
+		Update:     validPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceOneDoc := mongo.Doc{
@@ -36,7 +43,7 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 		Collection: "instances",
 		Key:        "_id",
 		Value:      instanceID,
-		Update:     validPublishedInstanceData,
+		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
 	}
 
 	dimensionOneDoc := mongo.Doc{
@@ -44,14 +51,14 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9811",
-		Update:     validTimeDimensionsData,
+		Update:     validTimeDimensionsData(instanceID),
 	}
 	dimensionTwoDoc := mongo.Doc{
 		Database:   "datasets",
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9812",
-		Update:     validAggregateDimensionsData,
+		Update:     validAggregateDimensionsData(instanceID),
 	}
 
 	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)
@@ -104,53 +111,49 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 	}
 }
 
-// All these 3 tests will fail due to a bug in code.
-// Raised a trello card for these bugs.
-func TestFailureToGetInstanceDimensions(t *testing.T) {
-
-	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
-
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-
-	Convey("Fail to get instance document", t, func() {
-		Convey("and return status not found", func() {
-			Convey("when instance document does not exist", func() {
-				datasetAPI.GET("/instances/{id}/dimensions", "7990").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound)
-			})
-		})
-		Convey("and return status request is forbidden", func() {
-			Convey("when an unauthorised user sends a GET request", func() {
-				if err := mongo.Setup(database, "instances", "_id", "799", validUnpublishedInstanceData); err != nil {
-					log.ErrorC("Was unable to run test", err, nil)
-					os.Exit(1)
-				}
-
-				datasetAPI.GET("/instances/{id}/dimensions", "789").
-					Expect().Status(http.StatusForbidden)
-			})
-		})
-
-		Convey("and return status not unauthorised", func() {
-			Convey("when an invalid token is provided", func() {
-				datasetAPI.GET("/instances/{id}/dimensions", "789").WithHeader(internalToken, invalidInternalTokenID).
-					Expect().Status(http.StatusUnauthorized)
-			})
-		})
-	})
-
-	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Failed to tear down test data", err, nil)
-			os.Exit(1)
-		}
-	}
-}
+// TODO Reinstate tests once endpoint is fixed
+// func TestFailureToGetInstanceDimensions(t *testing.T) {
+// 	datasetID := uuid.NewV4().String()
+// 	instanceID := uuid.NewV4().String()
+//
+// 	edition := "2017"
+//
+// 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+//
+// 	Convey("Fail to get instance document", t, func() {
+// 		Convey("and return status not found", func() {
+// 			Convey("when instance document does not exist", func() {
+// 				datasetAPI.GET("/instances/{id}/dimensions", "7990").WithHeader(internalToken, internalTokenID).
+// 					Expect().Status(http.StatusNotFound)
+// 			})
+// 		})
+// 		Convey("and return status request is forbidden", func() {
+// 			Convey("when an unauthorised user sends a GET request", func() {
+// 				if err := mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID)); err != nil {
+// 					log.ErrorC("Was unable to run test", err, nil)
+// 					os.Exit(1)
+// 				}
+//
+// 				datasetAPI.GET("/instances/{id}/dimensions", "789").
+// 					Expect().Status(http.StatusForbidden)
+// 			})
+// 		})
+//
+// 		Convey("and return status not unauthorised", func() {
+// 			Convey("when an invalid token is provided", func() {
+// 				datasetAPI.GET("/instances/{id}/dimensions", "789").WithHeader(internalToken, invalidInternalTokenID).
+// 					Expect().Status(http.StatusUnauthorized)
+// 			})
+// 		})
+// 	})
+//
+// 	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
+// 		if err != mgo.ErrNotFound {
+// 			log.ErrorC("Failed to tear down test data", err, nil)
+// 			os.Exit(1)
+// 		}
+// 	}
+// }
 
 func checkInstanceDimensionsResponse(response *httpexpect.Object) {
 

--- a/datasetAPI/get_instance_test.go
+++ b/datasetAPI/get_instance_test.go
@@ -10,66 +10,66 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSuccessfullyGetInstance(t *testing.T) {
 
-	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
-
-	if err := mongo.Setup(database, "instances", "_id", "799", validUnpublishedInstanceData); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
+	unpublishedInstanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Get an instance", t, func() {
-		Convey("When user is authenticated", func() {
-			response := datasetAPI.GET("/instances/{id}", "799").WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
+	Convey("Given an unpublished instance resource", t, func() {
+		if err := mongo.Setup(database, "instances", "_id", unpublishedInstanceID, validAssociatedInstanceData(datasetID, edition, unpublishedInstanceID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
 
-			response.Value("id").Equal("799")
-			response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("A list of ages between 18 and 75+")
-			response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/codelists/408064B3-A808-449B-9041-EA3A2F72CFAC$")
-			response.Value("dimensions").Array().Element(0).Object().Value("id").Equal("408064B3-A808-449B-9041-EA3A2F72CFAC")
-			response.Value("dimensions").Array().Element(0).Object().Value("name").Equal("age")
-			response.Value("downloads").Object().Value("csv").Object().Value("url").String().Match("(.+)/aws/census-2017-2-csv$")
-			response.Value("downloads").Object().Value("csv").Object().Value("url").String().Match("(.+)/aws/census-2017-2-csv$")
-			response.Value("downloads").Object().Value("csv").Object().Value("size").Equal("10mb")
-			response.Value("downloads").Object().Value("xls").Object().Value("url").String().Match("(.+)/aws/census-2017-2-xls$")
-			response.Value("downloads").Object().Value("xls").Object().Value("size").Equal("24mb")
-			response.Value("edition").Equal(edition)
-			response.Value("headers").Array().Element(0).String().Equal("time")
-			response.Value("headers").Array().Element(1).String().Equal("geography")
-			response.Value("links").Object().Value("job").Object().Value("href").String().Match("(.+)/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35$")
-			response.Value("links").Object().Value("job").Object().Value("id").Equal("042e216a-7822-4fa0-a3d6-e3f5248ffc35")
-			response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
-			response.Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
-			response.Value("links").Object().Value("dimensions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/2/dimensions$")
-			response.Value("links").Object().Value("edition").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "$")
-			response.Value("links").Object().Value("edition").Object().Value("id").Equal(edition)
-			response.Value("links").Object().Value("version").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/2$")
-			response.Value("links").Object().Value("version").Object().Value("id").Equal("2")
-			response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/instances/799$")
-			response.Value("release_date").Equal("2017-12-12")
-			response.Value("spatial").Equal("http://ons.gov.uk/geographylist")
-			response.Value("state").Equal("associated")
-			response.Value("temporal").Array().Element(0).Object().Value("start_date").Equal("2014-09-09")
-			response.Value("temporal").Array().Element(0).Object().Value("end_date").Equal("2017-09-09")
-			response.Value("temporal").Array().Element(0).Object().Value("frequency").Equal("monthly")
-			response.Value("total_inserted_observations").Equal(1000)
-			response.Value("total_observations").Equal(1000)
-			response.Value("version").Equal(2)
+		Convey("When an authenticated request to get instance", func() {
+			Convey("Then response contains the expected json object and a status ok (200)", func() {
+				response := datasetAPI.GET("/instances/{id}", unpublishedInstanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				response.Value("id").Equal(unpublishedInstanceID)
+				response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("A list of ages between 18 and 75+")
+				response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/codelists/408064B3-A808-449B-9041-EA3A2F72CFAC$")
+				response.Value("dimensions").Array().Element(0).Object().Value("id").Equal("408064B3-A808-449B-9041-EA3A2F72CFAC")
+				response.Value("dimensions").Array().Element(0).Object().Value("name").Equal("age")
+				response.Value("downloads").Object().Value("csv").Object().Value("url").String().Match("(.+)/aws/census-2017-2-csv$")
+				response.Value("downloads").Object().Value("csv").Object().Value("url").String().Match("(.+)/aws/census-2017-2-csv$")
+				response.Value("downloads").Object().Value("csv").Object().Value("size").Equal("10mb")
+				response.Value("downloads").Object().Value("xls").Object().Value("url").String().Match("(.+)/aws/census-2017-2-xls$")
+				response.Value("downloads").Object().Value("xls").Object().Value("size").Equal("24mb")
+				response.Value("edition").Equal(edition)
+				response.Value("headers").Array().Element(0).String().Equal("time")
+				response.Value("headers").Array().Element(1).String().Equal("geography")
+				response.Value("links").Object().Value("job").Object().Value("href").String().Match("(.+)/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35$")
+				response.Value("links").Object().Value("job").Object().Value("id").Equal("042e216a-7822-4fa0-a3d6-e3f5248ffc35")
+				response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
+				response.Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
+				response.Value("links").Object().Value("dimensions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/2/dimensions$")
+				response.Value("links").Object().Value("edition").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "$")
+				response.Value("links").Object().Value("edition").Object().Value("id").Equal(edition)
+				response.Value("links").Object().Value("version").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/2$")
+				response.Value("links").Object().Value("version").Object().Value("id").Equal("2")
+				response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/instances/" + unpublishedInstanceID + "$")
+				response.Value("links").Object().Value("spatial").Object().Value("href").Equal("http://ons.gov.uk/geographylist")
+				response.Value("release_date").Equal("2017-12-12")
+				response.Value("state").Equal("associated")
+				response.Value("temporal").Array().Element(0).Object().Value("start_date").Equal("2014-09-09")
+				response.Value("temporal").Array().Element(0).Object().Value("end_date").Equal("2017-09-09")
+				response.Value("temporal").Array().Element(0).Object().Value("frequency").Equal("monthly")
+				response.Value("total_inserted_observations").Equal(1000)
+				response.Value("total_observations").Equal(1000)
+				response.Value("version").Equal(2)
+			})
 		})
 	})
 
-	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
+	if err := mongo.Teardown(database, "instances", "_id", unpublishedInstanceID); err != nil {
 		if err != mgo.ErrNotFound {
 			os.Exit(1)
 		}
@@ -78,38 +78,46 @@ func TestSuccessfullyGetInstance(t *testing.T) {
 
 func TestFailureToGetInstance(t *testing.T) {
 
-	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
+	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Fail to get instance document", t, func() {
-		Convey("and return status not found", func() {
-			Convey("when instance document does not exist", func() {
-				datasetAPI.GET("/instances/{id}", "799").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound)
-			})
-		})
-		Convey("and return status unauthorised", func() {
-			Convey("when an unauthorised user sends a GET request", func() {
-				if err := mongo.Setup(database, "instances", "_id", "799", validUnpublishedInstanceData); err != nil {
-					log.ErrorC("Was unable to run test", err, nil)
-					os.Exit(1)
-				}
-
-				datasetAPI.GET("/instances/{id}", "799").
-					Expect().Status(http.StatusUnauthorized)
+	Convey("Given an instance resource does not exist", t, func() {
+		Convey("When an authorised request is made to get instance", func() {
+			Convey("Then return a status not found (404) with message `Instance not found`", func() {
+				datasetAPI.GET("/instances/{id}", instanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
 			})
 		})
 	})
 
-	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
-		if err != mgo.ErrNotFound {
+	Convey("Given a published instance resource exists", t, func() {
+		if err := mongo.Setup(database, "instances", "_id", instanceID, validPublishedInstanceData(datasetID, edition, instanceID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
 			os.Exit(1)
 		}
-	}
+		Convey("When no authentication header is provided in request to get resource", func() {
+			Convey("Then return a status of unauthorised (401) with message `No authentication header provided`", func() {
+
+				datasetAPI.GET("/instances/{id}", instanceID).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+			})
+		})
+
+		Convey("When an unauthorised request is made to get resource", func() {
+			Convey("Then return a status of unauthorised (401) with message `Unauthorised access to API`", func() {
+
+				datasetAPI.GET("/instances/{id}", instanceID).WithHeader(internalToken, "wrong-header").
+					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+			})
+		})
+
+		if err := mongo.Teardown(database, "instances", "_id", instanceID); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
+	})
 }

--- a/datasetAPI/get_instances_test.go
+++ b/datasetAPI/get_instances_test.go
@@ -10,117 +10,163 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestGetAListOfInstances(t *testing.T) {
+func TestSuccessfullyGetAListOfInstances(t *testing.T) {
 
-	if err := mongo.Teardown(database, "instances", "_id", instanceID); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
-
-	if err := mongo.Setup(database, "instances", "_id", instanceID, validPublishedInstanceData); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
+	instanceID := uuid.NewV4().String()
+	secondInstanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Get a list of instances", t, func() {
-		Convey("when the user is authorised", func() {
-			response := datasetAPI.GET("/instances").WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
+	Convey("Given a published instance exists", t, func() {
+		if err := mongo.Setup(database, "instances", "_id", instanceID, validPublishedInstanceData(datasetID, edition, instanceID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
 
-			response.Value("items").Array().Element(0).Object().Value("id").NotNull()
+		Convey("When an authorised request to get a list of instances is received", func() {
+			Convey("Then a list of instances are returned", func() {
+				response := datasetAPI.GET("/instances").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				response.Value("items").Array().Element(0).Object().Value("id").NotNull()
+			})
 		})
 
-		Convey("when the user filters by a 'state' value", func() {
-			var docs []mongo.Doc
+		if err := mongo.Teardown(database, "instances", "_id", instanceID); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+	})
 
-			completedDoc := mongo.Doc{
-				Database:   database,
-				Collection: "instances",
-				Key:        "_id",
-				Value:      "799",
-				Update:     validCompletedInstanceData,
-			}
-			editionConfirmedDoc := mongo.Doc{
-				Database:   database,
-				Collection: "instances",
-				Key:        "_id",
-				Value:      "779",
-				Update:     validEditionConfirmedInstanceData,
-			}
+	Convey("Given a `completed` and `edition-confirmed` instances exist", t, func() {
+		var docs []mongo.Doc
 
-			docs = append(docs, completedDoc, editionConfirmedDoc)
+		completedDoc := mongo.Doc{
+			Database:   database,
+			Collection: "instances",
+			Key:        "_id",
+			Value:      instanceID,
+			Update:     validCompletedInstanceData(datasetID, "2018", instanceID),
+		}
+		editionConfirmedDoc := mongo.Doc{
+			Database:   database,
+			Collection: "instances",
+			Key:        "_id",
+			Value:      secondInstanceID,
+			Update:     validEditionConfirmedInstanceData(datasetID, "2017", secondInstanceID),
+		}
 
-			d := &mongo.ManyDocs{
-				Docs: docs,
-			}
+		docs = append(docs, completedDoc, editionConfirmedDoc)
 
-			if err := mongo.TeardownMany(d); err != nil {
-				if err != mgo.ErrNotFound {
-					log.ErrorC("Was unable to run test", err, nil)
-					os.Exit(1)
+		d := &mongo.ManyDocs{
+			Docs: docs,
+		}
+
+		if err := mongo.SetupMany(d); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When the authorised request contains a query parameter 'state' of value completed", func() {
+			Convey("Then return only instances that contain a 'state' of value completed", func() {
+
+				response := datasetAPI.GET("/instances").WithQuery("state", "completed").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				var foundInstance bool
+
+				for i := 0; i < len(response.Value("items").Array().Iter()); i++ {
+					response.Value("items").Array().Element(i).Object().Value("id").NotEqual(secondInstanceID)
+					if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == instanceID {
+						foundInstance = true
+						response.Value("items").Array().Element(i).Object().Value("state").Equal("completed")
+					}
 				}
-			}
 
-			if err := mongo.SetupMany(d); err != nil {
+				So(foundInstance, ShouldEqual, true)
+			})
+		})
+
+		Convey("When the authorised request contains a query parameter 'state' of value `completed` and `edition-confirmed`", func() {
+			Convey("Then return all instances that contain a 'state' of value `completed` or `edition-confirmed`", func() {
+
+				response := datasetAPI.GET("/instances").WithQuery("state", "completed,edition-confirmed").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				count := 0
+
+				for i := 0; i < len(response.Value("items").Array().Iter()); i++ {
+					if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == instanceID {
+						response.Value("items").Array().Element(i).Object().Value("state").Equal("completed")
+
+						count++
+					}
+					if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == secondInstanceID {
+						response.Value("items").Array().Element(i).Object().Value("state").Equal("edition-confirmed")
+
+						count++
+					}
+				}
+
+				// Check both resources were found in response
+				So(count, ShouldEqual, 2)
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
 				log.ErrorC("Was unable to run test", err, nil)
 				os.Exit(1)
 			}
-
-			response := datasetAPI.GET("/instances").WithQuery("state", "completed").WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			for i := 0; i < len(response.Value("items").Array().Iter()); i++ {
-				response.Value("items").Array().Element(i).Object().Value("id").NotEqual("779")
-				if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == "799" {
-					response.Value("items").Array().Element(i).Object().Value("state").Equal("completed")
-				}
-			}
-
-			if err := mongo.TeardownMany(d); err != nil {
-				if err != mgo.ErrNotFound {
-					log.ErrorC("Was unable to run test", err, nil)
-					os.Exit(1)
-				}
-			}
-		})
-
-		Convey("when the user filters by multiple 'state' values", func() {
-			response := datasetAPI.GET("/instances").WithQuery("state", "completed,edition-confirmed").WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			for i := 0; i < len(response.Value("items").Array().Iter()); i++ {
-				if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == "799" {
-					response.Value("items").Array().Element(i).Object().Value("state").Equal("completed")
-				}
-				if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == "779" {
-					response.Value("items").Array().Element(i).Object().Value("state").Equal("edition-confirmed")
-				}
-			}
-		})
+		}
 	})
+}
 
-	Convey("Fail to get a list of instances", t, func() {
-		Convey("When the user is unauthorised", func() {
-			datasetAPI.GET("/instances").
-				Expect().Status(http.StatusUnauthorized)
-		})
+func TestFailureToGetAListOfInstances(t *testing.T) {
 
-		Convey("When the user filters by the wrong 'state' value", func() {
-			datasetAPI.GET("/instances").WithQuery("state", "foo").WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusBadRequest)
-		})
-	})
+	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
 
-	if err := mongo.Teardown(database, "instances", "_id", instanceID); err != nil {
-		if err != mgo.ErrNotFound {
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given an instance with state `published` exists", t, func() {
+		if err := mongo.Setup(database, "instances", "_id", instanceID, validPublishedInstanceData(datasetID, edition, instanceID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
 			os.Exit(1)
 		}
-	}
+
+		Convey("When no authentication header is provided in request to get list of resources", func() {
+			Convey("Then return a status of unauthorised (401) with message `No authentication header provided`", func() {
+				datasetAPI.GET("/instances").Expect().Status(http.StatusUnauthorized).
+					Body().Contains("No authentication header provided\n")
+			})
+		})
+
+		Convey("When an unauthorised request is made to get resource", func() {
+			Convey("Then return a status of unauthorised (401) with message `Unauthorised access to API`", func() {
+				datasetAPI.GET("/instances").WithHeader(internalToken, "wrong-header").
+					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+			})
+		})
+
+		Convey("When an authorised request to get a list of resources is made with an invalid filter value for 'state'", func() {
+			Convey("Then return a status of bad request (400) with message `Bad request - invalid filter state values`", func() {
+				datasetAPI.GET("/instances").WithQuery("state", "foo").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - invalid filter state values: [foo]\n")
+			})
+		})
+
+		if err := mongo.Teardown(database, "instances", "_id", instanceID); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
+	})
 }

--- a/datasetAPI/get_version_test.go
+++ b/datasetAPI/get_version_test.go
@@ -8,145 +8,245 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 	mgo "gopkg.in/mgo.v2"
 )
 
 func TestSuccessfullyGetVersionOfADatasetEdition(t *testing.T) {
-	d, err := teardownVersion()
-	if err != nil {
-		log.ErrorC("Failed to tear down test data", err, nil)
-		os.Exit(1)
-	}
 
-	if err := mongo.SetupMany(d); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
+	instanceID := uuid.NewV4().String()
+	unpublishedInstanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	edition := "2017"
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Get an existing version for an edition of a dataset", t, func() {
-		Convey("When user is authenticated and version is not published", func() {
-
-			response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2", datasetID, edition).WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			response.Value("id").Equal("799")
-			response.Value("collection_id").Equal("208064B3-A808-449B-9041-EA3A2F72CFAB")
-			response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("A list of ages between 18 and 75+")
-			response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/codelists/408064B3-A808-449B-9041-EA3A2F72CFAC$")
-			response.Value("dimensions").Array().Element(0).Object().Value("id").Equal("408064B3-A808-449B-9041-EA3A2F72CFAC")
-			response.Value("dimensions").Array().Element(0).Object().Value("name").Equal("age")
-			response.Value("downloads").Object().Value("csv").Object().Value("url").String().Match("(.+)/aws/census-2017-2-csv$")
-			response.Value("downloads").Object().Value("csv").Object().Value("size").Equal("10mb")
-			response.Value("downloads").Object().Value("xls").Object().Value("url").String().Match("(.+)/aws/census-2017-2-xls$")
-			response.Value("downloads").Object().Value("xls").Object().Value("size").Equal("24mb")
-			response.Value("edition").Equal(edition)
-			response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
-			response.Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
-			response.Value("links").Object().Value("dimensions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/2/dimensions$")
-			response.Value("links").Object().Value("edition").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "$")
-			response.Value("links").Object().Value("edition").Object().Value("id").Equal(edition)
-			response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/2$")
-			response.Value("release_date").Equal("2017-12-12")
-			response.Value("spatial").Equal("http://ons.gov.uk/geographylist")
-			response.Value("state").Equal("associated")
-			response.Value("temporal").Array().Element(0).Object().Value("start_date").Equal("2014-09-09")
-			response.Value("temporal").Array().Element(0).Object().Value("end_date").Equal("2017-09-09")
-			response.Value("temporal").Array().Element(0).Object().Value("frequency").Equal("monthly")
-			response.Value("version").Equal(2)
-		})
-
-		Convey("When user is unauthenticated", func() {
-
-			response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			response.Value("id").Equal(instanceID)
-			response.Value("collection_id").Equal("108064B3-A808-449B-9041-EA3A2F72CFAA")
-			response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("A list of ages between 18 and 75+")
-			response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/codelists/408064B3-A808-449B-9041-EA3A2F72CFAC$")
-			response.Value("dimensions").Array().Element(0).Object().Value("id").Equal("408064B3-A808-449B-9041-EA3A2F72CFAC")
-			response.Value("dimensions").Array().Element(0).Object().Value("name").Equal("age")
-			response.Value("downloads").Object().Value("csv").Object().Value("url").String().Match("(.+)/aws/census-2017-1-csv$")
-			response.Value("downloads").Object().Value("csv").Object().Value("size").Equal("10mb")
-			response.Value("downloads").Object().Value("xls").Object().Value("url").String().Match("(.+)/aws/census-2017-1-xls$")
-			response.Value("downloads").Object().Value("xls").Object().Value("size").Equal("24mb")
-			response.Value("edition").Equal(edition)
-			response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
-			response.Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
-			response.Value("links").Object().Value("dimensions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/1/dimensions$")
-			response.Value("links").Object().Value("edition").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "$")
-			response.Value("links").Object().Value("edition").Object().Value("id").Equal(edition)
-			response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/1$")
-			response.Value("release_date").Equal("2017-12-12")
-			response.Value("spatial").Equal("http://ons.gov.uk/geographylist")
-			response.Value("state").Equal("published")
-			response.Value("temporal").Array().Element(0).Object().Value("start_date").Equal("2014-09-09")
-			response.Value("temporal").Array().Element(0).Object().Value("end_date").Equal("2017-09-09")
-			response.Value("temporal").Array().Element(0).Object().Value("frequency").Equal("monthly")
-			response.Value("version").Equal(1)
-		})
-	})
-
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
+	Convey("Given a published and unpublished version for a dataset edition exists", t, func() {
+		d, err := setupPublishedAndUnpublishedVersions(datasetID, editionID, edition, instanceID, unpublishedInstanceID)
+		if err != nil {
+			log.ErrorC("Failed to setup test data", err, nil)
 			os.Exit(1)
 		}
-	}
+
+		Convey("When an authenticated request is made to get the unpublished version", func() {
+			Convey("Then the response body contains the expected version", func() {
+				response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2", datasetID, edition).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				response.Value("id").Equal(unpublishedInstanceID)
+				response.Value("collection_id").Equal("208064B3-A808-449B-9041-EA3A2F72CFAB")
+				response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("A list of ages between 18 and 75+")
+				response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/codelists/408064B3-A808-449B-9041-EA3A2F72CFAC$")
+				response.Value("dimensions").Array().Element(0).Object().Value("id").Equal("408064B3-A808-449B-9041-EA3A2F72CFAC")
+				response.Value("dimensions").Array().Element(0).Object().Value("name").Equal("age")
+				response.Value("downloads").Object().Value("csv").Object().Value("url").String().Match("(.+)/aws/census-2017-2-csv$")
+				response.Value("downloads").Object().Value("csv").Object().Value("size").Equal("10mb")
+				response.Value("downloads").Object().Value("xls").Object().Value("url").String().Match("(.+)/aws/census-2017-2-xls$")
+				response.Value("downloads").Object().Value("xls").Object().Value("size").Equal("24mb")
+				response.Value("edition").Equal(edition)
+				response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
+				response.Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
+				response.Value("links").Object().Value("dimensions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/2/dimensions$")
+				response.Value("links").Object().Value("edition").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "$")
+				response.Value("links").Object().Value("edition").Object().Value("id").Equal(edition)
+				response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/2$")
+				response.Value("links").Object().Value("spatial").Object().Value("href").Equal("http://ons.gov.uk/geographylist")
+				response.Value("release_date").Equal("2017-12-12")
+				response.Value("state").Equal("associated")
+				response.Value("temporal").Array().Element(0).Object().Value("start_date").Equal("2014-09-09")
+				response.Value("temporal").Array().Element(0).Object().Value("end_date").Equal("2017-09-09")
+				response.Value("temporal").Array().Element(0).Object().Value("frequency").Equal("monthly")
+				response.Value("version").Equal(2)
+			})
+		})
+
+		Convey("When an unauthenticated request is made to get the published version", func() {
+			Convey("Then the response body contains the expected version", func() {
+				response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				response.Value("id").Equal(instanceID)
+				response.Value("collection_id").Equal("108064B3-A808-449B-9041-EA3A2F72CFAA")
+				response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("A list of ages between 18 and 75+")
+				response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/codelists/408064B3-A808-449B-9041-EA3A2F72CFAC$")
+				response.Value("dimensions").Array().Element(0).Object().Value("id").Equal("408064B3-A808-449B-9041-EA3A2F72CFAC")
+				response.Value("dimensions").Array().Element(0).Object().Value("name").Equal("age")
+				response.Value("downloads").Object().Value("csv").Object().Value("url").String().Match("(.+)/aws/census-2017-1-csv$")
+				response.Value("downloads").Object().Value("csv").Object().Value("size").Equal("10mb")
+				response.Value("downloads").Object().Value("xls").Object().Value("url").String().Match("(.+)/aws/census-2017-1-xls$")
+				response.Value("downloads").Object().Value("xls").Object().Value("size").Equal("24mb")
+				response.Value("edition").Equal(edition)
+				response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
+				response.Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
+				response.Value("links").Object().Value("dimensions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/1/dimensions$")
+				response.Value("links").Object().Value("edition").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "$")
+				response.Value("links").Object().Value("edition").Object().Value("id").Equal(edition)
+				response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/1$")
+				response.Value("links").Object().Value("spatial").Object().Value("href").Equal("http://ons.gov.uk/geographylist")
+				response.Value("release_date").Equal("2017-12-12")
+				response.Value("state").Equal("published")
+				response.Value("temporal").Array().Element(0).Object().Value("start_date").Equal("2014-09-09")
+				response.Value("temporal").Array().Element(0).Object().Value("end_date").Equal("2017-09-09")
+				response.Value("temporal").Array().Element(0).Object().Value("frequency").Equal("monthly")
+				response.Value("version").Equal(1)
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
+	})
 }
 
 func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
-	d, err := teardownVersion()
-	if err != nil {
-		log.ErrorC("Failed to tear down test data", err, nil)
-		os.Exit(1)
-	}
+
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	edition := "2017"
+
+	unpublishedDatasetID := uuid.NewV4().String()
+	unpublishedEditionID := uuid.NewV4().String()
+	unpublishedInstanceID := uuid.NewV4().String()
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Fail to get version document", t, func() {
-		Convey("and return status bad request", func() {
-			Convey("When the dataset does not exist", func() {
+	Convey("Given the dataset, edition and version do not exist", t, func() {
+		Convey("When an authorised request to get the version of the dataset edition", func() {
+			Convey("Then return status bad request (400) with message `Dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When the edition does not exist", func() {
-				if err := mongo.Setup(database, collection, "_id", datasetID, validPublishedDatasetData); err != nil {
-					log.ErrorC("Was unable to run test", err, nil)
-					os.Exit(1)
-				}
-
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-		})
-		Convey("and return status not found", func() {
-			mongo.Setup(database, "editions", "_id", editionID, validPublishedEditionData)
-
-			Convey("When the version does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound)
-			})
-			Convey("When user is unauthenticated and version is not published", func() {
-				mongo.Setup(database, "instances", "_id", "799", validUnpublishedInstanceData)
-
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
-					Expect().Status(http.StatusNotFound)
+					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
 			})
 		})
 	})
 
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
+	Convey("Given an unpublished dataset exist", t, func() {
+		if err := mongo.Setup(database, collection, "_id", unpublishedDatasetID, validAssociatedDatasetData(unpublishedDatasetID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
 			os.Exit(1)
 		}
-	}
+
+		Convey("but an edition and version do not exist", func() {
+			Convey("When a request to get the version of the dataset edition", func() {
+				Convey("Then return status bad request (400) with message `Edition not found`", func() {
+					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", unpublishedDatasetID, edition).WithHeader(internalToken, internalTokenID).
+						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+				})
+			})
+		})
+
+		Convey("and an unpublished edition exist", func() {
+			if err := mongo.Setup(database, "editions", "_id", unpublishedEditionID, validUnpublishedEditionData(unpublishedDatasetID, unpublishedEditionID, edition)); err != nil {
+				log.ErrorC("Was unable to run test", err, nil)
+				os.Exit(1)
+			}
+
+			Convey("but a version does not exist", func() {
+				Convey("When a request to get the version of the dataset edition", func() {
+					Convey("Then return status bad request (404) with message `Version not found`", func() {
+						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", unpublishedDatasetID, edition).WithHeader(internalToken, internalTokenID).
+							Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+					})
+				})
+			})
+
+			if err := mongo.Teardown(database, "editions", "_id", unpublishedEditionID); err != nil {
+				log.ErrorC("Was unable to run test", err, nil)
+				os.Exit(1)
+			}
+		})
+
+		if err := mongo.Teardown(database, collection, "_id", unpublishedDatasetID); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+	})
+
+	// Similar tests for unauthorised requests
+	Convey("Given an unpublished dataset", t, func() {
+		if err := mongo.Setup(database, collection, "_id", unpublishedDatasetID, validAssociatedDatasetData(unpublishedDatasetID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an unauthorised request to get the version of the dataset edition", func() {
+			Convey("Then return status bad request (400) with message `Dataset not found`", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+			})
+		})
+
+		if err := mongo.Teardown(database, collection, "_id", unpublishedDatasetID); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+	})
+
+	Convey("Given a published dataset", t, func() {
+		if err := mongo.Setup(database, collection, "_id", datasetID, validPublishedDatasetData(datasetID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("and an unpublished edition", func() {
+			if err := mongo.Setup(database, "editions", "_id", unpublishedEditionID, validUnpublishedEditionData(datasetID, unpublishedEditionID, edition)); err != nil {
+				log.ErrorC("Was unable to run test", err, nil)
+				os.Exit(1)
+			}
+
+			Convey("When an unauthorised request to get the version of the dataset edition", func() {
+				Convey("Then return status bad request (400) with message `Edition not found`", func() {
+					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
+						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+				})
+			})
+
+			if err := mongo.Teardown(database, "editions", "_id", unpublishedEditionID); err != nil {
+				log.ErrorC("Was unable to run test", err, nil)
+				os.Exit(1)
+			}
+		})
+
+		Convey("and a published edition but an unpublished version", func() {
+			if err := mongo.Setup(database, "editions", "_id", editionID, validPublishedEditionData(datasetID, editionID, edition)); err != nil {
+				log.ErrorC("Was unable to run test", err, nil)
+				os.Exit(1)
+			}
+
+			if err := mongo.Setup(database, "instances", "_id", unpublishedInstanceID, validAssociatedInstanceData(datasetID, editionID, unpublishedInstanceID)); err != nil {
+				log.ErrorC("Was unable to run test", err, nil)
+				os.Exit(1)
+			}
+
+			Convey("When an unauthorised request to get the version of the dataset edition", func() {
+				Convey("Then return status bad request (404) with message `Version not found`", func() {
+					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
+						Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+				})
+			})
+
+			if err := mongo.Teardown(database, "editions", "_id", editionID); err != nil {
+				log.ErrorC("Was unable to run test", err, nil)
+				os.Exit(1)
+			}
+
+			if err := mongo.Teardown(database, "instances", "_id", unpublishedInstanceID); err != nil {
+				log.ErrorC("Was unable to run test", err, nil)
+				os.Exit(1)
+			}
+		})
+
+		if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+	})
 }
 
-func teardownVersion() (*mongo.ManyDocs, error) {
+func setupPublishedAndUnpublishedVersions(datasetID, editionID, edition, instanceID, unpublishedInstanceID string) (*mongo.ManyDocs, error) {
 	var docs []mongo.Doc
 
 	datasetDoc := mongo.Doc{
@@ -154,7 +254,7 @@ func teardownVersion() (*mongo.ManyDocs, error) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedDatasetData,
+		Update:     validPublishedDatasetData(datasetID),
 	}
 
 	publishedEditionDoc := mongo.Doc{
@@ -162,7 +262,7 @@ func teardownVersion() (*mongo.ManyDocs, error) {
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData,
+		Update:     validPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	publishedVersionDoc := mongo.Doc{
@@ -170,15 +270,15 @@ func teardownVersion() (*mongo.ManyDocs, error) {
 		Collection: "instances",
 		Key:        "_id",
 		Value:      instanceID,
-		Update:     validPublishedInstanceData,
+		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
 	}
 
 	unpublishedVersionDoc := mongo.Doc{
 		Database:   "datasets",
 		Collection: "instances",
 		Key:        "_id",
-		Value:      "799",
-		Update:     validUnpublishedInstanceData,
+		Value:      unpublishedInstanceID,
+		Update:     validAssociatedInstanceData(datasetID, edition, unpublishedInstanceID),
 	}
 
 	docs = append(docs, datasetDoc, publishedEditionDoc, publishedVersionDoc, unpublishedVersionDoc)
@@ -187,10 +287,8 @@ func teardownVersion() (*mongo.ManyDocs, error) {
 		Docs: docs,
 	}
 
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			return nil, err
-		}
+	if err := mongo.SetupMany(d); err != nil {
+		return nil, err
 	}
 
 	return d, nil

--- a/datasetAPI/get_versions_test.go
+++ b/datasetAPI/get_versions_test.go
@@ -284,7 +284,7 @@ func setUpDatasetEditionVersions(datasetID, editionID, edition, instanceID, unpu
 		Update:     validAssociatedInstanceData(datasetID, edition, unpublishedInstanceID),
 	}
 
-	docs = append(docs, datasetDoc, editionDoc, instanceDoc, unpublishedInstanceDoc) //, instanceDoc)
+	docs = append(docs, datasetDoc, editionDoc, instanceDoc, unpublishedInstanceDoc)
 
 	d := &mongo.ManyDocs{
 		Docs: docs,

--- a/datasetAPI/get_versions_test.go
+++ b/datasetAPI/get_versions_test.go
@@ -10,180 +10,220 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestGetVersions_ReturnsListOfVersions(t *testing.T) {
-	var docs []mongo.Doc
 
-	datasetDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "datasets",
-		Key:        "_id",
-		Value:      datasetID,
-		Update:     validPublishedDatasetData,
-	}
+	instanceID := uuid.NewV4().String()
+	unpublishedInstanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	edition := "2017"
 
-	editionDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "editions",
-		Key:        "_id",
-		Value:      editionID,
-		Update:     validPublishedEditionData,
-	}
+	Convey("Given a dataset edition has a published and unpublished version", t, func() {
 
-	instanceOneDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "instances",
-		Key:        "_id",
-		Value:      instanceID,
-		Update:     validPublishedInstanceData,
-	}
-
-	instanceTwoDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "instances",
-		Key:        "_id",
-		Value:      "799",
-		Update:     validUnpublishedInstanceData,
-	}
-
-	docs = append(docs, datasetDoc, editionDoc, instanceTwoDoc, instanceOneDoc)
-
-	d := &mongo.ManyDocs{
-		Docs: docs,
-	}
-
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
+		d, err := setUpDatasetEditionVersions(datasetID, editionID, edition, instanceID, unpublishedInstanceID)
+		if err != nil {
 			log.ErrorC("Was unable to run test", err, nil)
 			os.Exit(1)
 		}
-	}
 
-	if err := mongo.SetupMany(d); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
+		datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-
-	Convey("Get a list of all versions of a dataset", t, func() {
 		Convey("When user is authenticated", func() {
-			response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
+			response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
+				WithHeader("Internal-Token", internalTokenID).Expect().Status(http.StatusOK).JSON().Object()
 
-			response.Value("items").Array().Length().Equal(2)
-			checkVersionResponse(response.Value("items").Array().Element(1).Object())
+			Convey("Then response contains a list of all versions of the dataset edition", func() {
+				response.Value("items").Array().Length().Equal(2)
+				for i := 0; i < len(response.Value("items").Array().Iter()); i++ {
 
-			response.Value("items").Array().Element(0).Object().Value("id").Equal("799")
-			response.Value("items").Array().Element(0).Object().Value("state").Equal("associated")
+					if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == instanceID {
+						// check the published test version document has the expected returned fields and values
+						response.Value("items").Array().Element(i).Object().Value("id").Equal(instanceID)
+						checkVersionResponse(datasetID, editionID, instanceID, edition, response.Value("items").Array().Element(i).Object())
+					}
+
+					if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == unpublishedInstanceID {
+						response.Value("items").Array().Element(i).Object().Value("id").Equal(unpublishedInstanceID)
+						response.Value("items").Array().Element(i).Object().Value("state").Equal("associated")
+					}
+				}
+			})
 		})
 
 		Convey("When a user is not authenticated", func() {
 			response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 				Expect().Status(http.StatusOK).JSON().Object()
 
-			response.Value("items").Array().Length().Equal(1)
-			checkVersionResponse(response.Value("items").Array().Element(0).Object())
+			Convey("Then response contains a list of only published versions of the dataset edition", func() {
+				response.Value("items").Array().Length().Equal(1)
+				checkVersionResponse(datasetID, editionID, instanceID, edition, response.Value("items").Array().Element(0).Object())
+			})
 		})
-	})
 
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			os.Exit(1)
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
 		}
-	}
+	})
 }
 
 func TestGetVersions_Failed(t *testing.T) {
-	var docs []mongo.Doc
 
-	datasetDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "datasets",
-		Key:        "_id",
-		Value:      datasetID,
-		Update:     validPublishedDatasetData,
-	}
+	unpublishedInstanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	edition := "2018"
 
-	editionDoc := mongo.Doc{
-		Database:   "datasets",
-		Collection: "editions",
-		Key:        "_id",
-		Value:      editionID,
-		Update:     validPublishedEditionData,
-	}
-
-	docs = append(docs, datasetDoc, editionDoc)
-
-	d := &mongo.ManyDocs{
-		Docs: docs,
-	}
-
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
-
-	if err := mongo.SetupMany(d); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
+	unpublishedDatasetID := uuid.NewV4().String()
+	unpublishedEditionID := uuid.NewV4().String()
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Fail to get a list of versions for a dataset", t, func() {
-		Convey("When authenticated", func() {
-			Convey("When the dataset does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", "1234", "2018").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When the edition does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, "2018").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When there are no versions", func() {
+	Convey("Given the dataset and subsequently the edition does not exist", t, func() {
+		Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
+			Convey("Then return status bad request (400)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound)
-			})
-		})
-		Convey("When unauthenticated", func() {
-			Convey("When the dataset does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", "1234", "2018").
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When the edition does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, "2018").
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When there are no published versions", func() {
-				// Create an unpublished instance document
-				mongo.Teardown(database, "instances", "_id", "799")
-				mongo.Setup(database, "instances", "_id", "799", validUnpublishedInstanceData)
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
-					Expect().Status(http.StatusNotFound)
-
-				mongo.Teardown(database, "instances", "_id", "799")
+					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
 			})
 		})
 	})
 
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
+	Convey("Given the dataset exists", t, func() {
+		update := validPublishedDatasetData(datasetID)
+		if err := mongo.Setup(database, collection, "_id", datasetID, update); err != nil {
+			log.ErrorC("Unable to setup test data", err, nil)
 			os.Exit(1)
 		}
-	}
+
+		Convey("but the edition does not", func() {
+			Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
+				Convey("Then return status bad request (400)", func() {
+					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(internalToken, internalTokenID).
+						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+				})
+			})
+		})
+
+		Convey("and the edition does exist but there are no versions", func() {
+			update := validPublishedEditionData(datasetID, editionID, edition)
+			if err := mongo.Setup(database, "editions", "_id", editionID, update); err != nil {
+				log.ErrorC("Unable to setup test data", err, nil)
+				os.Exit(1)
+			}
+
+			Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
+				Convey("Then return status not found (404)", func() {
+					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(internalToken, internalTokenID).
+						Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+				})
+			})
+			if err := mongo.Teardown(database, "editions", "_id", editionID); err != nil {
+				log.ErrorC("Unable to remove test data from mongo db", err, nil)
+				os.Exit(1)
+			}
+		})
+
+		if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
+			log.ErrorC("Unable to remove test data from mongo db", err, nil)
+			os.Exit(1)
+		}
+	})
+
+	// Make sure an unauthorised user cannot find the dataset
+	Convey("Given an unpublished dataset exists", t, func() {
+		update := validAssociatedDatasetData(unpublishedDatasetID)
+		if err := mongo.Setup(database, collection, "_id", unpublishedDatasetID, update); err != nil {
+			log.ErrorC("Unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an unauthenticated request is made to get a list of versions of the dataset edition", func() {
+			Convey("Then return status bad request (400)", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+			})
+		})
+
+		if err := mongo.Teardown(database, collection, "_id", unpublishedDatasetID); err != nil {
+			log.ErrorC("Unable to remove test data from mongo db", err, nil)
+			os.Exit(1)
+		}
+	})
+
+	Convey("Given a published dataset exists", t, func() {
+		update := validPublishedDatasetData(datasetID)
+		if err := mongo.Setup(database, collection, "_id", datasetID, update); err != nil {
+			log.ErrorC("Unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("but only an unpublished edition exists", func() {
+			update := validUnpublishedEditionData(datasetID, unpublishedEditionID, edition)
+			if err := mongo.Setup(database, "editions", "_id", unpublishedEditionID, update); err != nil {
+				log.ErrorC("Unable to setup test data", err, nil)
+				os.Exit(1)
+			}
+
+			Convey("When an unauthenticated request is made to get a list of versions of the dataset edition", func() {
+				Convey("Then return status bad request (400)", func() {
+					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
+						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+				})
+			})
+
+			if err := mongo.Teardown(database, "editions", "_id", unpublishedEditionID); err != nil {
+				log.ErrorC("Unable to remove test data from mongo db", err, nil)
+				os.Exit(1)
+			}
+		})
+
+		Convey("and a published edition exists", func() {
+			update := validPublishedEditionData(datasetID, editionID, edition)
+			if err := mongo.Setup(database, "editions", "_id", editionID, update); err != nil {
+				log.ErrorC("Unable to setup test data", err, nil)
+				os.Exit(1)
+			}
+
+			Convey("but only unpublished versions exist for the dataset edition", func() {
+				update := validAssociatedInstanceData(datasetID, edition, unpublishedInstanceID)
+				if err := mongo.Setup(database, "instances", "_id", unpublishedInstanceID, update); err != nil {
+					log.ErrorC("Unable to setup test data", err, nil)
+					os.Exit(1)
+				}
+
+				Convey("When an unauthenticated request is made to get a list of versions of the dataset edition", func() {
+					Convey("Then return status not found (404)", func() {
+						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
+							Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+					})
+				})
+
+				if err := mongo.Teardown(database, "instances", "_id", unpublishedInstanceID); err != nil {
+					log.ErrorC("Unable to remove test data from mongo db", err, nil)
+					os.Exit(1)
+				}
+			})
+
+			if err := mongo.Teardown(database, "editions", "_id", editionID); err != nil {
+				log.ErrorC("Unable to remove test data from mongo db", err, nil)
+				os.Exit(1)
+			}
+		})
+
+		if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
+			log.ErrorC("Unable to remove test data from mongo db", err, nil)
+			os.Exit(1)
+		}
+	})
 }
 
-func checkVersionResponse(response *httpexpect.Object) {
-	response.Value("id").Equal("789")
+func checkVersionResponse(datasetID, editionID, instanceID, edition string, response *httpexpect.Object) {
+	response.Value("id").Equal(instanceID)
 	response.Value("collection_id").Equal("108064B3-A808-449B-9041-EA3A2F72CFAA")
 	response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("A list of ages between 18 and 75+")
 	response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/codelists/408064B3-A808-449B-9041-EA3A2F72CFAC$")
@@ -200,11 +240,59 @@ func checkVersionResponse(response *httpexpect.Object) {
 	response.Value("links").Object().Value("edition").Object().Value("id").Equal(edition)
 	response.Value("links").Object().Value("edition").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "$")
 	response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + edition + "/versions/1$")
+	response.Value("links").Object().Value("spatial").Object().Value("href").Equal("http://ons.gov.uk/geographylist")
 	response.Value("release_date").Equal("2017-12-12") // TODO Should be isodate
-	response.Value("spatial").Equal("http://ons.gov.uk/geographylist")
 	response.Value("state").Equal("published")
 	response.Value("temporal").Array().Element(0).Object().Value("start_date").Equal("2014-09-09")
 	response.Value("temporal").Array().Element(0).Object().Value("end_date").Equal("2017-09-09")
 	response.Value("temporal").Array().Element(0).Object().Value("frequency").Equal("monthly")
 	response.Value("version").Equal(1)
+}
+
+func setUpDatasetEditionVersions(datasetID, editionID, edition, instanceID, unpublishedInstanceID string) (*mongo.ManyDocs, error) {
+	var docs []mongo.Doc
+
+	datasetDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     validPublishedDatasetData(datasetID),
+	}
+
+	editionDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "editions",
+		Key:        "_id",
+		Value:      editionID,
+		Update:     validPublishedEditionData(datasetID, editionID, edition),
+	}
+
+	instanceDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "instances",
+		Key:        "_id",
+		Value:      instanceID,
+		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
+	}
+
+	unpublishedInstanceDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "instances",
+		Key:        "_id",
+		Value:      unpublishedInstanceID,
+		Update:     validAssociatedInstanceData(datasetID, edition, unpublishedInstanceID),
+	}
+
+	docs = append(docs, datasetDoc, editionDoc, instanceDoc, unpublishedInstanceDoc) //, instanceDoc)
+
+	d := &mongo.ManyDocs{
+		Docs: docs,
+	}
+
+	if err := mongo.SetupMany(d); err != nil {
+		return nil, err
+	}
+
+	return d, nil
 }

--- a/datasetAPI/initialise.go
+++ b/datasetAPI/initialise.go
@@ -11,14 +11,14 @@ import (
 var cfg *config.Config
 
 const (
-	database               = "datasets"
-	collection             = "datasets"
-	datasetID              = "123"
-	editionID              = "456"
-	edition                = "2017"
-	instanceID             = "789" // This maybe known as the version Id
-	dimensionID            = "999"
-	dimensionOptionID      = "888"
+	database   = "datasets"
+	collection = "datasets"
+	// datasetID              = "123"
+	// editionID              = "456"
+	// edition                = "2017"
+	// instanceID             = "789" // This maybe known as the version Id
+	// dimensionID            = "999"
+	// dimensionOptionID      = "888"
 	internalToken          = "Internal-Token"
 	internalTokenID        = "FD0108EA-825D-411C-9B1D-41EF7727F465"
 	invalidInternalTokenID = "FD0108EA-825D-411C-9B1D-41EF7727F465A"
@@ -38,6 +38,16 @@ func init() {
 	}
 
 	if err = mongo.Teardown(database, collection, "test_data", "true"); err != nil {
+		log.ErrorC("Unable to remove all test data from mongo db", err, nil)
+		os.Exit(1)
+	}
+
+	if err = mongo.Teardown(database, "editions", "test_data", "true"); err != nil {
+		log.ErrorC("Unable to remove all test data from mongo db", err, nil)
+		os.Exit(1)
+	}
+
+	if err = mongo.Teardown(database, "instances", "test_data", "true"); err != nil {
 		log.ErrorC("Unable to remove all test data from mongo db", err, nil)
 		os.Exit(1)
 	}

--- a/datasetAPI/initialise.go
+++ b/datasetAPI/initialise.go
@@ -13,12 +13,7 @@ var cfg *config.Config
 const (
 	database   = "datasets"
 	collection = "datasets"
-	// datasetID              = "123"
-	// editionID              = "456"
-	// edition                = "2017"
-	// instanceID             = "789" // This maybe known as the version Id
-	// dimensionID            = "999"
-	// dimensionOptionID      = "888"
+
 	internalToken          = "Internal-Token"
 	internalTokenID        = "FD0108EA-825D-411C-9B1D-41EF7727F465"
 	invalidInternalTokenID = "FD0108EA-825D-411C-9B1D-41EF7727F465A"

--- a/datasetAPI/json.go
+++ b/datasetAPI/json.go
@@ -1,383 +1,430 @@
 package datasetAPI
 
-import "gopkg.in/mgo.v2/bson"
+import (
+	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
+	"gopkg.in/mgo.v2/bson"
+)
 
-// Contact represents an object containing contact information
-type Contact struct {
-	Email     string
-	Name      string
-	Telephone string
-}
-
-// Dimension represents information regarding a dimension and it's codelist
-type Dimension struct {
-	Description string
-	HRef        string
-	ID          string
-	Name        string
-}
-
-// GenericObject represents a generic object structure
-type GenericObject struct {
-	Description string
-	HRef        string
-	Title       string
-}
-
-// TemporalFrequency represents
-type TemporalFrequency struct {
-	EndDate   string `bson:"end_date"`
-	Frequency string
-	StartDate string `bson:"start_date"`
-}
-
-var contact = Contact{
+var contact = mongo.ContactDetails{
 	Email:     "cpi@onstest.gov.uk",
 	Name:      "Automation Tester",
 	Telephone: "+44 (0)1633 123456",
 }
 
-var methodology = GenericObject{
+var methodology = mongo.GeneralDetails{
 	Description: "Consumer price inflation is the rate at which the prices of the goods and services bought by households rise or fall, and is estimated by using consumer price indices.",
 	HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
 	Title:       "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
 }
 
-var publication = GenericObject{
+var publication = mongo.GeneralDetails{
 	Description: "Price indices, percentage changes and weights for the different measures of consumer price inflation.",
 	HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
 	Title:       "UK consumer price inflation: August 2017",
 }
 
-var relatedDatasets = GenericObject{
+var relatedDatasets = mongo.GeneralDetails{
 	HRef:  "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceindices",
 	Title: "Consumer Price Inflation time series dataset",
 }
 
-var dimension = Dimension{
+var dimension = mongo.CodeList{
 	Description: "A list of ages between 18 and 75+",
 	HRef:        "http://localhost:8080/codelists/408064B3-A808-449B-9041-EA3A2F72CFAC",
 	ID:          "408064B3-A808-449B-9041-EA3A2F72CFAC",
 	Name:        "age",
 }
 
-var temporal = TemporalFrequency{
+var temporal = mongo.TemporalFrequency{
 	EndDate:   "2017-09-09",
 	Frequency: "monthly",
 	StartDate: "2014-09-09",
 }
 
-var validPublishedDatasetData = bson.M{
-	"$set": bson.M{
-		"id": datasetID,
-		"current.access_right":              "http://ons.gov.uk/accessrights",
-		"current.collection_id":             "108064B3-A808-449B-9041-EA3A2F72CFAA",
-		"current.contacts":                  []Contact{contact},
-		"current.description":               "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
-		"current.id":                        datasetID,
-		"current.keywords":                  []string{"cpi", "boy"},
-		"current.last_updated":              "2017-06-06", // TODO this should be an isodate
-		"current.license":                   "ONS license",
-		"current.links.editions.href":       "http://localhost:8080/datasets/" + datasetID + "/editions",
-		"current.links.latest_version.id":   "1",
-		"current.links.latest_version.href": "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/1",
-		"current.links.self.href":           "http://localhost:8080/datasets/" + datasetID,
-		"current.methodologies":             []GenericObject{methodology},
-		"current.national_statistic":        true,
-		"current.next_release":              "2017-10-10",
-		"current.publications":              []GenericObject{publication},
-		"current.publisher.name":            "Automation Tester",
-		"current.publisher.type":            "publisher",
-		"current.publisher.href":            "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
-		"current.qmi.description":           "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
-		"current.qmi.href":                  "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
-		"current.qmi.title":                 "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
-		"current.related_datasets":          []GenericObject{relatedDatasets},
-		"current.release_frequency":         "Monthly",
-		"current.state":                     "published",
-		"current.theme":                     "Goods and services",
-		"current.title":                     "CPI",
-		"current.uri":                       "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
-		"next.access_right":                 "http://ons.gov.uk/accessrights",
-		"next.collection_id":                "208064B3-A808-449B-9041-EA3A2F72CFAB",
-		"next.contacts":                     []Contact{contact},
-		"next.description":                  "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
-		"next.id":                           datasetID,
-		"next.keywords":                     []string{"cpi", "boy"},
-		"next.last_updated":                 "2017-10-11", // TODO this should be an isodate
-		"next.license":                      "ONS license",
-		"next.links.editions.href":          "http://localhost:8080/datasets/" + datasetID + "/editions",
-		"next.links.latest_version.id":      "1",
-		"next.links.latest_version.href":    "http://localhost:8080/datasets/" + datasetID + "/editions/2018/versions/1",
-		"next.links.self.href":              "http://localhost:8080/datasets/" + datasetID,
-		"next.methodologies":                []GenericObject{methodology},
-		"next.national_statistic":           true,
-		"next.next_release":                 "2018-10-10",
-		"next.publications":                 []GenericObject{publication},
-		"next.publisher.name":               "Automation Tester",
-		"next.publisher.type":               "publisher",
-		"next.publisher.href":               "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
-		"next.qmi.description":              "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
-		"next.qmi.href":                     "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
-		"next.qmi.title":                    "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
-		"next.related_datasets":             []GenericObject{relatedDatasets},
-		"next.release_frequency":            "Monthly",
-		"next.state":                        "created",
-		"next.theme":                        "Goods and services",
-		"next.title":                        "CPI",
-		"next.uri":                          "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
-		"test_data":                         "true",
-	},
+func validPublishedDatasetData(datasetID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"id": datasetID,
+			"current.collection_id":             "108064B3-A808-449B-9041-EA3A2F72CFAA",
+			"current.contacts":                  []mongo.ContactDetails{contact},
+			"current.description":               "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
+			"current.id":                        datasetID,
+			"current.keywords":                  []string{"cpi", "boy"},
+			"current.last_updated":              "2017-06-06", // TODO this should be an isodate
+			"current.license":                   "ONS license",
+			"current.links.access_rights.href":  "http://ons.gov.uk/accessrights",
+			"current.links.editions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions",
+			"current.links.latest_version.id":   "1",
+			"current.links.latest_version.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2017/versions/1",
+			"current.links.self.href":           cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"current.methodologies":             []mongo.GeneralDetails{methodology},
+			"current.national_statistic":        true,
+			"current.next_release":              "2017-10-10",
+			"current.publications":              []mongo.GeneralDetails{publication},
+			"current.publisher.name":            "Automation Tester",
+			"current.publisher.type":            "publisher",
+			"current.publisher.href":            "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
+			"current.qmi.description":           "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
+			"current.qmi.href":                  "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
+			"current.qmi.title":                 "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
+			"current.related_datasets":          []mongo.GeneralDetails{relatedDatasets},
+			"current.release_frequency":         "Monthly",
+			"current.state":                     "published",
+			"current.theme":                     "Goods and services",
+			"current.title":                     "CPI",
+			"current.uri":                       "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
+			"next.collection_id":                "208064B3-A808-449B-9041-EA3A2F72CFAB",
+			"next.contacts":                     []mongo.ContactDetails{contact},
+			"next.description":                  "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
+			"next.id":                           datasetID,
+			"next.keywords":                     []string{"cpi", "boy"},
+			"next.last_updated":                 "2017-10-11", // TODO this should be an isodate
+			"next.license":                      "ONS license",
+			"next.links.access_rights.href":     "http://ons.gov.uk/accessrights",
+			"next.links.editions.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions",
+			"next.links.latest_version.id":      "1",
+			"next.links.latest_version.href":    cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2018/versions/1",
+			"next.links.self.href":              cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"next.methodologies":                []mongo.GeneralDetails{methodology},
+			"next.national_statistic":           true,
+			"next.next_release":                 "2018-10-10",
+			"next.publications":                 []mongo.GeneralDetails{publication},
+			"next.publisher.name":               "Automation Tester",
+			"next.publisher.type":               "publisher",
+			"next.publisher.href":               "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
+			"next.qmi.description":              "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
+			"next.qmi.href":                     "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
+			"next.qmi.title":                    "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
+			"next.related_datasets":             []mongo.GeneralDetails{relatedDatasets},
+			"next.release_frequency":            "Monthly",
+			"next.state":                        "created",
+			"next.theme":                        "Goods and services",
+			"next.title":                        "CPI",
+			"next.uri":                          "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
+			"test_data":                         "true",
+		},
+	}
 }
 
-var validUnpublishedDatasetData = bson.M{
-	"$set": bson.M{
-		"id":                             "133",
-		"next.collection_id":             "208064B3-A808-449B-9041-EA3A2F72CFAB",
-		"next.contacts":                  []Contact{contact},
-		"next.description":               "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
-		"next.id":                        "133",
-		"next.keywords":                  []string{"cpi", "boy"},
-		"next.last_updated":              "2017-10-11", // TODO this should be an isodate
-		"next.links.editions.href":       "http://localhost:8080/datasets/" + datasetID + "/editions",
-		"next.links.latest_version.id":   "1",
-		"next.links.latest_version.href": "http://localhost:8080/datasets/" + datasetID + "/editions/2018/versions/1",
-		"next.links.self.href":           "http://localhost:8080/datasets/" + datasetID,
-		"next.methodologies":             []GenericObject{methodology},
-		"next.national_statistic":        true,
-		"next.next_release":              "2018-10-10",
-		"next.publications":              []GenericObject{publication},
-		"next.publisher.name":            "Automation Tester",
-		"next.publisher.type":            "publisher",
-		"next.publisher.href":            "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
-		"next.qmi.description":           "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
-		"next.qmi.href":                  "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
-		"next.qmi.title":                 "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
-		"next.related_datasets":          []GenericObject{relatedDatasets},
-		"next.release_frequency":         "Monthly",
-		"next.state":                     "created",
-		"next.theme":                     "Goods and services",
-		"next.title":                     "CPI",
-		"next.uri":                       "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
-		"test_data":                      "true",
-	},
+func validAssociatedDatasetData(datasetID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"id":                             datasetID,
+			"next.collection_id":             "208064B3-A808-449B-9041-EA3A2F72CFAB",
+			"next.contacts":                  []mongo.ContactDetails{contact},
+			"next.description":               "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
+			"next.id":                        datasetID,
+			"next.keywords":                  []string{"cpi", "boy"},
+			"next.last_updated":              "2017-10-11", // TODO this should be an isodate
+			"next.links.access_rights.href":  "http://ons.gov.uk/accessrights",
+			"next.links.editions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions",
+			"next.links.latest_version.id":   "1",
+			"next.links.latest_version.href": cfg.DatasetAPIURL + "/datasets" + datasetID + "/editions/2018/versions/1",
+			"next.links.self.href":           cfg.DatasetAPIURL + "/datasets" + datasetID,
+			"next.methodologies":             []mongo.GeneralDetails{methodology},
+			"next.national_statistic":        true,
+			"next.next_release":              "2018-10-10",
+			"next.publications":              []mongo.GeneralDetails{publication},
+			"next.publisher.name":            "Automation Tester",
+			"next.publisher.type":            "publisher",
+			"next.publisher.href":            "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
+			"next.qmi.description":           "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
+			"next.qmi.href":                  "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
+			"next.qmi.title":                 "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
+			"next.related_datasets":          []mongo.GeneralDetails{relatedDatasets},
+			"next.release_frequency":         "Monthly",
+			"next.state":                     "associated",
+			"next.theme":                     "Goods and services",
+			"next.title":                     "CPI",
+			"next.uri":                       "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
+			"test_data":                      "true",
+		},
+	}
 }
 
-var validTimeDimensionsData = bson.M{
-	"$set": bson.M{
-
-		"_id":                  "9811",
-		"instance_id":          instanceID,
-		"name":                 "time",
-		"option":               "202.45",
-		"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
-		"links.code_list.href": "http://localhost:8080/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a",
-		"links.code.id":        "202.45",
-		"links.code.href":      "http://localhost:8080/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/202.45",
-
-		"node_id": "",
-
-		"last_updated": "2017-09-09", // TODO Should be isodate
-		"test_data":    "true",
-	},
+func validCreatedDatasetData(datasetID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"id":                             datasetID,
+			"next.contacts":                  []mongo.ContactDetails{contact},
+			"next.description":               "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
+			"next.id":                        datasetID,
+			"next.keywords":                  []string{"cpi", "boy"},
+			"next.last_updated":              "2017-10-11", // TODO this should be an isodate
+			"next.links.access_rights.href":  "http://ons.gov.uk/accessrights",
+			"next.links.editions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions",
+			"next.links.latest_version.id":   "1",
+			"next.links.latest_version.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2018/versions/1",
+			"next.links.self.href":           cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"next.methodologies":             []mongo.GeneralDetails{methodology},
+			"next.national_statistic":        true,
+			"next.next_release":              "2018-10-10",
+			"next.publications":              []mongo.GeneralDetails{publication},
+			"next.publisher.name":            "Automation Tester",
+			"next.publisher.type":            "publisher",
+			"next.publisher.href":            "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
+			"next.qmi.description":           "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
+			"next.qmi.href":                  "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
+			"next.qmi.title":                 "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
+			"next.related_datasets":          []mongo.GeneralDetails{relatedDatasets},
+			"next.release_frequency":         "Monthly",
+			"next.state":                     "created",
+			"next.theme":                     "Goods and services",
+			"next.title":                     "CPI",
+			"next.uri":                       "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
+			"test_data":                      "true",
+		},
+	}
 }
 
-var validTimeDimensionsDataWithOutOptions = bson.M{
-	"$set": bson.M{
-
-		"_id":                  "9811",
-		"instance_id":          instanceID,
-		"name":                 "time",
-		"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
-		"links.code_list.href": "http://localhost:8080/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a",
-		"links.code.id":        "202.45",
-		"links.code.href":      "http://localhost:8080/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/202.45",
-
-		"node_id": "",
-
-		"last_updated": "2017-09-09", // TODO Should be isodate
-		"test_data":    "true",
-	},
-}
-var validAggregateDimensionsData = bson.M{
-	"$set": bson.M{
-
-		"_id":                  "9812",
-		"instance_id":          instanceID,
-		"name":                 "aggregate",
-		"option":               "cpi1dimA19",
-		"label":                "CPI (Overall Index)",
-		"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
-		"links.code_list.href": "http://localhost:8080/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a",
-		"links.code.id":        "cpi1dimA19",
-		"links.code.href":      "http://localhost:8080/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/cpi1dimA19",
-
-		"last_updated": "2017-09-08", // TODO Should be isodate
-		"test_data":    "true",
-	},
+func validTimeDimensionsData(instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"_id":                  "9811",
+			"instance_id":          instanceID,
+			"name":                 "time",
+			"option":               "202.45",
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code.id":        "202.45",
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/202.45",
+			"node_id":              "",
+			"last_updated":         "2017-09-09", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
 }
 
-var validPublishedEditionData = bson.M{
-	"$set": bson.M{
-		"edition":             "2017",
-		"id":                  editionID,
-		"last_updated":        "2017-09-08", // TODO Should be isodate
-		"links.dataset.id":    datasetID,
-		"links.dataset.href":  "http://localhost:8080/datasets/" + datasetID,
-		"links.self.href":     "http://localhost:8080/datasets/" + datasetID + "/editions/2017",
-		"links.versions.href": "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions",
-		"state":               "published",
-		"test_data":           "true",
-	},
+func validTimeDimensionsDataWithOutOptions(instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"_id":                  "9811",
+			"instance_id":          instanceID,
+			"name":                 "time",
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code.id":        "202.45",
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/202.45",
+			"node_id":              "",
+			"last_updated":         "2017-09-09", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
 }
 
-var validUnpublishedEditionData = bson.M{
-	"$set": bson.M{
-		"edition":             "2018",
-		"id":                  "466",
-		"last_updated":        "2017-10-08", // TODO Should be isodate
-		"links.dataset.id":    datasetID,
-		"links.dataset.href":  "http://localhost:8080/datasets/" + datasetID,
-		"links.self.href":     "http://localhost:8080/datasets/" + datasetID + "/editions/2018",
-		"links.versions.href": "http://localhost:8080/datasets/" + datasetID + "/editions/2018/versions",
-		"state":               "edition-confirmed",
-		"test_data":           "true",
-	},
+func validAggregateDimensionsData(instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"_id":                  "9812",
+			"instance_id":          instanceID,
+			"name":                 "aggregate",
+			"option":               "cpi1dimA19",
+			"label":                "CPI (Overall Index)",
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code.id":        "cpi1dimA19",
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/cpi1dimA19",
+			"last_updated":         "2017-09-08", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
 }
 
-var validPublishedInstanceData = bson.M{
-	"$set": bson.M{
-		"collection_id":               "108064B3-A808-449B-9041-EA3A2F72CFAA",
-		"dimensions":                  []Dimension{dimension},
-		"downloads.csv.url":           "http://localhost:8080/aws/census-2017-1-csv",
-		"downloads.csv.size":          "10mb",
-		"downloads.xls.url":           "http://localhost:8080/aws/census-2017-1-xls",
-		"downloads.xls.size":          "24mb",
-		"edition":                     "2017",
-		"headers":                     []string{"time", "geography"},
-		"id":                          instanceID,
-		"last_updated":                "2017-09-08", // TODO Should be isodate
-		"license":                     "ONS License",
-		"links.job.id":                "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-		"links.job.href":              "http://localhost:8080/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-		"links.dataset.id":            datasetID,
-		"links.dataset.href":          "http://localhost:8080/datasets/" + datasetID,
-		"links.dimensions.href":       "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/1/dimensions",
-		"links.edition.id":            edition,
-		"links.edition.href":          "http://localhost:8080/datasets/" + datasetID + "/editions/2017",
-		"links.self.href":             "http://localhost:8080/instances/" + instanceID,
-		"links.version.href":          "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/1",
-		"links.version.id":            "1",
-		"release_date":                "2017-12-12", // TODO Should be isodate
-		"spatial":                     "http://ons.gov.uk/geographylist",
-		"state":                       "published",
-		"temporal":                    []TemporalFrequency{temporal},
-		"total_inserted_observations": 1000,
-		"total_observations":          1000,
-		"version":                     1,
-		"test_data":                   "true",
-	},
+func validPublishedEditionData(datasetID, editionID, edition string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"edition":                   edition,
+			"id":                        editionID,
+			"last_updated":              "2017-09-08", // TODO Should be isodate
+			"links.dataset.id":          datasetID,
+			"links.dataset.href":        cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"links.latest_version.id":   "1",
+			"links.latest_version.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/1",
+			"links.self.href":           cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
+			"links.versions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions",
+			"state":                     "published",
+			"test_data":                 "true",
+		},
+	}
 }
 
-var validUnpublishedInstanceData = bson.M{
-	"$set": bson.M{
-		"collection_id":               "208064B3-A808-449B-9041-EA3A2F72CFAB",
-		"dimensions":                  []Dimension{dimension},
-		"downloads.csv.url":           "http://localhost:8080/aws/census-2017-2-csv",
-		"downloads.csv.size":          "10mb",
-		"downloads.xls.url":           "http://localhost:8080/aws/census-2017-2-xls",
-		"downloads.xls.size":          "24mb",
-		"edition":                     edition,
-		"headers":                     []string{"time", "geography"},
-		"id":                          "799",
-		"last_updated":                "2017-09-08", // TODO Should be isodate
-		"license":                     "ONS license",
-		"links.job.id":                "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-		"links.job.href":              "http://localhost:8080/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-		"links.dataset.id":            datasetID,
-		"links.dataset.href":          "http://localhost:8080/datasets/" + datasetID,
-		"links.dimensions.href":       "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/2/dimensions",
-		"links.edition.id":            edition,
-		"links.edition.href":          "http://localhost:8080/datasets/" + datasetID + "/editions/2017",
-		"links.self.href":             "http://localhost:8080/instances/" + "799",
-		"links.version.href":          "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/2",
-		"links.version.id":            "2",
-		"release_date":                "2017-12-12", // TODO Should be isodate
-		"spatial":                     "http://ons.gov.uk/geographylist",
-		"state":                       "associated",
-		"temporal":                    []TemporalFrequency{temporal},
-		"total_inserted_observations": 1000,
-		"total_observations":          1000,
-		"version":                     2,
-		"test_data":                   "true",
-	},
+func validUnpublishedEditionData(datasetID, editionID, edition string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"edition":             edition,
+			"id":                  editionID,
+			"last_updated":        "2017-10-08", // TODO Should be isodate
+			"links.dataset.id":    datasetID,
+			"links.dataset.href":  cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"links.self.href":     cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
+			"links.versions.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions",
+			"state":               "edition-confirmed",
+			"test_data":           "true",
+		},
+	}
 }
 
-var validCompletedInstanceData = bson.M{
-	"$set": bson.M{
-		"collection_id":         "208064B3-A808-449B-9041-EA3A2F72CFAB",
-		"downloads.csv.url":     "http://localhost:8080/aws/census-2017-2-csv",
-		"downloads.csv.size":    "10mb",
-		"downloads.xls.url":     "http://localhost:8080/aws/census-2017-2-xls",
-		"downloads.xls.size":    "24mb",
-		"edition":               edition,
-		"headers":               []string{"time", "geography"},
-		"id":                    "799",
-		"last_updated":          "2017-09-08", // TODO Should be isodate
-		"license":               "ONS license",
-		"links.job.id":          "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-		"links.job.href":        "http://localhost:8080/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-		"links.dataset.id":      datasetID,
-		"links.dataset.href":    "http://localhost:8080/datasets/" + datasetID,
-		"links.dimensions.href": "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/2/dimensions",
-		"links.edition.id":      edition,
-		"links.edition.href":    "http://localhost:8080/datasets/" + datasetID + "/editions/2017",
-		"links.self.href":       "http://localhost:8080/instances/" + "799",
-		"links.version.href":    "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/2",
-		"links.version.id":      "2",
-		"release_date":          "2017-12-12", // TODO Should be isodate
-		"state":                 "completed",
-		"total_inserted_observations": 1000,
-		"total_observations":          1000,
-		"version":                     2,
-		"test_data":                   "true",
-	},
+func validPublishedInstanceData(datasetID, edition, instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"collection_id":               "108064B3-A808-449B-9041-EA3A2F72CFAA",
+			"dimensions":                  []mongo.CodeList{dimension},
+			"downloads.csv.url":           cfg.DatasetAPIURL + "/aws/census-2017-1-csv",
+			"downloads.csv.size":          "10mb",
+			"downloads.xls.url":           cfg.DatasetAPIURL + "/aws/census-2017-1-xls",
+			"downloads.xls.size":          "24mb",
+			"edition":                     edition,
+			"headers":                     []string{"time", "geography"},
+			"id":                          instanceID,
+			"last_updated":                "2017-09-08", // TODO Should be isodate
+			"license":                     "ONS License",
+			"links.job.id":                "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.job.href":              cfg.DatasetAPIURL + "/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.dataset.id":            datasetID,
+			"links.dataset.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"links.dimensions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/1/dimensions",
+			"links.edition.id":            edition,
+			"links.edition.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
+			"links.self.href":             cfg.DatasetAPIURL + "/instances/" + instanceID,
+			"links.spatial.href":          "http://ons.gov.uk/geographylist",
+			"links.version.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/1",
+			"links.version.id":            "2",
+			"release_date":                "2017-12-12", // TODO Should be isodate
+			"state":                       "published",
+			"temporal":                    []mongo.TemporalFrequency{temporal},
+			"total_inserted_observations": 1000,
+			"total_observations":          1000,
+			"version":                     1,
+			"test_data":                   "true",
+		},
+	}
 }
 
-var validEditionConfirmedInstanceData = bson.M{
-	"$set": bson.M{
-		"collection_id":         "208064B3-A808-449B-9041-EA3A2F72CFAB",
-		"downloads.csv.url":     "http://localhost:8080/aws/census-2017-2-csv",
-		"downloads.csv.size":    "10mb",
-		"downloads.xls.url":     "http://localhost:8080/aws/census-2017-2-xls",
-		"downloads.xls.size":    "24mb",
-		"edition":               edition,
-		"headers":               []string{"time", "geography"},
-		"id":                    "779",
-		"last_updated":          "2017-09-08", // TODO Should be isodate
-		"license":               "ONS license",
-		"links.job.id":          "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-		"links.job.href":        "http://localhost:8080/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-		"links.dataset.id":      datasetID,
-		"links.dataset.href":    "http://localhost:8080/datasets/" + datasetID,
-		"links.dimensions.href": "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/2/dimensions",
-		"links.edition.id":      edition,
-		"links.edition.href":    "http://localhost:8080/datasets/" + datasetID + "/editions/2017",
-		"links.self.href":       "http://localhost:8080/instances/" + "799",
-		"links.version.href":    "http://localhost:8080/datasets/" + datasetID + "/editions/2017/versions/2",
-		"links.version.id":      "2",
-		"release_date":          "2017-12-12", // TODO Should be isodate
-		"state":                 "edition-confirmed",
-		"total_inserted_observations": 1000,
-		"total_observations":          1000,
-		"version":                     2,
-		"test_data":                   "true",
-	},
+func validAssociatedInstanceData(datasetID, edition, instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"collection_id":               "208064B3-A808-449B-9041-EA3A2F72CFAB",
+			"dimensions":                  []mongo.CodeList{dimension},
+			"downloads.csv.url":           cfg.DatasetAPIURL + "/aws/census-2017-2-csv",
+			"downloads.csv.size":          "10mb",
+			"downloads.xls.url":           cfg.DatasetAPIURL + "/aws/census-2017-2-xls",
+			"downloads.xls.size":          "24mb",
+			"edition":                     edition,
+			"headers":                     []string{"time", "geography"},
+			"id":                          instanceID,
+			"last_updated":                "2017-09-08", // TODO Should be isodate
+			"license":                     "ONS license",
+			"links.job.id":                "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.job.href":              cfg.DatasetAPIURL + "/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.dataset.id":            datasetID,
+			"links.dataset.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"links.dimensions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/2/dimensions",
+			"links.edition.id":            edition,
+			"links.edition.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
+			"links.self.href":             cfg.DatasetAPIURL + "/instances/" + instanceID,
+			"links.spatial.href":          "http://ons.gov.uk/geographylist",
+			"links.version.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/2",
+			"links.version.id":            "2",
+			"release_date":                "2017-12-12", // TODO Should be isodate
+			"state":                       "associated",
+			"temporal":                    []mongo.TemporalFrequency{temporal},
+			"total_inserted_observations": 1000,
+			"total_observations":          1000,
+			"version":                     2,
+			"test_data":                   "true",
+		},
+	}
+}
+
+func validEditionConfirmedInstanceData(datasetID, edition, instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"dimensions":                  []mongo.CodeList{dimension},
+			"downloads.csv.url":           cfg.DatasetAPIURL + "/aws/census-2017-2-csv",
+			"downloads.csv.size":          "10mb",
+			"downloads.xls.url":           cfg.DatasetAPIURL + "/aws/census-2017-2-xls",
+			"downloads.xls.size":          "24mb",
+			"edition":                     edition,
+			"headers":                     []string{"time", "geography"},
+			"id":                          instanceID,
+			"last_updated":                "2017-09-08", // TODO Should be isodate
+			"license":                     "ONS license",
+			"links.job.id":                "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.job.href":              cfg.DatasetAPIURL + "/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.dataset.id":            datasetID,
+			"links.dataset.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"links.dimensions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/2/dimensions",
+			"links.edition.id":            edition,
+			"links.edition.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
+			"links.self.href":             cfg.DatasetAPIURL + "/instances/" + instanceID,
+			"links.spatial.href":          "http://ons.gov.uk/geographylist",
+			"links.version.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/2",
+			"links.version.id":            "2",
+			"release_date":                "2017-12-12", // TODO Should be isodate
+			"state":                       "edition-confirmed",
+			"temporal":                    []mongo.TemporalFrequency{temporal},
+			"total_inserted_observations": 1000,
+			"total_observations":          1000,
+			"version":                     2,
+			"test_data":                   "true",
+		},
+	}
+}
+
+func validCompletedInstanceData(datasetID, edition, instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"collection_id":         "208064B3-A808-449B-9041-EA3A2F72CFAB",
+			"downloads.csv.url":     cfg.DatasetAPIURL + "/aws/census-2017-2-csv",
+			"downloads.csv.size":    "10mb",
+			"downloads.xls.url":     cfg.DatasetAPIURL + "/aws/census-2017-2-xls",
+			"downloads.xls.size":    "24mb",
+			"edition":               edition,
+			"headers":               []string{"time", "geography"},
+			"id":                    instanceID,
+			"last_updated":          "2017-09-08", // TODO Should be isodate
+			"license":               "ONS license",
+			"links.job.id":          "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.job.href":        cfg.DatasetAPIURL + "/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.dataset.id":      datasetID,
+			"links.dataset.href":    cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"links.dimensions.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2017/versions/2/dimensions",
+			"links.edition.id":      edition,
+			"links.edition.href":    cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2017",
+			"links.self.href":       cfg.DatasetAPIURL + "/instances/" + instanceID,
+			"links.version.href":    cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2017/versions/2",
+			"links.version.id":      "2",
+			"release_date":          "2017-12-12", // TODO Should be isodate
+			"state":                 "completed",
+			"total_inserted_observations": 1000,
+			"total_observations":          1000,
+			"version":                     2,
+			"test_data":                   "true",
+		},
+	}
+}
+
+func validCreatedInstanceData(datasetID, edition, instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"edition":            edition,
+			"headers":            []string{"time", "geography"},
+			"id":                 instanceID,
+			"last_updated":       "2017-09-08", // TODO Should be isodate
+			"links.job.id":       "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.job.href":     cfg.DatasetAPIURL + "/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			"links.dataset.id":   datasetID,
+			"links.dataset.href": cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"links.self.href":    cfg.DatasetAPIURL + "/instances/" + instanceID,
+			"state":              "created",
+			"total_observations": 1000,
+			"test_data":          "true",
+		},
+	}
 }
 
 var validPOSTCreateDatasetJSON string = `
 {
-	"access_right": "http://ons.gov.uk/accessrights",
   "collection_id": "108064B3-A808-449B-9041-EA3A2F72CFAA",
   "contacts": [
     {
@@ -391,6 +438,11 @@ var validPOSTCreateDatasetJSON string = `
     "cpi"
   ],
 	"license": "ONS license",
+	"links": {
+		"access_rights": {
+			"href": "http://ons.gov.uk/accessrights"
+		}
+	},
   "methodologies": [
     {
       "description": "Consumer price inflation is the rate at which the prices of the goods and services bought by households rise or fall, and is estimated by using consumer price indices.",
@@ -476,7 +528,7 @@ var validPUTUpdateDatasetJSON string = `{
 			"title": "Producer Price Index time series dataset"
 			}
 		],
-		"release_frequency": "Quaterly",
+		"release_frequency": "Quarterly",
 		"state": "created",
 		"theme": "Price movement of goods",
 		"title": "RPI",
@@ -484,6 +536,16 @@ var validPUTUpdateDatasetJSON string = `{
 		}`
 
 var validPOSTCreateInstanceJSON string = `
+{
+  "links": {
+    "job": {
+      "id": "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+      "href": "http://localhost:21800/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35"
+    }
+  }
+}`
+
+var validPOSTCreateFullInstanceJSON string = `
 {
   "links": {
     "job": {
@@ -515,7 +577,108 @@ var validPUTCompletedInstanceJSON string = `
   "state": "completed"
 }`
 
-var validPUTUpdateVersionJSON string = `
+var validPUTFullInstanceJSON string = `
 {
-		"state": "published"
+	"dimensions": [
+		{
+			"description": "The age ranging from 16 to 75+",
+			"href": "http://localhost:22400//code-lists/43513D18-B4D8-4227-9820-492B2971E7T5",
+			"id": "43513D18-B4D8-4227-9820-492B2971E7T5",
+			"name": "age"
+		}
+	],
+	"links": {
+		"spatial": {
+			"href": "http://ons.gov.uk/geography-list"
+		}
+	},
+	"release_date": "2017-11-11",
+  "state": "completed",
+	"temporal": [
+		{
+			"start_date": "2014-10-10",
+			"end_date": "2016-10-10",
+			"frequency": "monthly"
+		}
+	],
+	"total_inserted_observations": 1000
+}`
+
+var validPUTEditionConfirmedInstanceJSON string = `
+{
+	"dimensions": [
+		{
+			"description": "The age ranging from 16 to 75+",
+			"href": "http://localhost:22400//code-lists/43513D18-B4D8-4227-9820-492B2971E7T5",
+			"id": "43513D18-B4D8-4227-9820-492B2971E7T5",
+			"name": "age"
+		}
+	],
+	"links": {
+		"spatial": {
+			"href": "http://ons.gov.uk/geography-list"
+		}
+	},
+	"release_date": "2017-11-11",
+  "state": "edition-confirmed",
+	"temporal": [
+		{
+			"start_date": "2014-10-10",
+			"end_date": "2016-10-10",
+			"frequency": "monthly"
+		}
+	],
+	"total_inserted_observations": 1000
+}`
+
+var validPUTUpdateVersionMetaDataJSON string = `
+{
+"links": {
+  "spatial": {
+	  "href": "http://ons.gov.uk/new-geography-list"
+	},
+  "self": {
+	  "href": "http://bogus/bad-link"
+	}
+},
+"release_date": "2018-11-11",
+"temporal": [
+	{
+		"start_date": "2014-11-11",
+		"end_date": "2017-11-11",
+		"frequency": "monthly"
+	}
+]
+}`
+
+var validPUTUpdateVersionToAssociatedJSON string = `
+{
+	"state": "associated",
+	"collection_id": "45454545"
+}`
+
+var validPUTUpdateVersionFromAssociatedToEditionConfirmedJSON string = `
+{
+	"collection_id": ""
+}`
+
+var validPUTUpdateVersionToPublishedWithCollectionIDJSON string = `
+{
+	"collection_id": "33333333",
+	"state": "published"
+}`
+
+var validPUTUpdateVersionToPublishedJSON string = `
+{
+	"state": "published"
+}`
+
+var invalidPOSTCreateInstanceJSON string = `
+{
+  "links": {
+    "dataset": {
+    	"id": "34B13D18-B4D8-4227-9820-492B2971E221",
+      "href": "http://localhost:21800/datasets/34B13D18-B4D8-4227-9820-492B2971E221"
+    }
+  }
 }`

--- a/datasetAPI/post_dataset_test.go
+++ b/datasetAPI/post_dataset_test.go
@@ -107,10 +107,10 @@ func TestFailureToPostDataset(t *testing.T) {
 		}
 
 		Convey("When an authorised POST request to create the same dataset resource is made", func() {
-			Convey("Then return a status of forbidden with a message `Forbidden - dataset already exists`", func() {
+			Convey("Then return a status of forbidden with a message `forbidden - dataset already exists`", func() {
 
 				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPOSTCreateDatasetJSON)).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusForbidden).Body().Contains("Forbidden - dataset already exists\n")
+					Expect().Status(http.StatusForbidden).Body().Contains("forbidden - dataset already exists\n")
 			})
 		})
 

--- a/datasetAPI/post_dataset_test.go
+++ b/datasetAPI/post_dataset_test.go
@@ -5,93 +5,118 @@ import (
 	"os"
 	"testing"
 
-	mgo "gopkg.in/mgo.v2"
-
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSuccessfullyPostDataset(t *testing.T) {
-	if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
+	datasetID := uuid.NewV4().String()
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Create a dataset", t, func() {
+	Convey("Given a dataset with the an id of ["+datasetID+"] does not exist", t, func() {
 
-		response := datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
-			Expect().Status(http.StatusCreated).JSON().Object()
+		Convey("When an authorised POST request is made to create a dataset resource", func() {
+			Convey("Then return a status ok and the expected response body", func() {
+				response := datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
+					Expect().Status(http.StatusCreated).JSON().Object()
 
-		response.Value("id").Equal(datasetID)
-		response.Value("next").Object().Value("access_right").Equal("http://ons.gov.uk/accessrights")
-		response.Value("next").Object().Value("collection_id").Equal("108064B3-A808-449B-9041-EA3A2F72CFAA")
-		response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("email").Equal("cpi@onstest.gov.uk")
-		response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("name").Equal("Automation Tester")
-		response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("telephone").Equal("+44 (0)1633 123456")
-		response.Value("next").Object().Value("description").Equal("Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.")
-		response.Value("next").Object().Value("keywords").Array().Element(0).Equal("cpi")
-		response.Value("next").Object().Value("id").Equal(datasetID)
-		response.Value("next").Object().Value("license").Equal("ONS license")
-		response.Value("next").Object().Value("links").Object().Value("editions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions$")
-		response.Value("next").Object().Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
-		response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("description").Equal("Consumer price inflation is the rate at which the prices of the goods and services bought by households rise or fall, and is estimated by using consumer price indices.")
-		response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi")
-		response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("title").Equal("Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)")
-		response.Value("next").Object().Value("national_statistic").Boolean().True()
-		response.Value("next").Object().Value("next_release").Equal("17 October 2017")
-		response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("description").Equal("Price indices, percentage changes and weights for the different measures of consumer price inflation.")
-		response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017")
-		response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("title").Equal("UK consumer price inflation: August 2017")
-		response.Value("next").Object().Value("publisher").Object().Value("name").Equal("Automation Tester")
-		response.Value("next").Object().Value("publisher").Object().Value("type").Equal("publisher")
-		response.Value("next").Object().Value("publisher").Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017")
-		response.Value("next").Object().Value("qmi").Object().Value("description").Equal("Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall")
-		response.Value("next").Object().Value("qmi").Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi")
-		response.Value("next").Object().Value("qmi").Object().Value("title").Equal("Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)")
-		response.Value("next").Object().Value("related_datasets").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceindices")
-		response.Value("next").Object().Value("related_datasets").Array().Element(0).Object().Value("title").Equal("Consumer Price Inflation time series dataset")
-		response.Value("next").Object().Value("release_frequency").Equal("Monthly")
-		response.Value("next").Object().Value("state").Equal("created")
-		response.Value("next").Object().Value("theme").Equal("Goods and services")
-		response.Value("next").Object().Value("title").Equal("CPI")
-		response.Value("next").Object().Value("uri").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation")
+				response.Value("id").Equal(datasetID)
+				response.Value("next").Object().Value("collection_id").Equal("108064B3-A808-449B-9041-EA3A2F72CFAA")
+				response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("email").Equal("cpi@onstest.gov.uk")
+				response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("name").Equal("Automation Tester")
+				response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("telephone").Equal("+44 (0)1633 123456")
+				response.Value("next").Object().Value("description").Equal("Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.")
+				response.Value("next").Object().Value("keywords").Array().Element(0).Equal("cpi")
+				response.Value("next").Object().Value("id").Equal(datasetID)
+				response.Value("next").Object().Value("license").Equal("ONS license")
+				response.Value("next").Object().Value("links").Object().Value("access_rights").Object().Value("href").Equal("http://ons.gov.uk/accessrights")
+				response.Value("next").Object().Value("links").Object().Value("editions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions$")
+				response.Value("next").Object().Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
+				response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("description").Equal("Consumer price inflation is the rate at which the prices of the goods and services bought by households rise or fall, and is estimated by using consumer price indices.")
+				response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi")
+				response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("title").Equal("Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)")
+				response.Value("next").Object().Value("national_statistic").Boolean().True()
+				response.Value("next").Object().Value("next_release").Equal("17 October 2017")
+				response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("description").Equal("Price indices, percentage changes and weights for the different measures of consumer price inflation.")
+				response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017")
+				response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("title").Equal("UK consumer price inflation: August 2017")
+				response.Value("next").Object().Value("publisher").Object().Value("name").Equal("Automation Tester")
+				response.Value("next").Object().Value("publisher").Object().Value("type").Equal("publisher")
+				response.Value("next").Object().Value("publisher").Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017")
+				response.Value("next").Object().Value("qmi").Object().Value("description").Equal("Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall")
+				response.Value("next").Object().Value("qmi").Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi")
+				response.Value("next").Object().Value("qmi").Object().Value("title").Equal("Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)")
+				response.Value("next").Object().Value("related_datasets").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceindices")
+				response.Value("next").Object().Value("related_datasets").Array().Element(0).Object().Value("title").Equal("Consumer Price Inflation time series dataset")
+				response.Value("next").Object().Value("release_frequency").Equal("Monthly")
+				response.Value("next").Object().Value("state").Equal("created")
+				response.Value("next").Object().Value("theme").Equal("Goods and services")
+				response.Value("next").Object().Value("title").Equal("CPI")
+				response.Value("next").Object().Value("uri").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation")
 
-		if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
-			if err != mgo.ErrNotFound {
-				os.Exit(1)
-			}
-		}
+				if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
+					log.ErrorC("Was unable to run test", err, nil)
+					os.Exit(1)
+				}
+			})
+		})
 	})
 }
 
 func TestFailureToPostDataset(t *testing.T) {
 
+	datasetID := uuid.NewV4().String()
+
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Fail to create a dataset due to an invalid token value", t, func() {
+	Convey("Given the dataset does not already exist", t, func() {
+		Convey("When an authorised POST request is made to create dataset resource with an invalid body", func() {
 
-		datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
-			Expect().Status(http.StatusUnauthorized)
+			Convey("Then return a status of bad request with a message `Failed to parse json body`", func() {
+
+				datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte("{")).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body\n")
+			})
+		})
+
+		Convey("When an unauthorised POST request is made to create a dataset resource with an invalid authentication header", func() {
+			Convey("Then return a status of unauthorized with a message `Unauthorised access to API`", func() {
+
+				datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+			})
+		})
+
+		Convey("When no authentication header is provided in POST request to create a dataset resource", func() {
+			Convey("Then return a status of unauthorized with a message `No authentication header provided`", func() {
+
+				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+			})
+		})
 	})
 
-	Convey("Fail to create a dataset without a token", t, func() {
+	Convey("Given a dataset does exist", t, func() {
+		if err := mongo.Setup(database, collection, "_id", datasetID, validPublishedDatasetData(datasetID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
 
-		datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
-			Expect().Status(http.StatusUnauthorized)
-	})
+		Convey("When an authorised POST request to create the same dataset resource is made", func() {
+			Convey("Then return a status of forbidden with a message `Forbidden - dataset already exists`", func() {
 
-	Convey("Fail to create a dataset due to an invalid json body", t, func() {
+				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPOSTCreateDatasetJSON)).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusForbidden).Body().Contains("Forbidden - dataset already exists\n")
+			})
+		})
 
-		datasetAPI.POST("/datasets/{id}", datasetID).WithHeader("internal-token", "FD0108EA-825D-411C-9B1D-41EF7727F465").WithBytes([]byte("{")).
-			Expect().Status(http.StatusBadRequest)
+		if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
 	})
 }
-
-// TODO
-// 403 - Forbidden to overwrite dataset, already published

--- a/datasetAPI/post_instance_test.go
+++ b/datasetAPI/post_instance_test.go
@@ -15,47 +15,99 @@ import (
 func TestSuccessfullyPostInstance(t *testing.T) {
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Successfully create an Instance", t, func() {
+	Convey("Given an authorised user wants to create an instance", t, func() {
+		Convey("When a valid authorised PUT request is made with a job properties", func() {
+			Convey("Then the expected response body is returned and a status of created (201)", func() {
 
-		response := datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPOSTCreateInstanceJSON)).
-			Expect().Status(http.StatusCreated).JSON().Object()
+				response := datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPOSTCreateInstanceJSON)).
+					Expect().Status(http.StatusCreated).JSON().Object()
 
-		instanceUniqueID := response.Value("id").String().Raw()
+				instanceUniqueID := response.Value("id").String().Raw()
 
-		response.Value("id").NotNull()
-		response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("The age ranging from 16 to 75+")
-		response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/code-lists/43513D18-B4D8-4227-9820-492B2971E7T5$")
-		response.Value("dimensions").Array().Element(0).Object().Value("id").Equal("43513D18-B4D8-4227-9820-492B2971E7T5")
-		response.Value("dimensions").Array().Element(0).Object().Value("name").Equal("age")
-		response.Value("links").Object().Value("job").Object().Value("id").Equal("042e216a-7822-4fa0-a3d6-e3f5248ffc35")
-		response.Value("links").Object().Value("job").Object().Value("href").String().Match("(.+)/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35$")
-		response.Value("links").Object().Value("dataset").Object().Value("id").Equal("34B13D18-B4D8-4227-9820-492B2971E221")
-		response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/34B13D18-B4D8-4227-9820-492B2971E221$")
-		// TODO Reinstate once API has been fixed
-		// response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/instances" + instanceUniqueID + "$")
-		response.Value("state").Equal("created")
-		response.Value("last_updated").NotNull()
+				response.Value("id").NotNull()
+				response.Value("links").Object().Value("job").Object().Value("id").Equal("042e216a-7822-4fa0-a3d6-e3f5248ffc35")
+				response.Value("links").Object().Value("job").Object().Value("href").String().Match("(.+)/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35$")
+				response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/instances/" + instanceUniqueID + "$")
+				response.Value("state").Equal("created")
+				response.Value("last_updated").NotNull()
 
-		if err := mongo.Teardown(database, "instances", "id", instanceUniqueID); err != nil {
-			if err != mgo.ErrNotFound {
-				os.Exit(1)
-			}
-		}
+				if err := mongo.Teardown(database, "instances", "id", instanceUniqueID); err != nil {
+					if err != mgo.ErrNotFound {
+						os.Exit(1)
+					}
+				}
+			})
+		})
+
+		Convey("When a valid authorised PUT request is made with dimensions and dataset as well as a job properties", func() {
+			Convey("Then the expected response body is returned and a status of created (201)", func() {
+
+				response := datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPOSTCreateFullInstanceJSON)).
+					Expect().Status(http.StatusCreated).JSON().Object()
+
+				instanceUniqueID := response.Value("id").String().Raw()
+
+				response.Value("id").NotNull()
+				response.Value("dimensions").Array().Element(0).Object().Value("description").Equal("The age ranging from 16 to 75+")
+				response.Value("dimensions").Array().Element(0).Object().Value("href").String().Match("(.+)/code-lists/43513D18-B4D8-4227-9820-492B2971E7T5$")
+				response.Value("dimensions").Array().Element(0).Object().Value("id").Equal("43513D18-B4D8-4227-9820-492B2971E7T5")
+				response.Value("dimensions").Array().Element(0).Object().Value("name").Equal("age")
+				response.Value("links").Object().Value("job").Object().Value("id").Equal("042e216a-7822-4fa0-a3d6-e3f5248ffc35")
+				response.Value("links").Object().Value("job").Object().Value("href").String().Match("(.+)/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35$")
+				response.Value("links").Object().Value("dataset").Object().Value("id").Equal("34B13D18-B4D8-4227-9820-492B2971E221")
+				response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/34B13D18-B4D8-4227-9820-492B2971E221$")
+				response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/instances/" + instanceUniqueID + "$")
+				response.Value("state").Equal("created")
+				response.Value("last_updated").NotNull()
+
+				if err := mongo.Teardown(database, "instances", "id", instanceUniqueID); err != nil {
+					if err != mgo.ErrNotFound {
+						os.Exit(1)
+					}
+				}
+			})
+		})
 	})
 }
 
 func TestFailureToPostInstance(t *testing.T) {
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Fail to create an Instance due to an invalid token", t, func() {
+	Convey("Given an authorised user wants to create an instance", t, func() {
+		Convey("When an authorised POST request is made to create an instance resource with invalid json", func() {
+			Convey("Then fail to create resource and return a status bad request (400) with a message `Failed to parse json body: unexpected end of JSON input`", func() {
 
-		datasetAPI.POST("/instances").WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPOSTCreateInstanceJSON)).
-			Expect().Status(http.StatusUnauthorized)
+				datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body: unexpected end of JSON input\n")
+			})
+		})
 	})
 
-	Convey("Fail to create an Instance due to no token", t, func() {
+	Convey("Given an authorised user wants to create an instance", t, func() {
+		Convey("When an authorised POST request is made to create an instance resource with missing job properties", func() {
+			Convey("Then fail to create resource and return a status bad request (400) with a message `Missing job properties`", func() {
 
-		datasetAPI.POST("/instances").WithBytes([]byte(validPOSTCreateInstanceJSON)).
-			Expect().Status(http.StatusUnauthorized)
+				datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(invalidPOSTCreateInstanceJSON)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Missing job properties\n")
+			})
+		})
+	})
+
+	Convey("Given an unauthorised user wants to create an instance", t, func() {
+		Convey("When an unauthorised POST request is made to create an instance resource with an invalid authentication header", func() {
+			Convey("Then fail to create resource and return a status unauthorized (401) with a message `Unauthorised access to API`", func() {
+
+				datasetAPI.POST("/instances").WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPOSTCreateInstanceJSON)).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+			})
+		})
+
+		Convey("When no authentication header is provided in PUT request to create an instance resource", func() {
+			Convey("Then fail to create resource and return a status of unauthorized (401) with a message `No authentication header provided`", func() {
+
+				datasetAPI.POST("/instances").WithBytes([]byte(validPOSTCreateInstanceJSON)).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+			})
+		})
 	})
 }

--- a/datasetAPI/put_dataset_test.go
+++ b/datasetAPI/put_dataset_test.go
@@ -10,67 +10,55 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSuccessfulyUpdateDataset(t *testing.T) {
-	if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
 
-	if err := mongo.Setup(database, "datasets", "_id", datasetID, validPublishedDatasetData); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
+	datasetID := uuid.NewV4().String()
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Update the dataset", t, func() {
-		datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
-			Expect().Status(http.StatusOK)
-	})
+	Convey("Given a published dataset already exists", t, func() {
 
-	Convey("Get the updated dataset details", t, func() {
+		if err := mongo.Setup(database, "datasets", "_id", datasetID, validPublishedDatasetData(datasetID)); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
 
-		response := datasetAPI.GET("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).
-			Expect().Status(http.StatusOK).JSON().Object()
+		originalDataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve original dataset document", err, nil)
+			os.Exit(1)
+		}
 
-		response.Value("id").Equal(datasetID)
-		response.Value("next").Object().Value("access_right").Equal("http://ons.gov.uk/accessrights")
-		response.Value("next").Object().Value("collection_id").Equal("308064B3-A808-449B-9041-EA3A2F72CFAC")
-		response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("email").Equal("rpi@onstest.gov.uk")
-		response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("name").Equal("Test Automation")
-		response.Value("next").Object().Value("contacts").Array().Element(0).Object().Value("telephone").Equal("+44 (0)1833 456123")
-		response.Value("next").Object().Value("description").Equal("Producer Price Indices (PPIs) are a series of economic indicators that measure the price movement of goods bought and sold by UK manufacturers")
-		response.Value("next").Object().Value("keywords").Array().Element(0).Equal("rpi")
-		response.Value("next").Object().Value("license").Equal("ONS license")
-		response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("description").Equal("The Producer Price Index (PPI) is a monthly survey that measures the price changes of goods bought and sold by UK manufacturers")
-		response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/producerpriceindicesqmi")
-		response.Value("next").Object().Value("methodologies").Array().Element(0).Object().Value("title").Equal("Producer price indices QMI")
+		// Check dataset current subdocument
+		expectedCurrentSubDoc := expectedCurrentSubDoc(datasetID, "2017")
+		So(originalDataset.Current, ShouldResemble, expectedCurrentSubDoc)
 
-		// TODO Reinstate once API has been fixed
-		// response.Value("next").Object().Value("national_statistic").Boolean().False()
+		Convey("When a Put request is made to update the dataset", func() {
+			Convey("Then the dataset resource is updated and response contains a status ok (200)", func() {
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
+					Expect().Status(http.StatusOK)
 
-		response.Value("next").Object().Value("next_release").Equal("18 September 2017")
-		response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("description").Equal("Changes in the prices of goods bought and sold by UK manufacturers including price indices of materials and fuels purchased (input prices) and factory gate prices (output prices)")
-		response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/producerpriceinflation/september2017")
-		response.Value("next").Object().Value("publications").Array().Element(0).Object().Value("title").Equal("Producer price inflation, UK: September 2017")
-		response.Value("next").Object().Value("publisher").Object().Value("name").Equal("Test Automation Engineer")
-		response.Value("next").Object().Value("publisher").Object().Value("type").Equal("publisher")
-		response.Value("next").Object().Value("publisher").Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/producerpriceinflation/september2017")
-		response.Value("next").Object().Value("qmi").Object().Value("description").Equal("PPI provides an important measure of inflation")
-		response.Value("next").Object().Value("qmi").Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/producerpriceindicesqmi")
-		response.Value("next").Object().Value("qmi").Object().Value("title").Equal("The Producer Price Index (PPI) is a monthly survey that measures the price changes")
-		response.Value("next").Object().Value("related_datasets").Array().Element(0).Object().Value("href").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/producerpriceindex")
-		response.Value("next").Object().Value("related_datasets").Array().Element(0).Object().Value("title").Equal("Producer Price Index time series dataset")
-		response.Value("next").Object().Value("release_frequency").Equal("Quaterly")
-		response.Value("next").Object().Value("state").Equal("created")
-		response.Value("next").Object().Value("theme").Equal("Price movement of goods")
-		response.Value("next").Object().Value("title").Equal("RPI")
-		response.Value("next").Object().Value("uri").Equal("https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/producerpriceindex")
+				expectedNextSubDoc := expectedNextSubDoc(datasetID, "2018")
+
+				dataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated dataset document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check dataset current subdocument has not changed
+				So(dataset.Current, ShouldResemble, expectedCurrentSubDoc)
+
+				// Check dataset next subdocument does not match the original dataset next subdocument
+				So(originalDataset.Next, ShouldNotResemble, expectedNextSubDoc)
+
+				So(dataset.Next, ShouldResemble, expectedNextSubDoc)
+			})
+		})
 
 		if err := mongo.Teardown(database, "datasets", "_id", datasetID); err != nil {
 			if err != mgo.ErrNotFound {
@@ -82,41 +70,202 @@ func TestSuccessfulyUpdateDataset(t *testing.T) {
 
 func TestFailureToUpdateDataset(t *testing.T) {
 
-	if err := mongo.Teardown(database, collection, "_id", datasetID); err != nil {
-		if err != mgo.ErrNotFound {
+	datasetID := uuid.NewV4().String()
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given published dataset does not exist", t, func() {
+		Convey("When an authorised PUT request is made to update dataset resource", func() {
+			Convey("Then fail to update resource and return a status of not found (404) with a message `Dataset not found`", func() {
+
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+			})
+		})
+	})
+
+	Convey("Given a published dataset exists", t, func() {
+
+		if err := mongo.Setup(database, "datasets", "_id", datasetID, validPublishedDatasetData(datasetID)); err != nil {
 			log.ErrorC("Was unable to run test", err, nil)
 			os.Exit(1)
 		}
-	}
 
-	if err := mongo.Setup(database, "datasets", "_id", datasetID, validPublishedDatasetData); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
+		Convey("When an unauthorised PUT request is made to update a dataset resource with an invalid authentication header", func() {
+			Convey("Then fail to update resource and return a status unauthorized (401) with a message `Unauthorised access to API`", func() {
 
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+			})
+		})
 
-	Convey("Fail to update a dataset with an invalid token value", t, func() {
+		Convey("When no authentication header is provided in PUT request to update dataset resource", func() {
+			Convey("Then fail to update resource and return a status of unauthorized (401) with a message `No authentication header provided`", func() {
 
-		datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
-			Expect().Status(http.StatusUnauthorized)
-	})
+				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+			})
+		})
 
-	Convey("Fail to update a dataset without a token", t, func() {
+		Convey("When an authorised PUT request is made to update dataset resource with an invalid body", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message `Failed to parse json body`", func() {
 
-		datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
-			Expect().Status(http.StatusUnauthorized)
-	})
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte("{")).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body\n")
+			})
+		})
 
-	Convey("Fail to update a dataset with an invalid json body", t, func() {
-
-		datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte("{")).
-			Expect().Status(http.StatusBadRequest)
-	})
-
-	if err := mongo.Teardown(database, "datasets", "_id", datasetID); err != nil {
-		if err != mgo.ErrNotFound {
-			os.Exit(1)
+		if err := mongo.Teardown(database, "datasets", "_id", datasetID); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
 		}
+	})
+}
+
+// ------------------------------------------------------------------------
+
+func expectedCurrentSubDoc(datasetID, edition string) *mongo.Dataset {
+	contactDetails := mongo.ContactDetails{
+		Email:     "cpi@onstest.gov.uk",
+		Name:      "Automation Tester",
+		Telephone: "+44 (0)1633 123456",
 	}
+
+	methodology := mongo.GeneralDetails{
+		Description: "Consumer price inflation is the rate at which the prices of the goods and services bought by households rise or fall, and is estimated by using consumer price indices.",
+		HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
+		Title:       "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
+	}
+
+	nationalStatistic := true
+
+	publication := mongo.GeneralDetails{
+		Description: "Price indices, percentage changes and weights for the different measures of consumer price inflation.",
+		HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
+		Title:       "UK consumer price inflation: August 2017",
+	}
+
+	relatedDataset := mongo.GeneralDetails{
+		HRef:  "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceindices",
+		Title: "Consumer Price Inflation time series dataset",
+	}
+
+	currentSubDoc := &mongo.Dataset{
+		CollectionID: "108064B3-A808-449B-9041-EA3A2F72CFAA",
+		Contacts:     []mongo.ContactDetails{contactDetails},
+		Description:  "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
+		Keywords:     []string{"cpi", "boy"},
+		ID:           "",
+		License:      "ONS license",
+		Links: &mongo.DatasetLinks{
+			AccessRights: &mongo.LinkObject{
+				HRef: "http://ons.gov.uk/accessrights",
+			},
+			Editions: &mongo.LinkObject{
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions",
+			},
+			LatestVersion: &mongo.LinkObject{
+				ID:   "1",
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/1",
+			},
+			Self: &mongo.LinkObject{
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			},
+		},
+		Methodologies:     []mongo.GeneralDetails{methodology},
+		NationalStatistic: &nationalStatistic,
+		NextRelease:       "2017-10-10",
+		Publications:      []mongo.GeneralDetails{publication},
+		Publisher: &mongo.Publisher{
+			Name: "Automation Tester",
+			Type: "publisher",
+			HRef: "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
+		},
+		QMI: &mongo.GeneralDetails{
+			Description: "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
+			HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
+			Title:       "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
+		},
+		RelatedDatasets:  []mongo.GeneralDetails{relatedDataset},
+		ReleaseFrequency: "Monthly",
+		State:            "published",
+		Theme:            "Goods and services",
+		Title:            "CPI",
+		URI:              "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
+	}
+
+	return currentSubDoc
+}
+
+func expectedNextSubDoc(datasetID, edition string) *mongo.Dataset {
+	contactDetails := mongo.ContactDetails{
+		Email:     "rpi@onstest.gov.uk",
+		Name:      "Test Automation",
+		Telephone: "+44 (0)1833 456123",
+	}
+
+	methodology := mongo.GeneralDetails{
+		Description: "The Producer Price Index (PPI) is a monthly survey that measures the price changes of goods bought and sold by UK manufacturers",
+		HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/producerpriceindicesqmi",
+		Title:       "Producer price indices QMI",
+	}
+
+	nationalStatistic := false
+
+	publication := mongo.GeneralDetails{
+		Description: "Changes in the prices of goods bought and sold by UK manufacturers including price indices of materials and fuels purchased (input prices) and factory gate prices (output prices)",
+		HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/producerpriceinflation/september2017",
+		Title:       "Producer price inflation, UK: September 2017",
+	}
+
+	relatedDataset := mongo.GeneralDetails{
+		HRef:  "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/producerpriceindex",
+		Title: "Producer Price Index time series dataset",
+	}
+
+	currentSubDoc := &mongo.Dataset{
+		CollectionID: "308064B3-A808-449B-9041-EA3A2F72CFAC",
+		Contacts:     []mongo.ContactDetails{contactDetails},
+		Description:  "Producer Price Indices (PPIs) are a series of economic indicators that measure the price movement of goods bought and sold by UK manufacturers",
+		Keywords:     []string{"rpi"},
+		ID:           "",
+		License:      "ONS license",
+		Links: &mongo.DatasetLinks{
+			AccessRights: &mongo.LinkObject{
+				HRef: "http://ons.gov.uk/accessrights",
+			},
+			Editions: &mongo.LinkObject{
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions",
+			},
+			LatestVersion: &mongo.LinkObject{
+				ID:   "1",
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/1",
+			},
+			Self: &mongo.LinkObject{
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			},
+		},
+		Methodologies:     []mongo.GeneralDetails{methodology},
+		NationalStatistic: &nationalStatistic,
+		NextRelease:       "18 September 2017",
+		Publications:      []mongo.GeneralDetails{publication},
+		Publisher: &mongo.Publisher{
+			Name: "Test Automation Engineer",
+			Type: "publisher",
+			HRef: "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/producerpriceinflation/september2017",
+		},
+		QMI: &mongo.GeneralDetails{
+			Description: "PPI provides an important measure of inflation",
+			HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/producerpriceindicesqmi",
+			Title:       "The Producer Price Index (PPI) is a monthly survey that measures the price changes",
+		},
+		RelatedDatasets:  []mongo.GeneralDetails{relatedDataset},
+		ReleaseFrequency: "Quarterly",
+		State:            "created",
+		Theme:            "Price movement of goods",
+		Title:            "RPI",
+		URI:              "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/producerpriceindex",
+	}
+
+	return currentSubDoc
 }

--- a/datasetAPI/put_dataset_test.go
+++ b/datasetAPI/put_dataset_test.go
@@ -116,8 +116,6 @@ func TestFailureToUpdateDataset(t *testing.T) {
 	})
 }
 
-// ------------------------------------------------------------------------
-
 func expectedCurrentSubDoc(datasetID, edition string) *mongo.Dataset {
 	contactDetails := mongo.ContactDetails{
 		Email:     "cpi@onstest.gov.uk",

--- a/datasetAPI/put_instance_test.go
+++ b/datasetAPI/put_instance_test.go
@@ -10,11 +10,209 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSuccessfullyPutInstance(t *testing.T) {
 
+	datasetID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+	edition := "2017"
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given an instance has been created by an import job", t, func() {
+		d, err := setupInstance(datasetID, edition, instanceID)
+		if err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When a PUT request is made to update instance meta data", func() {
+			Convey("Then the instance is updated and return a status ok (200)", func() {
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTFullInstanceJSON)).
+					Expect().Status(http.StatusOK)
+
+				instance, err := mongo.GetInstance(database, "instances", "_id", instanceID)
+				if err != nil {
+					if err != mgo.ErrNotFound {
+						log.ErrorC("Was unable to remove test data", err, nil)
+						os.Exit(1)
+					}
+				}
+
+				log.Debug("next instance", log.Data{"instance": instance})
+
+				So(instance.InstanceID, ShouldEqual, instanceID)
+				checkInstanceDoc(datasetID, instanceID, "completed", instance)
+			})
+		})
+
+		Convey("and is updated to a state of `completed`", func() {
+
+			datasetAPI.PUT("/instances/{instance_id}", instanceID).
+				WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTCompletedInstanceJSON)).
+				Expect().Status(http.StatusOK)
+
+			instance, err := mongo.GetInstance(database, "instances", "_id", instanceID)
+			if err != nil {
+				if err != mgo.ErrNotFound {
+					log.ErrorC("Was unable to remove test data", err, nil)
+					os.Exit(1)
+				}
+			}
+
+			So(instance.InstanceID, ShouldEqual, instanceID)
+			So(instance.State, ShouldEqual, "completed")
+
+			Convey("When a PUT request is made to update instance meta data and set state to `edition-confirmed`", func() {
+				Convey("Then the instance is updated and return a status ok (200)", func() {
+					datasetAPI.PUT("/instances/{instance_id}", instanceID).
+						WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTEditionConfirmedInstanceJSON)).
+						Expect().Status(http.StatusOK)
+
+					instance, err := mongo.GetInstance(database, "instances", "_id", instanceID)
+					if err != nil {
+						if err != mgo.ErrNotFound {
+							log.ErrorC("Was unable to remove test data", err, nil)
+							os.Exit(1)
+						}
+					}
+
+					So(instance.InstanceID, ShouldEqual, instanceID)
+					checkInstanceDoc(datasetID, instanceID, "edition-confirmed", instance)
+					So(instance.Version, ShouldEqual, 1)
+
+					// Check edition document has been created
+					edition, err := mongo.GetEdition(database, "editions", "links.self.href", instance.Links.Edition.HRef)
+					if err != nil {
+						if err != mgo.ErrNotFound {
+							log.ErrorC("Was unable to remove test data", err, nil)
+							os.Exit(1)
+						}
+					}
+
+					checkEditionDoc(datasetID, instanceID, edition)
+
+					if err := mongo.Teardown(database, "editions", "links.self.href", instance.Links.Edition.HRef); err != nil {
+						if err != mgo.ErrNotFound {
+							log.ErrorC("Was unable to remove test data", err, nil)
+							os.Exit(1)
+						}
+					}
+				})
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
+	})
+}
+
+func TestFailureToPutInstance(t *testing.T) {
+
+	datasetID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+	edition := "2017"
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given an instance does not exist", t, func() {
+
+		Convey("When an authorised PUT request is made to update instance with meta data", func() {
+			Convey("Then the response return a status not found (404) with message `Instance not found`", func() {
+
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTFullInstanceJSON)).
+					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
+			})
+		})
+	})
+
+	Convey("Given a created instance exists", t, func() {
+		d, err := setupInstance(datasetID, edition, instanceID)
+		if err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an authorised PUT request is made to update instance with invalid json", func() {
+			Convey("Then the response return a status not found (400) with message `Failed to parse json body: unexpected end of JSON input`", func() {
+
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte("{")).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body: unexpected end of JSON input\n")
+			})
+		})
+
+		Convey("When an unauthorised PUT request is made to update an instance resource with an invalid authentication header", func() {
+			Convey("Then fail to update resource and return a status unauthorized (401) with a message `Unauthorised access to API`", func() {
+
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).WithBytes([]byte(validPUTFullInstanceJSON)).
+					WithHeader(internalToken, invalidInternalTokenID).Expect().Status(http.StatusUnauthorized).
+					Body().Contains("Unauthorised access to API\n")
+			})
+		})
+
+		Convey("When no authentication header is provided in PUT request to update an instance resource", func() {
+			Convey("Then fail to update resource and return a status of unauthorized (401) with a message `No authentication header provided`", func() {
+
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).WithBytes([]byte(validPUTFullInstanceJSON)).
+					Expect().Status(http.StatusUnauthorized).
+					Body().Contains("No authentication header provided\n")
+			})
+		})
+
+		Convey("When a PUT request is made to update instance state to `edition-confirmed`", func() {
+			Convey("Then fail to update resource and return a status of forbidden (403) with a message `Unable to update resource, expected resource to have a state of completed`", func() {
+
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "edition-confirmed"}`)).
+					Expect().Status(http.StatusForbidden).Body().Contains("Unable to update resource, expected resource to have a state of completed\n")
+			})
+		})
+
+		Convey("When a PUT request is made to update instance state to `associated`", func() {
+			Convey("Then fail to update resource and return a status of forbidden (403) with a message `Unable to update resource, expected resource to have a state of edition-confirmed`", func() {
+
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "associated"}`)).
+					Expect().Status(http.StatusForbidden).Body().Contains("Unable to update resource, expected resource to have a state of edition-confirmed\n")
+			})
+		})
+
+		Convey("When a PUT request is made to update instance state to `published`", func() {
+			Convey("Then fail to update resource and return a status of forbidden (403) with a message `Unable to update resource, expected resource to have a state of edition-confirmed`", func() {
+
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "published"}`)).
+					Expect().Status(http.StatusForbidden).Body().Contains("Unable to update resource, expected resource to have a state of associated\n")
+			})
+		})
+
+		Convey("When a PUT request is made to update instance state to `fake-state`", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message `Bad request - invalid filter state values: [fake-state]`", func() {
+
+				datasetAPI.PUT("/instances/{instance_id}", instanceID).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "fake-state"}`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - invalid filter state values: [fake-state]\n")
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
+	})
+}
+
+func setupInstance(datasetID, edition, instanceID string) (*mongo.ManyDocs, error) {
 	var docs []mongo.Doc
 
 	datasetDoc := mongo.Doc{
@@ -22,15 +220,15 @@ func TestSuccessfullyPutInstance(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedDatasetData,
+		Update:     validPublishedDatasetData(datasetID),
 	}
 
 	instanceOneDoc := mongo.Doc{
 		Database:   "datasets",
 		Collection: "instances",
 		Key:        "_id",
-		Value:      "799",
-		Update:     validUnpublishedInstanceData,
+		Value:      instanceID,
+		Update:     validCreatedInstanceData(datasetID, edition, instanceID),
 	}
 
 	docs = append(docs, datasetDoc, instanceOneDoc)
@@ -39,32 +237,83 @@ func TestSuccessfullyPutInstance(t *testing.T) {
 		Docs: docs,
 	}
 
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
-
 	if err := mongo.SetupMany(d); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
+		return nil, err
 	}
 
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-
-	// TODO should consider all types of data in Put Request (currently only checking if state is set to completed)
-	Convey("Update an instance properties", t, func() {
-
-		datasetAPI.PUT("/instances/{instance_id}", "799").WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTCompletedInstanceJSON)).
-			Expect().Status(http.StatusOK)
-	})
-
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			os.Exit(1)
-		}
-	}
+	return d, nil
 }
 
-// TODO Test failure scenarios
+func checkInstanceDoc(datasetID, instanceID, state string, instance mongo.Instance) {
+	dimension := mongo.CodeList{
+		Description: "The age ranging from 16 to 75+",
+		HRef:        "http://localhost:22400//code-lists/43513D18-B4D8-4227-9820-492B2971E7T5",
+		ID:          "43513D18-B4D8-4227-9820-492B2971E7T5",
+		Name:        "age",
+	}
+
+	links := mongo.InstanceLinks{
+		Job: &mongo.IDLink{
+			ID:   "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+			HRef: "http://localhost:22000/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
+		},
+		Dataset: &mongo.IDLink{
+			ID:   datasetID,
+			HRef: "http://localhost:22000/datasets/" + datasetID,
+		},
+		Self: &mongo.IDLink{
+			HRef: cfg.DatasetAPIURL + "/instances/" + instanceID,
+		},
+		Spatial: &mongo.IDLink{
+			HRef: "http://ons.gov.uk/geography-list",
+		},
+	}
+
+	if state == "edition-confirmed" {
+		links.Dimensions = &mongo.IDLink{
+			HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2017/versions/1/dimensions",
+		}
+		links.Edition = &mongo.IDLink{
+			ID:   "2017",
+			HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2017",
+		}
+		links.Version = &mongo.IDLink{
+			ID:   "1",
+			HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2017/versions/1",
+		}
+	}
+
+	observations := 1000
+
+	temporal := mongo.TemporalFrequency{
+		EndDate:   "2016-10-10",
+		Frequency: "monthly",
+		StartDate: "2014-10-10",
+	}
+
+	So(instance.Dimensions, ShouldResemble, []mongo.CodeList{dimension})
+	So(instance.Edition, ShouldEqual, "2017")
+	So(instance.Headers, ShouldResemble, &[]string{"time", "geography"})
+	So(instance.LastUpdated, ShouldNotBeNil)
+	So(instance.Links, ShouldResemble, links)
+	So(instance.ReleaseDate, ShouldEqual, "2017-11-11")
+	So(instance.State, ShouldEqual, state)
+	So(instance.Temporal, ShouldResemble, &[]mongo.TemporalFrequency{temporal})
+	So(instance.TotalObservations, ShouldResemble, &observations)
+	So(instance.InsertedObservations, ShouldResemble, &observations)
+
+	return
+}
+
+func checkEditionDoc(datasetID, instanceID string, editionDoc mongo.Edition) {
+	So(editionDoc.Edition, ShouldEqual, "2017")
+	So(editionDoc.Links.Dataset.ID, ShouldEqual, datasetID)
+	So(editionDoc.Links.Dataset.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID)
+	So(editionDoc.Links.LatestVersion.ID, ShouldEqual, "1")
+	So(editionDoc.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017/versions/1")
+	So(editionDoc.Links.Self.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017")
+	So(editionDoc.Links.Versions.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017/versions")
+	So(editionDoc.State, ShouldEqual, "created")
+
+	return
+}

--- a/datasetAPI/put_version_test.go
+++ b/datasetAPI/put_version_test.go
@@ -1,6 +1,7 @@
 package datasetAPI
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"testing"
@@ -10,78 +11,650 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
+	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSuccessfullyUpdateVersion(t *testing.T) {
 
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given an unpublished dataset, edition and version", t, func() {
+		edition := "2018"
+		version := "2"
+
+		d, err := setupResources(datasetID, editionID, edition, instanceID, 1)
+		if err != nil {
+			log.ErrorC("Was unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When a PUT request to update meta data against the version resource", func() {
+			Convey("Then version resource is updated and returns a status ok (200)", func() {
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+					WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).Expect().Status(http.StatusOK)
+
+				updatedVersion, err := mongo.GetVersion(database, "instances", "_id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check version has been updated
+				So(updatedVersion.ID, ShouldEqual, instanceID)
+				So(updatedVersion.ReleaseDate, ShouldEqual, "2018-11-11")
+				So(updatedVersion.Links.Spatial.HRef, ShouldEqual, "http://ons.gov.uk/new-geography-list")
+				// Check self link does not update - the only link that can be updated is `spatial`
+				So(updatedVersion.Links.Self.HRef, ShouldNotEqual, "http://bogus/bad-link")
+
+				temporal := mongo.TemporalFrequency{
+					StartDate: "2014-11-11",
+					EndDate:   "2017-11-11",
+					Frequency: "monthly",
+				}
+
+				temporalList := &[]mongo.TemporalFrequency{temporal}
+
+				So(updatedVersion.Temporal, ShouldResemble, temporalList)
+			})
+		})
+
+		Convey("When a PUT request to update version resource with a collection id and state of associated", func() {
+			Convey("Then the dataset and version resources are updated and returns a status ok (200)", func() {
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+					WithBytes([]byte(validPUTUpdateVersionToAssociatedJSON)).Expect().Status(http.StatusOK)
+
+				updatedVersion, err := mongo.GetVersion(database, "instances", "_id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check version has been updated
+				So(updatedVersion.ID, ShouldEqual, instanceID)
+				So(updatedVersion.CollectionID, ShouldEqual, "45454545")
+				So(updatedVersion.State, ShouldEqual, "associated")
+
+				updatedDataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check dataset has been updated
+				So(updatedDataset.ID, ShouldEqual, datasetID)
+				So(updatedDataset.Next.CollectionID, ShouldEqual, "45454545")
+				So(updatedDataset.Next.State, ShouldEqual, "associated")
+			})
+		})
+
+		Convey("When a PUT request to update version resource with a collection id and state of published", func() {
+			Convey("Then the dataset, edition and version resources are updated and returns a status ok (200)", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+					WithBytes([]byte(validPUTUpdateVersionToPublishedWithCollectionIDJSON)).Expect().Status(http.StatusOK)
+
+				updatedVersion, err := mongo.GetVersion(database, "instances", "_id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check version has been updated
+				So(updatedVersion.ID, ShouldEqual, instanceID)
+				So(updatedVersion.CollectionID, ShouldEqual, "33333333")
+				So(updatedVersion.State, ShouldEqual, "published")
+
+				log.Debug("edition id", log.Data{"edition_id": editionID})
+
+				updatedEdition, err := mongo.GetEdition(database, "editions", "_id", editionID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check edition has been updated
+				So(updatedEdition.ID, ShouldEqual, editionID)
+				So(updatedEdition.State, ShouldEqual, "published")
+
+				updatedDataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check dataset has been updated
+				So(updatedDataset.ID, ShouldEqual, datasetID)
+				So(updatedDataset.Current.CollectionID, ShouldEqual, "33333333")
+				So(updatedDataset.Current.State, ShouldEqual, "published")
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Was unable to remove test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+
+	Convey("Given an unpublished dataset, edition and a version that has been associated", t, func() {
+		edition := "2018"
+		version := "2"
+
+		d, err := setupResources(datasetID, editionID, edition, instanceID, 2)
+		if err != nil {
+			log.ErrorC("Was unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		// TODO reinstate test once dataset API has been fixed
+		// Convey("When a PUT request to update version resource to remove collection id", func() {
+		// 	Convey("Then the dataset and version resources are updated accordingly and returns a status ok (200)", func() {
+		// 		datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+		// 			WithBytes([]byte(validPUTUpdateVersionFromAssociatedToEditionConfirmedJSON)).Expect().Status(http.StatusOK)
+		//
+		// 		updatedVersion, err := mongo.GetVersion(database, "instances", "_id", instanceID)
+		// 		if err != nil {
+		// 			log.ErrorC("Unable to retrieve updated version document", err, nil)
+		// 			os.Exit(1)
+		// 		}
+		//
+		// 		// Check version has been updated
+		// 		So(updatedVersion.ID, ShouldEqual, instanceID)
+		// 		So(updatedVersion.CollectionID, ShouldEqual, "")
+		// 		So(updatedVersion.State, ShouldEqual, "edition-confirmed")
+		//
+		// 		updatedDataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
+		// 		if err != nil {
+		// 			log.ErrorC("Unable to retrieve updated version document", err, nil)
+		// 			os.Exit(1)
+		// 		}
+		//
+		// 		// Check dataset has been updated
+		// 		So(updatedDataset.ID, ShouldEqual, datasetID)
+		// 		So(updatedDataset.Next.CollectionID, ShouldEqual, "")
+		// 		So(updatedDataset.Next.State, ShouldEqual, "edition-confirmed")
+		// 	})
+		// })
+
+		Convey("When a PUT request to update version resource with a state of published", func() {
+			Convey("Then the dataset, edition and version resources are updated and returns a status ok (200)", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+					WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).Expect().Status(http.StatusOK)
+
+				updatedVersion, err := mongo.GetVersion(database, "instances", "_id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check version has been updated
+				So(updatedVersion.ID, ShouldEqual, instanceID)
+				So(updatedVersion.State, ShouldEqual, "published")
+
+				updatedEdition, err := mongo.GetEdition(database, "editions", "_id", editionID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check edition has been updated
+				So(updatedEdition.ID, ShouldEqual, editionID)
+				So(updatedEdition.State, ShouldEqual, "published")
+				log.Debug("latest version?", log.Data{"latest_version": updatedEdition.Links.LatestVersion})
+				So(updatedEdition.Links.LatestVersion.ID, ShouldEqual, "2")
+				So(updatedEdition.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2018/versions/2")
+
+				updatedDataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check dataset has been updated, next sub document should be copied across to current sub doc
+				So(updatedDataset.ID, ShouldEqual, datasetID)
+				So(updatedDataset.Current.State, ShouldEqual, "published")
+				So(updatedDataset.Next.State, ShouldEqual, "published") // Check next subdoc still exists
+				So(updatedDataset, ShouldResemble, expectedDatasetResource(datasetID, 0))
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Was unable to remove test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+
+	Convey("Given an published dataset and edition, and a version that has been associated", t, func() {
+		edition := "2017"
+		version := "2"
+
+		d, err := setupResources(datasetID, editionID, edition, instanceID, 3)
+		if err != nil {
+			log.ErrorC("Was unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When a PUT request to update version resource with a state of published", func() {
+			Convey("Then the dataset, edition and version resources are updated and returns a status ok (200)", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+					WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).Expect().Status(http.StatusOK)
+
+				updatedVersion, err := mongo.GetVersion(database, "instances", "_id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check version has been updated
+				So(updatedVersion.ID, ShouldEqual, instanceID)
+				So(updatedVersion.State, ShouldEqual, "published")
+
+				updatedEdition, err := mongo.GetEdition(database, "editions", "_id", editionID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check edition has been updated
+				So(updatedEdition.ID, ShouldEqual, editionID)
+				So(updatedEdition.State, ShouldEqual, "published")
+				So(updatedEdition.Links.LatestVersion.ID, ShouldEqual, "2")
+				So(updatedEdition.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017/versions/2")
+
+				updatedDataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check dataset has been updated, next sub document should be copied across to current sub doc
+				So(updatedDataset.ID, ShouldEqual, datasetID)
+				So(updatedDataset.Current.State, ShouldEqual, "published")
+				So(updatedDataset.Next.State, ShouldEqual, "published") // Check next subdoc still exists
+				So(updatedDataset, ShouldResemble, expectedDatasetResource(datasetID, 1))
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Was unable to remove test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+}
+
+func TestFailureToUpdateVersion(t *testing.T) {
+
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2018"
+	version := "2"
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	// test for updating a version that has no dataset (bad request)
+	Convey("Given an edition and a version of state associated exist for a dataset that does not exist in datastore", t, func() {
+
+		d, err := setupResources(datasetID, editionID, edition, instanceID, 4)
+		if err != nil {
+			log.ErrorC("Was unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an authorised PUT request is made to update version resource", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message `Dataset not found`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Was unable to remove test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+
+	// test for updating a version that has no edition (bad request)
+	Convey("Given a dataset and a version both of state associated exist but the edition does not", t, func() {
+
+		d, err := setupResources(datasetID, editionID, edition, instanceID, 5)
+		if err != nil {
+			log.ErrorC("Was unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an authorised PUT request is made to update version resource", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message `Edition not found`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Was unable to remove test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+
+	// test for updating a version that does not exist (not found)
+	Convey("Given a dataset and edition exist but the version for the dataset edition does not", t, func() {
+		edition := "2018"
+		version := "2"
+
+		d, err := setupResources(datasetID, editionID, edition, instanceID, 6)
+		if err != nil {
+			log.ErrorC("Was unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an authorised PUT request is made to update version resource", func() {
+			Convey("Then fail to update resource and return a status of not found (404) with a message `Version not found`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Was unable to remove test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+
+	// test for bad request (invalid json)
+	Convey("Given a dataset, edition and version do not exist", t, func() {
+		Convey("When an authorised PUT request is made to update version resource with invalid json", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message ``", func() {
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body\n")
+			})
+		})
+	})
+
+	Convey("Given a dataset, edition exist and the version for the dataset edition has a state of `edition-confirmed`", t, func() {
+		edition := "2018"
+		version := "2"
+
+		d, err := setupResources(datasetID, editionID, edition, instanceID, 7)
+		if err != nil {
+			log.ErrorC("Was unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		// test for bad request when associating version (Missing mandatory fields)
+		Convey("When an authorised PUT request is made to update version resource to a state of associated", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message `Missing collection_id for association between version and a collection`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "associated"}`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Missing collection_id for association between version and a collection\n")
+
+			})
+		})
+
+		// test for bad request when publishing version (Missing mandatory fields)
+		Convey("When an authorised PUT request is made to update version resource to a state of published", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message `Missing collection_id for association between version and a collection`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "published"}`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Missing collection_id for association between version and a collection\n")
+
+			})
+		})
+
+		// test for unauthorised request to update version
+		Convey("When an unauthorised PUT request is made to update version resource", func() {
+			Convey("Then fail to update resource and return a status of unauthorised (401) with a message `Unauthorised access to API`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+
+			})
+		})
+
+		// test for missing auth header when making a request to update version
+		Convey("When a PUT request is made to update version resource without an authentication header", func() {
+			Convey("Then fail to update resource and return a status of unauthorised (401) with a message `No authentication header provided`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).
+					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Was unable to remove test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+
+	Convey("Given a dataset, edition and version for the dataset edition are published", t, func() {
+		edition := "2017"
+		version := "1"
+
+		d, err := setupResources(datasetID, editionID, edition, instanceID, 8)
+		if err != nil {
+			log.ErrorC("Was unable to setup test data", err, nil)
+			os.Exit(1)
+		}
+
+		// test for reverting state against a published version (forbidden)
+		Convey("When an authorised PUT request is made to update version resource to a state of `edition-confirmed`", func() {
+			Convey("Then fail to update resource and return a status of forbidden (403) with a message `Unable to update document, already published`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "edition-confirmed"}`)).
+					Expect().Status(http.StatusForbidden).Body().Contains("Unable to update document, already published\n")
+			})
+		})
+
+		// test for updating meta data against a published version (forbidden)
+		Convey("When an authorised PUT request is made to update version resource with meta data", func() {
+			Convey("Then fail to update resource and return a status of forbidden (403) with a message `Unable to update document, already published`", func() {
+
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
+					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"links":{"spatial":{"href": "http://ons.gov.uk/spatial-notes"}}}`)).
+					Expect().Status(http.StatusForbidden).Body().Contains("Unable to update document, already published\n")
+			})
+		})
+
+		if err := mongo.TeardownMany(d); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Was unable to remove test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+}
+
+func setupResources(datasetID, editionID, edition, instanceID string, setup int) (*mongo.ManyDocs, error) {
 	var docs []mongo.Doc
 
-	datasetDoc := mongo.Doc{
+	publishedDatasetDoc := mongo.Doc{
 		Database:   "datasets",
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedDatasetData,
+		Update:     validPublishedDatasetData(datasetID),
 	}
 
-	editionDoc := mongo.Doc{
+	associatedDatasetDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     validAssociatedDatasetData(datasetID),
+	}
+
+	createdDatasetDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     validCreatedDatasetData(datasetID),
+	}
+
+	publishedEditionDoc := mongo.Doc{
 		Database:   "datasets",
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData,
+		Update:     validPublishedEditionData(datasetID, editionID, edition),
 	}
 
-	instanceOneDoc := mongo.Doc{
+	unpublishedEditionDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "editions",
+		Key:        "_id",
+		Value:      editionID,
+		Update:     validUnpublishedEditionData(datasetID, editionID, edition),
+	}
+
+	publishedInstanceDoc := mongo.Doc{
 		Database:   "datasets",
 		Collection: "instances",
 		Key:        "_id",
 		Value:      instanceID,
-		Update:     validPublishedInstanceData,
+		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
 	}
 
-	instanceTwoDoc := mongo.Doc{
+	associatedInstanceDoc := mongo.Doc{
 		Database:   "datasets",
 		Collection: "instances",
 		Key:        "_id",
-		Value:      "799",
-		Update:     validUnpublishedInstanceData,
+		Value:      instanceID,
+		Update:     validAssociatedInstanceData(datasetID, edition, instanceID),
 	}
 
-	docs = append(docs, datasetDoc, editionDoc, instanceOneDoc, instanceTwoDoc)
+	editionConfirmedInstanceDoc := mongo.Doc{
+		Database:   "datasets",
+		Collection: "instances",
+		Key:        "_id",
+		Value:      instanceID,
+		Update:     validEditionConfirmedInstanceData(datasetID, edition, instanceID),
+	}
+
+	switch setup {
+	case 1:
+		docs = append(docs, createdDatasetDoc, unpublishedEditionDoc, editionConfirmedInstanceDoc)
+	case 2:
+		docs = append(docs, associatedDatasetDoc, unpublishedEditionDoc, associatedInstanceDoc)
+	case 3:
+		docs = append(docs, publishedDatasetDoc, publishedEditionDoc, associatedInstanceDoc)
+	case 4:
+		docs = append(docs, unpublishedEditionDoc, associatedInstanceDoc)
+	case 5:
+		docs = append(docs, associatedDatasetDoc, associatedInstanceDoc)
+	case 6:
+		docs = append(docs, associatedDatasetDoc, unpublishedEditionDoc)
+	case 7:
+		docs = append(docs, publishedDatasetDoc, publishedEditionDoc, editionConfirmedInstanceDoc)
+	case 8:
+		docs = append(docs, publishedDatasetDoc, publishedEditionDoc, publishedInstanceDoc)
+	default:
+		errMsg := fmt.Errorf("Failed to pick a valid setup value")
+		log.Error(errMsg, log.Data{"setup": setup})
+		return nil, errMsg
+	}
 
 	d := &mongo.ManyDocs{
 		Docs: docs,
 	}
 
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Was unable to run test", err, nil)
-			os.Exit(1)
-		}
-	}
-
 	if err := mongo.SetupMany(d); err != nil {
 		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
+		return nil, err
 	}
 
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-
-	// TODO test name incorrect
-	Convey("Fail to update a version for an edition of a dataset", t, func() {
-
-		// TODO Test only checks that a version state is updated, we should test all possible fields that could be updated
-		datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/2", datasetID, edition).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionJSON)).
-			Expect().Status(http.StatusOK)
-	})
-
-	if err := mongo.TeardownMany(d); err != nil {
-		if err != mgo.ErrNotFound {
-			os.Exit(1)
-		}
-	}
+	return d, nil
 }
 
-// TODO acceptance tests for failure scenarios
+func expectedDatasetResource(datasetID string, resource int) mongo.DatasetUpdate {
+
+	nationalStatistic := true
+
+	doc := mongo.Dataset{
+		CollectionID: "208064B3-A808-449B-9041-EA3A2F72CFAB",
+		Contacts:     []mongo.ContactDetails{contact},
+		Description:  "Comprehensive database of time series covering measures of inflation data including CPIH, CPI and RPI.",
+		Keywords:     []string{"cpi", "boy"},
+		Links: &mongo.DatasetLinks{
+			AccessRights: &mongo.LinkObject{
+				HRef: "http://ons.gov.uk/accessrights",
+			},
+			Editions: &mongo.LinkObject{
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions",
+			},
+			LatestVersion: &mongo.LinkObject{
+				ID:   "2",
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2018/versions/2",
+			},
+			Self: &mongo.LinkObject{
+				HRef: cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			},
+		},
+		Methodologies:     []mongo.GeneralDetails{methodology},
+		NationalStatistic: &nationalStatistic,
+		NextRelease:       "2018-10-10",
+		Publications:      []mongo.GeneralDetails{publication},
+		Publisher: &mongo.Publisher{
+			Name: "Automation Tester",
+			Type: "publisher",
+			HRef: "https://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/aug2017",
+		},
+		QMI: &mongo.GeneralDetails{
+			Description: "Consumer price inflation is the rate at which the prices of goods and services bought by households rise and fall",
+			HRef:        "https://www.ons.gov.uk/economy/inflationandpriceindices/qmis/consumerpriceinflationqmi",
+			Title:       "Consumer Price Inflation (includes all 3 indices – CPIH, CPI and RPI)",
+		},
+		RelatedDatasets:  []mongo.GeneralDetails{relatedDatasets},
+		ReleaseFrequency: "Monthly",
+		State:            "published",
+		Theme:            "Goods and services",
+		Title:            "CPI",
+		URI:              "https://www.ons.gov.uk/economy/inflationandpriceindices/datasets/consumerpriceinflation",
+	}
+
+	if resource == 1 {
+		doc.License = "ONS license"
+		doc.Links.LatestVersion.HRef = cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/2017/versions/2"
+	}
+
+	dataset := mongo.DatasetUpdate{
+		ID:      datasetID,
+		Current: &doc,
+		Next:    &doc,
+	}
+
+	return dataset
+}

--- a/datasetAPI/put_version_test.go
+++ b/datasetAPI/put_version_test.go
@@ -152,35 +152,36 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 			os.Exit(1)
 		}
 
-		// TODO reinstate test once dataset API has been fixed
-		// Convey("When a PUT request to update version resource to remove collection id", func() {
-		// 	Convey("Then the dataset and version resources are updated accordingly and returns a status ok (200)", func() {
-		// 		datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
-		// 			WithBytes([]byte(validPUTUpdateVersionFromAssociatedToEditionConfirmedJSON)).Expect().Status(http.StatusOK)
-		//
-		// 		updatedVersion, err := mongo.GetVersion(database, "instances", "_id", instanceID)
-		// 		if err != nil {
-		// 			log.ErrorC("Unable to retrieve updated version document", err, nil)
-		// 			os.Exit(1)
-		// 		}
-		//
-		// 		// Check version has been updated
-		// 		So(updatedVersion.ID, ShouldEqual, instanceID)
-		// 		So(updatedVersion.CollectionID, ShouldEqual, "")
-		// 		So(updatedVersion.State, ShouldEqual, "edition-confirmed")
-		//
-		// 		updatedDataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
-		// 		if err != nil {
-		// 			log.ErrorC("Unable to retrieve updated version document", err, nil)
-		// 			os.Exit(1)
-		// 		}
-		//
-		// 		// Check dataset has been updated
-		// 		So(updatedDataset.ID, ShouldEqual, datasetID)
-		// 		So(updatedDataset.Next.CollectionID, ShouldEqual, "")
-		// 		So(updatedDataset.Next.State, ShouldEqual, "edition-confirmed")
-		// 	})
-		// })
+		// TODO Remove skipped tests when code has been refactored (and hence fixed)
+		// 1 test skipped
+		SkipConvey("When a PUT request to update version resource to remove collection id", func() {
+			Convey("Then the dataset and version resources are updated accordingly and returns a status ok (200)", func() {
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+					WithBytes([]byte(validPUTUpdateVersionFromAssociatedToEditionConfirmedJSON)).Expect().Status(http.StatusOK)
+
+				updatedVersion, err := mongo.GetVersion(database, "instances", "_id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check version has been updated
+				So(updatedVersion.ID, ShouldEqual, instanceID)
+				So(updatedVersion.CollectionID, ShouldEqual, "")
+				So(updatedVersion.State, ShouldEqual, "edition-confirmed")
+
+				updatedDataset, err := mongo.GetDataset(database, collection, "_id", datasetID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated version document", err, nil)
+					os.Exit(1)
+				}
+
+				// Check dataset has been updated
+				So(updatedDataset.ID, ShouldEqual, datasetID)
+				So(updatedDataset.Next.CollectionID, ShouldEqual, "")
+				So(updatedDataset.Next.State, ShouldEqual, "edition-confirmed")
+			})
+		})
 
 		Convey("When a PUT request to update version resource with a state of published", func() {
 			Convey("Then the dataset, edition and version resources are updated and returns a status ok (200)", func() {

--- a/datasetAPI/put_version_test.go
+++ b/datasetAPI/put_version_test.go
@@ -474,7 +474,7 @@ func TestFailureToUpdateVersion(t *testing.T) {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "edition-confirmed"}`)).
-					Expect().Status(http.StatusForbidden).Body().Contains("Unable to update document, already published\n")
+					Expect().Status(http.StatusForbidden).Body().Contains("unable to update document, already published\n")
 			})
 		})
 
@@ -484,7 +484,7 @@ func TestFailureToUpdateVersion(t *testing.T) {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"links":{"spatial":{"href": "http://ons.gov.uk/spatial-notes"}}}`)).
-					Expect().Status(http.StatusForbidden).Body().Contains("Unable to update document, already published\n")
+					Expect().Status(http.StatusForbidden).Body().Contains("unable to update document, already published\n")
 			})
 		})
 

--- a/testDataSetup/mongo/mongo.go
+++ b/testDataSetup/mongo/mongo.go
@@ -1,6 +1,8 @@
 package mongo
 
 import (
+	"time"
+
 	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
@@ -114,6 +116,237 @@ func SetupMany(d *ManyDocs) error {
 	return nil
 }
 
+// ------------------------------------------------------------------------
+
+// DatasetUpdate represents an evolving dataset with the current dataset and the updated dataset
+type DatasetUpdate struct {
+	ID      string   `bson:"_id,omitempty"         json:"id,omitempty"`
+	Current *Dataset `bson:"current,omitempty"     json:"current,omitempty"`
+	Next    *Dataset `bson:"next,omitempty"        json:"next,omitempty"`
+}
+
+type Dataset struct {
+	CollectionID      string           `bson:"collection_id,omitempty"          json:"collection_id,omitempty"`
+	Contacts          []ContactDetails `bson:"contacts,omitempty"               json:"contacts,omitempty"`
+	Description       string           `bson:"description,omitempty"            json:"description,omitempty"`
+	Keywords          []string         `bson:"keywords,omitempty"               json:"keywords,omitempty"`
+	ID                string           `bson:"_id,omitempty"                    json:"id,omitempty"`
+	License           string           `bson:"license,omitempty"                json:"license,omitempty"`
+	Links             *DatasetLinks    `bson:"links,omitempty"                  json:"links,omitempty"`
+	Methodologies     []GeneralDetails `bson:"methodologies,omitempty"          json:"methodologies,omitempty"`
+	NationalStatistic *bool            `bson:"national_statistic,omitempty"     json:"national_statistic,omitempty"`
+	NextRelease       string           `bson:"next_release,omitempty"           json:"next_release,omitempty"`
+	Publications      []GeneralDetails `bson:"publications,omitempty"           json:"publications,omitempty"`
+	Publisher         *Publisher       `bson:"publisher,omitempty"              json:"publisher,omitempty"`
+	QMI               *GeneralDetails  `bson:"qmi,omitempty"                    json:"qmi,omitempty"`
+	RelatedDatasets   []GeneralDetails `bson:"related_datasets,omitempty"       json:"related_datasets,omitempty"`
+	ReleaseFrequency  string           `bson:"release_frequency,omitempty"      json:"release_frequency,omitempty"`
+	State             string           `bson:"state,omitempty"                  json:"state,omitempty"`
+	Theme             string           `bson:"theme,omitempty"                  json:"theme,omitempty"`
+	Title             string           `bson:"title,omitempty"                  json:"title,omitempty"`
+	URI               string           `bson:"uri,omitempty"                    json:"uri,omitempty"`
+}
+
+// ContactDetails represents an object containing information of the contact
+type ContactDetails struct {
+	Email     string `bson:"email,omitempty"      json:"email,omitempty"`
+	Name      string `bson:"name,omitempty"       json:"name,omitempty"`
+	Telephone string `bson:"telephone,omitempty"  json:"telephone,omitempty"`
+}
+
+// DatasetLinks represents a list of specific links related to the dataset resource
+type DatasetLinks struct {
+	AccessRights  *LinkObject `bson:"access_rights,omitempty"   json:"access_rights,omitempty"`
+	Editions      *LinkObject `bson:"editions,omitempty"        json:"editions,omitempty"`
+	LatestVersion *LinkObject `bson:"latest_version,omitempty"  json:"latest_version,omitempty"`
+	Self          *LinkObject `bson:"self,omitempty"            json:"self,omitempty"`
+}
+
+// GeneralDetails represents generic fields stored against an object (reused)
+type GeneralDetails struct {
+	Description string `bson:"description,omitempty"    json:"description,omitempty"`
+	HRef        string `bson:"href,omitempty"           json:"href,omitempty"`
+	Title       string `bson:"title,omitempty"          json:"title,omitempty"`
+}
+
+// LinkObject represents a generic structure for all links
+type LinkObject struct {
+	ID   string `bson:"id,omitempty"    json:"id,omitempty"`
+	HRef string `bson:"href,omitempty"  json:"href,omitempty"`
+}
+
+// Publisher represents an object containing information of the publisher
+type Publisher struct {
+	Name string `bson:"name,omitempty" json:"name,omitempty"`
+	Type string `bson:"type,omitempty" json:"type,omitempty"`
+	HRef string `bson:"href,omitempty" json:"href,omitempty"`
+}
+
+// Edition represents information related to a single edition for a dataset
+type Edition struct {
+	Edition     string        `bson:"edition,omitempty"      json:"edition,omitempty"`
+	ID          string        `bson:"id,omitempty"          json:"id,omitempty"`
+	Links       *EditionLinks `bson:"links,omitempty"        json:"links,omitempty"`
+	State       string        `bson:"state,omitempty"        json:"state,omitempty"`
+	LastUpdated time.Time     `bson:"last_updated,omitempty" json:"-"`
+}
+
+// EditionLinks represents a list of specific links related to the edition resource of a dataset
+type EditionLinks struct {
+	Dataset       *LinkObject `bson:"dataset,omitempty"        json:"dataset,omitempty"`
+	LatestVersion *LinkObject `bson:"latest_version,omitempty" json:"latest_version,omitempty"`
+	Self          *LinkObject `bson:"self,omitempty"           json:"self,omitempty"`
+	Versions      *LinkObject `bson:"versions,omitempty"       json:"versions,omitempty"`
+}
+
+// Version represents information related to a single version for an edition of a dataset
+type Version struct {
+	CollectionID string               `bson:"collection_id,omitempty" json:"collection_id,omitempty"`
+	Dimensions   []CodeList           `bson:"dimensions,omitempty"    json:"dimensions,omitempty"`
+	Downloads    *DownloadList        `bson:"downloads,omitempty"     json:"downloads,omitempty"`
+	Edition      string               `bson:"edition,omitempty"       json:"edition,omitempty"`
+	ID           string               `bson:"id,omitempty"            json:"id,omitempty"`
+	Links        *VersionLinks        `bson:"links,omitempty"         json:"links,omitempty"`
+	ReleaseDate  string               `bson:"release_date,omitempty"  json:"release_date,omitempty"`
+	State        string               `bson:"state,omitempty"         json:"state,omitempty"`
+	Temporal     *[]TemporalFrequency `bson:"temporal,omitempty"      json:"temporal,omitempty"`
+	LastUpdated  time.Time            `bson:"last_updated,omitempty"  json:"-"`
+	Version      int                  `bson:"version,omitempty"       json:"version,omitempty"`
+}
+
+// CodeList for a dimension within an instance
+type CodeList struct {
+	Description string `json:"description"`
+	HRef        string `json:"href"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+}
+
+// DownloadList represents a list of objects of containing information on the downloadable files
+type DownloadList struct {
+	CSV *DownloadObject `bson:"csv,omitempty" json:"csv,omitempty"`
+	XLS *DownloadObject `bson:"xls,omitempty" json:"xls,omitempty"`
+}
+
+// DownloadObject represents information on the downloadable file
+type DownloadObject struct {
+	URL  string `bson:"url,omitempty"  json:"url,omitempty"`
+	Size string `bson:"size,omitempty" json:"size,omitempty"`
+}
+
+// TemporalFrequency represents a frequency for a particular period of time
+type TemporalFrequency struct {
+	EndDate   string `bson:"end_date,omitempty"    json:"end_date,omitempty"`
+	Frequency string `bson:"frequency,omitempty"   json:"frequency,omitempty"`
+	StartDate string `bson:"start_date,omitempty"  json:"start_date,omitempty"`
+}
+
+// VersionLinks represents a list of specific links related to the version resource for an edition of a dataset
+type VersionLinks struct {
+	Dataset    *LinkObject `bson:"dataset,omitempty"     json:"dataset,omitempty"`
+	Dimensions *LinkObject `bson:"dimensions,omitempty"  json:"dimensions,omitempty"`
+	Edition    *LinkObject `bson:"edition,omitempty"     json:"edition,omitempty"`
+	Self       *LinkObject `bson:"self,omitempty"        json:"self,omitempty"`
+	Spatial    *LinkObject `bson:"spatial,omitempty"     json:"spatial,omitempty"`
+	Version    *LinkObject `bson:"version,omitempty"     json:"-"`
+}
+
+// Instance which presents a single dataset being imported
+type Instance struct {
+	InstanceID           string               `bson:"id,omitempty"                          json:"id,omitempty"`
+	CollectionID         string               `bson:"collection_id,omitempty"               json:"collection_id,omitempty"`
+	Dimensions           []CodeList           `bson:"dimensions,omitempty"                  json:"dimensions,omitempty"`
+	Downloads            *DownloadList        `bson:"downloads,omitempty"                   json:"downloads,omitempty"`
+	Edition              string               `bson:"edition,omitempty"                     json:"edition,omitempty"`
+	Events               *[]Event             `bson:"events,omitempty"                      json:"events,omitempty"`
+	Headers              *[]string            `bson:"headers,omitempty"                     json:"headers,omitempty"`
+	InsertedObservations *int                 `bson:"total_inserted_observations,omitempty" json:"total_inserted_observations,omitempty"`
+	Links                InstanceLinks        `bson:"links,omitempty"                       json:"links,omitempty"`
+	ReleaseDate          string               `bson:"release_date,omitempty"                json:"release_date,omitempty"`
+	State                string               `bson:"state,omitempty"                       json:"state,omitempty"`
+	Temporal             *[]TemporalFrequency `bson:"temporal,omitempty"                    json:"temporal,omitempty"`
+	TotalObservations    *int                 `bson:"total_observations,omitempty"          json:"total_observations,omitempty"`
+	Version              int                  `bson:"version,omitempty"                     json:"version,omitempty"`
+	LastUpdated          time.Time            `bson:"last_updated,omitempty"                json:"last_updated,omitempty"`
+}
+
+// InstanceLinks holds all links for an instance
+type InstanceLinks struct {
+	Job        *IDLink `bson:"job,omitempty"        json:"job"`
+	Dataset    *IDLink `bson:"dataset,omitempty"    json:"dataset,omitempty"`
+	Dimensions *IDLink `bson:"dimensions,omitempty" json:"dimensions,omitempty"`
+	Edition    *IDLink `bson:"edition,omitempty"    json:"edition,omitempty"`
+	Version    *IDLink `bson:"version,omitempty"    json:"version,omitempty"`
+	Self       *IDLink `bson:"self,omitempty"       json:"self,omitempty"`
+	Spatial    *IDLink `bson:"spatial,omitempty"    json:"spatial,omitempty"`
+}
+
+// IDLink holds the id and a link to the resource
+type IDLink struct {
+	ID   string `bson:"id,omitempty"   json:"id,omitempty"`
+	HRef string `bson:"href,omitempty" json:"href,omitempty"`
+}
+
+// Event which has happened to an instance
+type Event struct {
+	Type          string     `bson:"type,omitempty"           json:"type"`
+	Time          *time.Time `bson:"time,omitempty"           json:"time"`
+	Message       string     `bson:"message,omitempty"        json:"message"`
+	MessageOffset string     `bson:"message_offset,omitempty" json:"message_offset"`
+}
+
+// GetDataset retrieves a dataset document from mongo
+func GetDataset(database, collection, key, value string) (DatasetUpdate, error) {
+	s := session.Copy()
+	defer s.Close()
+
+	var dataset DatasetUpdate
+	if err := s.DB(database).C(collection).Find(bson.M{key: value}).One(&dataset); err != nil {
+		return dataset, err
+	}
+
+	return dataset, nil
+}
+
+// GetEdition retrieves an edition document from mongo
+func GetEdition(database, collection, key, value string) (Edition, error) {
+	s := session.Copy()
+	defer s.Close()
+
+	var edition Edition
+	if err := s.DB(database).C(collection).Find(bson.M{key: value}).One(&edition); err != nil {
+		return edition, err
+	}
+
+	return edition, nil
+}
+
+// GetVersion retrieves a version document from mongo
+func GetVersion(database, collection, key, value string) (Version, error) {
+	s := session.Copy()
+	defer s.Close()
+
+	var version Version
+	if err := s.DB(database).C(collection).Find(bson.M{key: value}).One(&version); err != nil {
+		return version, err
+	}
+
+	return version, nil
+}
+
+// GetInstance retrieves a version document from mongo
+func GetInstance(database, collection, key, value string) (Instance, error) {
+	s := session.Copy()
+	defer s.Close()
+
+	var instance Instance
+	if err := s.DB(database).C(collection).Find(bson.M{key: value}).One(&instance); err != nil {
+		return instance, err
+	}
+
+	return instance, nil
+}
+
 // Filter represents a structure for a filter blueprint or output
 type Filter struct {
 	InstanceID string      `bson:"instance_id"          json:"instance_id"`
@@ -131,12 +364,6 @@ type LinkMap struct {
 	FilterBlueprint LinkObject `bson:"filter_blueprint" json:"filter_blueprint,omitempty"`
 	Self            LinkObject `bson:"self"             json:"self,omitempty"`
 	Version         LinkObject `bson:"version"          json:"version,omitempty"`
-}
-
-// LinkObject represents a generic structure for all links
-type LinkObject struct {
-	ID   string `bson:"id,omitempty"   json:"id,omitempty"`
-	HRef string `bson:"href"           json:"href,omitempty"`
 }
 
 // Dimension represents an object containing a list of dimension values and the dimension name
@@ -172,7 +399,7 @@ type EventItem struct {
 	Type    string `bson:"type,omitempty"    json:"type,omitempty"`
 }
 
-// GetFilter retrieves a document from mongo
+// GetFilter retrieves a filter document from mongo
 func GetFilter(database, collection, key, value string) (Filter, error) {
 	s := session.Copy()
 	defer s.Close()


### PR DESCRIPTION
### What

Extend test coverage for almost all endpoints on the dataset API and refactor code to use gherkin (given, when, then). Test coverage for version and instance dimensions not extended due to restructuring the endpoints, which will mean a revamp of the spec for `/datasets/...../dimensions`, `/instances/....../dimensions`, `/datasets/...../options` and `/instances/....../options`.

### How to review

Make sure you have checkout `feature/fix-dataset-state-changes` on dp-dataset-api, run the tests by doing the following:

1) Run dataset API
2) cd `<path>/dp-api-tests/datasetAPI`
3) Run `go test ./...`

Make sure tests make sense and follow spec

### Who can review

Team B or Manoj
