### PR TITLE
Update dataset api tests - dimension id in response changed to dimension

### DIFF
--- a/datasetAPI/get_dimension_options_test.go
+++ b/datasetAPI/get_dimension_options_test.go
@@ -261,7 +261,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 
 func checkTimeDimensionResponse(instanceID string, response *httpexpect.Object) {
 
-	response.Value("items").Array().Element(0).Object().Value("dimension_id").Equal("time")
+	response.Value("items").Array().Element(0).Object().Value("dimension").Equal("time")
 
 	response.Value("items").Array().Element(0).Object().Value("label").Equal("")
 
@@ -279,7 +279,7 @@ func checkTimeDimensionResponse(instanceID string, response *httpexpect.Object) 
 
 func checkAggregateDimensionResponse(instanceID string, response *httpexpect.Object) {
 
-	response.Value("items").Array().Element(0).Object().Value("dimension_id").Equal("aggregate")
+	response.Value("items").Array().Element(0).Object().Value("dimension").Equal("aggregate")
 
 	response.Value("items").Array().Element(0).Object().Value("label").Equal("CPI (Overall Index)")
 

--- a/datasetAPI/get_instance_dimension_options_test.go
+++ b/datasetAPI/get_instance_dimension_options_test.go
@@ -86,7 +86,7 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 			response := datasetAPI.GET("/instances/{instance_id}/dimensions/time/options", instanceID).WithHeader(internalToken, internalTokenID).
 				Expect().Status(http.StatusOK).JSON().Object()
 
-			response.Value("dimension_id").Equal("time")
+			response.Value("dimension").Equal("time")
 			response.Value("values").Array().Element(0).Equal("202.45")
 
 		})
@@ -95,7 +95,7 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 			response := datasetAPI.GET("/instances/{instance_id}/dimensions/time/options", instanceID).
 				Expect().Status(http.StatusOK).JSON().Object()
 
-			response.Value("dimension_id").Equal("time")
+			response.Value("dimension").Equal("time")
 			response.Value("values").Array().Element(0).Equal("202.45")
 
 		})
@@ -107,7 +107,7 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 			response := datasetAPI.GET("/instances/{instance_id}/dimensions/aggregate/options", instanceID).WithHeader(internalToken, internalTokenID).
 				Expect().Status(http.StatusOK).JSON().Object()
 
-			response.Value("dimension_id").Equal("aggregate")
+			response.Value("dimension").Equal("aggregate")
 			response.Value("values").Array().Element(0).Equal("cpi1dimA19")
 
 		})
@@ -116,7 +116,7 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 			response := datasetAPI.GET("/instances/{instance_id}/dimensions/aggregate/options", instanceID).
 				Expect().Status(http.StatusOK).JSON().Object()
 
-			response.Value("dimension_id").Equal("aggregate")
+			response.Value("dimension").Equal("aggregate")
 			response.Value("values").Array().Element(0).Equal("cpi1dimA19")
 
 		})


### PR DESCRIPTION
### What

Change to dataset API test, expecting `dimension_id` instead of `dimension`

### How to review

Check tests pass

### Who can review

Team B
