### PR TITLE
Extend filter api tests for new validation rules

### DIFF
--- a/filterAPI/expectedTestData/filterJobWithDimensions.go
+++ b/filterAPI/expectedTestData/filterJobWithDimensions.go
@@ -187,7 +187,7 @@ func updatedAge(host, filterBlueprintID string) mongo.Dimension {
 	if filterBlueprintID == "" {
 		return mongo.Dimension{
 			Name:    "age",
-			Options: []string{"27", "28"},
+			Options: []string{"27", "42"},
 		}
 	}
 

--- a/filterAPI/initialise.go
+++ b/filterAPI/initialise.go
@@ -42,5 +42,15 @@ func init() {
 		os.Exit(1)
 	}
 
+	if err = mongo.Teardown("datasets", "instances", "test_data", "true"); err != nil {
+		log.ErrorC("Unable to remove all test data from mongo db", err, nil)
+		os.Exit(1)
+	}
+
+	if err = mongo.Teardown("datasets", "dimension.options", "test_data", "true"); err != nil {
+		log.ErrorC("Unable to remove all test data from mongo db", err, nil)
+		os.Exit(1)
+	}
+
 	log.Debug("config is:", log.Data{"config": cfg})
 }

--- a/filterAPI/json.go
+++ b/filterAPI/json.go
@@ -25,7 +25,7 @@ func GetValidPublishedInstanceDataBSON(instanceID string) bson.M {
 			"links.dataset.id":      "123",
 			"links.dataset.href":    "http://localhost:8080/datasets/123",
 			"links.dimensions.href": "http://localhost:8080/datasets/123/editions/2017/versions/1/dimensions",
-			"links.edition.id":      "1",
+			"links.edition.id":      "2017",
 			"links.edition.href":    "http://localhost:8080/datasets/123/editions/2017",
 			"links.self.href":       "http://localhost:8080/instances/" + instanceID,
 			"links.version.href":    "http://localhost:8080/datasets/123/editions/2017/versions/1",
@@ -184,6 +184,108 @@ func GetValidFilterOutputWithoutDownloadsBSON(host, filterID, instanceID, filter
 	}
 }
 
+func GetValidAge27DimensionData(instanceID string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"instance_id":          instanceID,
+			"name":                 "age",
+			"option":               "27",
+			"label":                "age 27",
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code.id":        "27",
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/27",
+			"last_updated":         "2017-09-09", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
+}
+
+func GetValidAgeDimensionData(instanceID, option string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"instance_id":          instanceID,
+			"name":                 "age",
+			"option":               option,
+			"label":                "age " + option,
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a",
+			"links.code.id":        option,
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/" + option,
+			"last_updated":         "2017-09-09", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
+}
+
+func GetValidSexDimensionData(instanceID, option string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"instance_id":          instanceID,
+			"name":                 "sex",
+			"option":               option,
+			"label":                "sex " + option,
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58b",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58b",
+			"links.code.id":        option,
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58b/codes/" + option,
+			"last_updated":         "2017-09-09", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
+}
+
+func GetValidGoodsAndServicesDimensionData(instanceID, option string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"instance_id":          instanceID,
+			"name":                 "Goods and services",
+			"option":               option,
+			"label":                "Goods and services " + option,
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58c",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58c",
+			"links.code.id":        option,
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58c/codes/" + option,
+			"last_updated":         "2017-09-09", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
+}
+
+func GetValidTimeDimensionData(instanceID, option string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"instance_id":          instanceID,
+			"name":                 "time",
+			"option":               option,
+			"label":                "time" + option,
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58d",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58d",
+			"links.code.id":        option,
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58d/codes/" + option,
+			"last_updated":         "2017-09-09", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
+}
+
+func GetValidResidenceTypeDimensionData(instanceID, option string) bson.M {
+	return bson.M{
+		"$set": bson.M{
+			"instance_id":          instanceID,
+			"name":                 "Residence Type",
+			"option":               option,
+			"label":                "Residence Type " + option,
+			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58e",
+			"links.code_list.href": cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58e",
+			"links.code.id":        option,
+			"links.code.href":      cfg.DatasetAPIURL + "/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58e/codes/" + option,
+			"last_updated":         "2017-09-09", // TODO Should be isodate
+			"test_data":            "true",
+		},
+	}
+}
+
 func GetValidPOSTCreateFilterJSON(instanceID string) string {
 	return `{
 	"instance_id": "` + instanceID + `" ,
@@ -191,7 +293,7 @@ func GetValidPOSTCreateFilterJSON(instanceID string) string {
 	  {
 		"name": "age",
 		"options": [
-		  "27", "28"
+		  "27", "42"
 		]
 	  }
 	]
@@ -206,7 +308,39 @@ func GetInvalidJSON(instanceID string) string {
 	  {
 		"name": "age",
 		"options": [
-		  "27", "28"
+		  "27", "42"
+		]
+	  }
+	]
+	}`
+}
+
+// GetInvalidDimensionJSON contains an invalid dimension for instance
+func GetInvalidDimensionJSON(instanceID string) string {
+	return `
+{
+	"instance_id": "` + instanceID + `",
+	"dimensions": [
+	  {
+		"name": "weight",
+		"options": [
+		  "27", "42"
+		]
+	  }
+	]
+	}`
+}
+
+// GetInvalidDimensionOptionJSON contains an invalid dimension for instance
+func GetInvalidDimensionOptionJSON(instanceID string) string {
+	return `
+{
+	"instance_id": "` + instanceID + `",
+	"dimensions": [
+	  {
+		"name": "age",
+		"options": [
+		  "27", "33"
 		]
 	  }
 	]

--- a/filterAPI/post_dimension_test.go
+++ b/filterAPI/post_dimension_test.go
@@ -71,7 +71,7 @@ func TestSuccessfullyPostDimension(t *testing.T) {
 		Convey("Overwrite a dimension that already exists on a filter blueprint", func() {
 			ageOptions := `{"options": ["28"]}`
 
-			filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/age", filterBlueprintID).
+			filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "age").
 				WithBytes([]byte(ageOptions)).
 				Expect().Status(http.StatusCreated)
 
@@ -119,7 +119,7 @@ func TestFailureToPostDimension(t *testing.T) {
 		Convey("When a request is made to add a new dimension to the filter blueprint", func() {
 			Convey("Then the response returns a status not found (404)", func() {
 
-				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/Residence Type", filterBlueprintID).
+				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "Residence Type").
 					WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
 					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
 			})
@@ -138,7 +138,7 @@ func TestFailureToPostDimension(t *testing.T) {
 		Convey("When the request body is invalid", func() {
 			Convey("Then the request body is invalid and returns status bad request (400)", func() {
 
-				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/Residence Type", filterBlueprintID).
+				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "Residence Type").
 					WithBytes([]byte(GetInvalidPOSTDimensionToFilterBlueprintJSON())).
 					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - Invalid request body")
 			})
@@ -147,7 +147,7 @@ func TestFailureToPostDimension(t *testing.T) {
 		Convey("When the instance does not exist for filter blueprint", func() {
 			Convey("Then the response returns a status unprocessable entity (422)", func() {
 
-				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/Residence Type", filterBlueprintID).
+				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "Residence Type").
 					WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
 					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("Unprocessable entity - instance for filter blueprint no longer exists\n")
 			})
@@ -162,7 +162,7 @@ func TestFailureToPostDimension(t *testing.T) {
 			Convey("When the dimension does not exist against instance", func() {
 				Convey("Then the response returns a status bad request (400)", func() {
 
-					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/foobar", filterBlueprintID).
+					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "foobar").
 						WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
 						Expect().Status(http.StatusBadRequest).Body().Contains("Dimension not found\n")
 				})
@@ -175,7 +175,7 @@ func TestFailureToPostDimension(t *testing.T) {
 				}
 				Convey("Then the response returns a status bad request (400)", func() {
 
-					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/age", filterBlueprintID).
+					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "age").
 						WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
 						Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimension options chosen: [Lives in a communal establishment Lives in a household]\n")
 				})

--- a/filterAPI/setup.go
+++ b/filterAPI/setup.go
@@ -14,19 +14,11 @@ func setupInstance(instanceID string, update bson.M) error {
 		return err
 	}
 
-	if err := mongo.Setup("datasets", "instances", "instance_id", instanceID, update); err != nil {
-		return err
-	}
-
-	return nil
+	return mongo.Setup("datasets", "instances", "instance_id", instanceID, update)
 }
 
 func setupDimensionOptions(ID string, update bson.M) error {
-	if err := mongo.Setup("datasets", "dimension.options", "_id", ID, update); err != nil {
-		return err
-	}
-
-	return nil
+	return mongo.Setup("datasets", "dimension.options", "_id", ID, update)
 }
 
 func teardownInstance(instanceID string) error {

--- a/filterAPI/setup.go
+++ b/filterAPI/setup.go
@@ -2,6 +2,8 @@ package filterAPI
 
 import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
+	"github.com/ONSdigital/go-ns/log"
+	uuid "github.com/satori/go.uuid"
 	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -19,6 +21,14 @@ func setupInstance(instanceID string, update bson.M) error {
 	return nil
 }
 
+func setupDimensionOptions(ID string, update bson.M) error {
+	if err := mongo.Setup("datasets", "dimension.options", "_id", ID, update); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func teardownInstance(instanceID string) error {
 	if err := mongo.Teardown("datasets", "instances", "instance_id", instanceID); err != nil {
 		if err == mgo.ErrNotFound {
@@ -26,5 +36,98 @@ func teardownInstance(instanceID string) error {
 		}
 		return err
 	}
+	return nil
+}
+
+func teardownDimensionOptions(instanceID string) error {
+	if err := mongo.Teardown("datasets", "dimension.options", "instance_id", instanceID); err != nil {
+		if err == mgo.ErrNotFound {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func setupMultipleDimensionsAndOptions(instanceID string) error {
+	var err error
+
+	// setup age dimension options
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidAgeDimensionData(instanceID, "27")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "age", "option": "27"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidAgeDimensionData(instanceID, "28")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "age", "option": "28"})
+	}
+
+	// setup sex dimension options
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidSexDimensionData(instanceID, "male")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "sex", "option": "male"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidSexDimensionData(instanceID, "female")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "sex", "option": "female"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidSexDimensionData(instanceID, "unknown")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "sex", "option": "unknown"})
+	}
+
+	// setup Goods and services dimension options
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidGoodsAndServicesDimensionData(instanceID, "Education")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "Goods and services", "option": "welfare"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidGoodsAndServicesDimensionData(instanceID, "health")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "Goods and services", "option": "welfare"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidGoodsAndServicesDimensionData(instanceID, "communication")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "Goods and services", "option": "welfare"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidGoodsAndServicesDimensionData(instanceID, "welfare")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "Goods and services", "option": "welfare"})
+	}
+
+	// setup time dimension options
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidTimeDimensionData(instanceID, "March 1997")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "time", "option": "February 2007"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidTimeDimensionData(instanceID, "April 1997")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "time", "option": "February 2007"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidTimeDimensionData(instanceID, "June 1997")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "time", "option": "February 2007"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidTimeDimensionData(instanceID, "September 1997")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "time", "option": "February 2007"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidTimeDimensionData(instanceID, "December 1997")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "time", "option": "February 2007"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidTimeDimensionData(instanceID, "February 2007")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "time", "option": "February 2007"})
+	}
+
+	// setup residence type dimension options
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidResidenceTypeDimensionData(instanceID, "Lives in a communal establishment")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "Residence Type", "option": "Lives in a communal establishment"})
+	}
+
+	if err = setupDimensionOptions(uuid.NewV4().String(), GetValidResidenceTypeDimensionData(instanceID, "Lives in a household")); err != nil {
+		log.ErrorC("Unable to setup dimension option", err, log.Data{"instance_id": instanceID, "dimension": "Residence Type", "option": "Lives in a communal establishment"})
+	}
+
+	if err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
### What

Validation applies to the dimension and dimension options chosen on request and need to be verified that they exist against the dataset version (instance) to be able to apply a filter blueprint.

### How to review

Check logic makes sense and that all endpoints (PUT's and POST's) have good coverage of validating dimension and dimension options as well as error scenarios.

Run acceptance tests by going to feature/validate-filter-dimensions on the dp-api-tests branch; then do the following:

1) Run dp-dataset-api
2) Run dp-filter-api (on feature/validate-filter-dimensions)
3) cd filterAPI; go test ./...

### Who can review

Team B