### PR TITLE
Feature/hide auth endpoints dataset

### DIFF
--- a/datasetAPI/get_dataset_dimensions_test.go
+++ b/datasetAPI/get_dataset_dimensions_test.go
@@ -96,7 +96,7 @@ func TestGetDimensions_ReturnsAllDimensionsFromADataset(t *testing.T) {
 	}
 }
 
-// TODO Remove skipped tests when code has been refactored (and hence fixed)
+// TODO Unskip skipped tests when code has been refactored (and hence fixed)
 func TestGetDimensions_Failed(t *testing.T) {
 	datasetID := uuid.NewV4().String()
 	editionID := uuid.NewV4().String()
@@ -141,38 +141,42 @@ func TestGetDimensions_Failed(t *testing.T) {
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
 	Convey("Fail to get a list of Dimensions for a dataset", t, func() {
-		Convey("When authenticated", func() {
-
-			// TODO Remove skip on test once endpoint fixed
-			SkipConvey("When the dataset does not exist", func() {
+		// TODO Remove skip on test once endpoint fixed
+		SkipConvey("When user is authenticated and the dataset does not exist", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
-			})
-
-			// TODO Remove skip on test once endpoint fixed
-			SkipConvey("When the edition does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
-			})
-
-			Convey("When there are no versions", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Version not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 
-		Convey("When unauthenticated", func() {
-
-			// TODO Remove skip on test once endpoint fixed
-			SkipConvey("When the dataset does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+		// TODO Remove skip on test once endpoint fixed
+		SkipConvey("When user is authenticated and the edition does not exist", func() {
+			Convey("Then return status not found (404)", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 			})
+		})
 
-			// TODO Remove skip on test once endpoint fixed
-			SkipConvey("When the edition does not exist", func() {
+		Convey("When user is authenticated and there are no versions", func() {
+			Convey("Then return status not found (404)", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+			})
+		})
+
+		// TODO Remove skip on test once endpoint fixed
+		SkipConvey("When user is unauthenticated and the dataset does not exist", func() {
+			Convey("Then return status not found (404)", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+			})
+		})
+
+		// TODO Remove skip on test once endpoint fixed
+		SkipConvey("When user is unauthenticated and the edition does not exist", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").
-					Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 			})
 
 			Convey("When there are no published versions", func() {
@@ -187,7 +191,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 
 				mongo.Setup(unpublishedInstance)
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Version not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
 
 				mongo.Teardown(unpublishedInstance)
 			})
@@ -195,15 +199,15 @@ func TestGetDimensions_Failed(t *testing.T) {
 	})
 
 	Convey("Given a valid dataset id, edition and version with no dimensions", t, func() {
-		Convey("When authenticated and get the dimensions", func() {
-			Convey("Then the error code should be 404", func() {
+		Convey("When authenticated", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
 					Expect().Status(http.StatusNotFound).Body().Contains("Dimensions not found\n")
 			})
 		})
 
-		Convey("When unauthenticated and get the dimensions", func() {
-			Convey("Then the error code should be 404", func() {
+		Convey("When user is unauthenticated", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).
 					Expect().Status(http.StatusNotFound).Body().Contains("Dimensions not found\n")
 			})

--- a/datasetAPI/get_dimension_options_test.go
+++ b/datasetAPI/get_dimension_options_test.go
@@ -121,7 +121,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 	}
 }
 
-// TODO Remove skipped tests when code has been refactored (and hence fixed)
+// TODO Unskip skipped tests when code has been refactored (and hence fixed)
 // 2 tests skipped
 func TestGetDimensionOptions_Failed(t *testing.T) {
 	datasetID := uuid.NewV4().String()
@@ -173,35 +173,44 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	SkipConvey("Fail to get a list of time dimension options for a dataset", t, func() {
-		Convey("When authenticated", func() {
-			Convey("When the dataset does not exist", func() {
+	Convey("Gieven Fail to get a list of time dimension options for a dataset", t, func() {
+		SkipConvey("When user is authenticated and the dataset does not exist", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When the edition does not exist", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
-			})
-
-			Convey("When there are no versions", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
-		Convey("When unauthenticated", func() {
-			Convey("When the dataset does not exist", func() {
+
+		SkipConvey("When user is authenticated and the edition does not exist", func() {
+			Convey("Then return status not found (404)", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+			})
+		})
+
+		Convey("When user is authenticated and there are no versions", func() {
+			Convey("Then return status not found (404)", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+			})
+		})
+
+		SkipConvey("When user is unauthenticated and the dataset does not exist", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).
-					Expect().Status(http.StatusBadRequest)
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
+		})
 
-			Convey("When the edition does not exist", func() {
+		SkipConvey("When user is unauthenticated and the edition does not exist", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").
-					Expect().Status(http.StatusBadRequest)
+					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 			})
+		})
 
-			Convey("When there are no published versions", func() {
+		Convey("When user is unauthenticated and there are no published versions", func() {
+			Convey("Then return status not found (404)", func() {
 				// Create an unpublished instance document
 				unpublishedInstance := &mongo.Doc{
 					Database:   cfg.MongoDB,
@@ -217,7 +226,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 				}
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).
-					Expect().Status(http.StatusBadRequest)
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
 
 				if err := mongo.Teardown(unpublishedInstance); err != nil {
 					if err != mgo.ErrNotFound {
@@ -230,19 +239,18 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 	})
 
 	SkipConvey("Given a valid dataset id, edition and version with no dimensions", t, func() {
-		Convey("When authenticated and get the time dimension options", func() {
-			Convey("Then the error code should be 404", func() {
+		Convey("When user is authenticated", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound)
+					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found\n")
 			})
-
 		})
-		Convey("When unauthenticated and get the time dimension options", func() {
-			Convey("Then the error code should be 404", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).
-					Expect().Status(http.StatusNotFound)
-			})
 
+		Convey("When user is unauthenticated", func() {
+			Convey("Then return status not found (404)", func() {
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, edition).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found\n")
+			})
 		})
 	})
 

--- a/datasetAPI/get_dimension_options_test.go
+++ b/datasetAPI/get_dimension_options_test.go
@@ -173,7 +173,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Gieven Fail to get a list of time dimension options for a dataset", t, func() {
+	Convey("Given Fail to get a list of time dimension options for a dataset", t, func() {
 		SkipConvey("When user is authenticated and the dataset does not exist", func() {
 			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).WithHeader(internalToken, internalTokenID).

--- a/datasetAPI/get_edition_test.go
+++ b/datasetAPI/get_edition_test.go
@@ -120,9 +120,9 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 
 	Convey("When the dataset does not exist", t, func() {
 		Convey("Given a request to get an edition of the dataset", func() {
-			Convey("Then the response returns a bad request (400)", func() {
+			Convey("Then the response returns status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest)
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 	})
@@ -135,9 +135,9 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 
 		Convey("but no editions exist against the dataset", func() {
 			Convey("Given a request to get an edition of the dataset", func() {
-				Convey("Then the response returns a not found (404)", func() {
+				Convey("Then the response returns status not found (404)", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).WithHeader(internalToken, internalTokenID).
-						Expect().Status(http.StatusNotFound)
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 		})
@@ -150,10 +150,10 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 			}
 
 			Convey("Given an unauthenticated request to get an edition of the dataset", func() {
-				Convey("Then the response returns a not found (404)", func() {
+				Convey("Then the response returns status not found (404)", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
-						Expect().Status(http.StatusNotFound)
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 		})

--- a/datasetAPI/get_editions_test.go
+++ b/datasetAPI/get_editions_test.go
@@ -116,10 +116,10 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 
 	Convey("Given the dataset does not exist", t, func() {
 		Convey("When a request to get editions for a dataset is made", func() {
-			Convey("Then return a status bad request (400)", func() {
+			Convey("Then return a status not found (404)", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions", datasetID).
-					Expect().Status(http.StatusBadRequest)
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 	})
@@ -135,7 +135,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 				Convey("Then return a status not found (404)", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions", datasetID).WithHeader(internalToken, internalTokenID).
-						Expect().Status(http.StatusNotFound)
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 		})
@@ -151,8 +151,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 				Convey("Then return a status not found (404)", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions", datasetID).
-						Expect().Status(http.StatusNotFound)
-
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 		})

--- a/datasetAPI/get_instance_dimension_options_test.go
+++ b/datasetAPI/get_instance_dimension_options_test.go
@@ -119,54 +119,62 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 	}
 }
 
-// TODO Reinstate tests once code has been fixed
-// func TestFailureToGetInstanceDimensionOptions(t *testing.T) {
-//
-// 	datasetID := uuid.NewV4().String()
-// 	instanceID := uuid.NewV4().String()
-//
-// 	edition := "2017"
-//
-// 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-//
-// 	Convey("Fail to get instance document", t, func() {
-// 		Convey("and return status bad request", func() {
-// 			Convey("when instance document does not exist", func() {
-// 				datasetAPI.GET("/instances/{id}/dimensions/time/options", "7990").WithHeader(internalToken, internalTokenID).
-// 					Expect().Status(http.StatusBadRequest)
-// 			})
-// 		})
-// 		Convey("and return status request is forbidden", func() {
-// 			Convey("when an unauthorised user sends a GET request", func() {
-// 				if err := mongo.Setup(database, "instances", "_id", "799", validEditionConfirmedInstanceData(datasetID, edition, instanceID)); err != nil {
-// 					log.ErrorC("Was unable to run test", err, nil)
-// 					os.Exit(1)
-// 				}
-//
-// 				datasetAPI.GET("/instances/{id}/dimensions/time/options", "789").
-// 					Expect().Status(http.StatusForbidden)
-// 			})
-// 		})
-//
-// 		Convey("and return status not unauthorised", func() {
-// 			Convey("when an invalid token is provided", func() {
-// 				datasetAPI.GET("/instances/{id}/dimensions/time/options", "789").WithHeader(internalToken, invalidInternalTokenID).
-// 					Expect().Status(http.StatusUnauthorized)
-// 			})
-// 		})
-//
-// 		Convey("and return status not found", func() {
-// 			Convey("dimension_id does not match any dimensions within the instance", func() {
-// 				datasetAPI.GET("/instances/{id}/dimensions/timeeww2342/options", "789").WithHeader(internalToken, internalTokenID).
-// 					Expect().Status(http.StatusNotFound)
-// 			})
-// 		})
-// 	})
-//
-// 	if err := mongo.Teardown(database, "instances", "_id", "799"); err != nil {
-// 		if err != mgo.ErrNotFound {
-// 			log.ErrorC("Failed to tear down test data", err, nil)
-// 			os.Exit(1)
-// 		}
-// 	}
-// }
+// TODO Reinstate skipped tests once code has been fixed
+func TestFailureToGetInstanceDimensionOptions(t *testing.T) {
+
+	datasetID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2017"
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Fail to get instance document", t, func() {
+		SkipConvey("when instance document does not exist", func() {
+			Convey("and return status not found", func() {
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", "7990").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
+			})
+		})
+		Convey("when an unauthorised user sends a GET request", func() {
+			SkipConvey("and return status not found", func() {
+				instanceDoc := &mongo.Doc{
+					Database:   cfg.MongoDB,
+					Collection: "instances",
+					Key:        "_id",
+					Value:      "799",
+					Update:     validEditionConfirmedInstanceData(datasetID, edition, instanceID),
+				}
+
+				if err := mongo.Setup(instanceDoc); err != nil {
+					log.ErrorC("Was unable to run test", err, nil)
+					os.Exit(1)
+				}
+
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", "789").
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+
+				if err := mongo.Teardown(instanceDoc); err != nil {
+					if err != mgo.ErrNotFound {
+						log.ErrorC("Failed to tear down test data", err, nil)
+						os.Exit(1)
+					}
+				}
+			})
+		})
+
+		SkipConvey("when an invalid token is provided", func() {
+			Convey("then return status not found", func() {
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", "789").WithHeader(internalToken, invalidInternalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		Convey("dimension_id does not match any dimensions within the instance", func() {
+			Convey("then return status not found", func() {
+				datasetAPI.GET("/instances/{id}/dimensions/timeeww2342/options", "789").WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dimension node not found\n")
+			})
+		})
+	})
+}

--- a/datasetAPI/get_instance_dimension_options_test.go
+++ b/datasetAPI/get_instance_dimension_options_test.go
@@ -5,12 +5,13 @@ import (
 	"os"
 	"testing"
 
+	mgo "gopkg.in/mgo.v2"
+
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	uuid "github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
-	mgo "gopkg.in/mgo.v2"
 )
 
 func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t *testing.T) {
@@ -20,6 +21,129 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 
 	edition := "2017"
 
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given a list of all unique time dimension options for an instance exists", t, func() {
+		docs, err := getInstanceDimensionOptionsSetup(datasetID, editionID, edition, instanceID)
+		if err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an authenticated user sends a GET request for a list of time options for instance", func() {
+			Convey("Then a list of time options is returned with a status of OK (200)", func() {
+
+				response := datasetAPI.GET("/instances/{instance_id}/dimensions/time/options", instanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				response.Value("dimension").Equal("time")
+				response.Value("values").Array().Element(0).Equal("202.45")
+			})
+		})
+
+		Convey("When an authenticated user sends a GET request for a list of aggregate options for instance", func() {
+			Convey("Then a list of aggregate options is returned with a status of OK (200)", func() {
+
+				response := datasetAPI.GET("/instances/{instance_id}/dimensions/aggregate/options", instanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				response.Value("dimension").Equal("aggregate")
+				response.Value("values").Array().Element(0).Equal("cpi1dimA19")
+			})
+		})
+
+		if err := mongo.Teardown(docs...); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
+	})
+}
+
+func TestFailureToGetInstanceDimensionOptions(t *testing.T) {
+
+	datasetID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2017"
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given an instance document does not exist", t, func() {
+		Convey("When a user sends a GET request for an instances dimension options without sending a token", func() {
+			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		Convey("When a user sends a GET request for an instances dimension options with an invalid token", func() {
+			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(internalToken, invalidInternalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		Convey("When an authenticated user sends a GET request for an instances dimension options", func() {
+			Convey("Then return status not found (404) with a message `Instance not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
+			})
+		})
+	})
+
+	Convey("Given an instance document does exist", t, func() {
+
+		instanceDoc := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: "instances",
+			Key:        "_id",
+			Value:      instanceID,
+			Update:     validEditionConfirmedInstanceData(datasetID, edition, instanceID),
+		}
+
+		if err := mongo.Setup(instanceDoc); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When a user sends a GET request for an instances dimension options without sending a token", func() {
+			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		Convey("When a user sends a GET request for an instances dimension options with an invalid token", func() {
+			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(internalToken, invalidInternalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		Convey("When an authenticated user sends a GET request for an instances dimension options", func() {
+			Convey("Then return status not found (404) with a message `Dimension node not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dimension node not found\n")
+			})
+		})
+
+		if err := mongo.Teardown(instanceDoc); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Failed to tear down test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+}
+
+func getInstanceDimensionOptionsSetup(datasetID, editionID, edition, instanceID string) ([]*mongo.Doc, error) {
 	var docs []*mongo.Doc
 
 	datasetDoc := &mongo.Doc{
@@ -65,116 +189,8 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)
 
 	if err := mongo.Setup(docs...); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
+		return nil, err
 	}
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
-	Convey("Get a list of all unique time  dimension options from an instance", t, func() {
-		Convey("When user is authenticated", func() {
-
-			response := datasetAPI.GET("/instances/{instance_id}/dimensions/time/options", instanceID).WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			response.Value("dimension").Equal("time")
-			response.Value("values").Array().Element(0).Equal("202.45")
-
-		})
-
-		Convey("When a user is not authenticated", func() {
-			response := datasetAPI.GET("/instances/{instance_id}/dimensions/time/options", instanceID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			response.Value("dimension").Equal("time")
-			response.Value("values").Array().Element(0).Equal("202.45")
-
-		})
-	})
-
-	Convey("Get a list of all unique aggregate dimension options from an instance", t, func() {
-		Convey("When user is authenticated", func() {
-
-			response := datasetAPI.GET("/instances/{instance_id}/dimensions/aggregate/options", instanceID).WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			response.Value("dimension").Equal("aggregate")
-			response.Value("values").Array().Element(0).Equal("cpi1dimA19")
-
-		})
-
-		Convey("When a user is not authenticated", func() {
-			response := datasetAPI.GET("/instances/{instance_id}/dimensions/aggregate/options", instanceID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			response.Value("dimension").Equal("aggregate")
-			response.Value("values").Array().Element(0).Equal("cpi1dimA19")
-
-		})
-	})
-
-	if err := mongo.Teardown(docs...); err != nil {
-		if err != mgo.ErrNotFound {
-			os.Exit(1)
-		}
-	}
-}
-
-// TODO Reinstate skipped tests once code has been fixed
-func TestFailureToGetInstanceDimensionOptions(t *testing.T) {
-
-	datasetID := uuid.NewV4().String()
-	instanceID := uuid.NewV4().String()
-
-	edition := "2017"
-
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-
-	Convey("Fail to get instance document", t, func() {
-		SkipConvey("when instance document does not exist", func() {
-			Convey("and return status not found", func() {
-				datasetAPI.GET("/instances/{id}/dimensions/time/options", "7990").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
-			})
-		})
-		Convey("when an unauthorised user sends a GET request", func() {
-			SkipConvey("and return status not found", func() {
-				instanceDoc := &mongo.Doc{
-					Database:   cfg.MongoDB,
-					Collection: "instances",
-					Key:        "_id",
-					Value:      "799",
-					Update:     validEditionConfirmedInstanceData(datasetID, edition, instanceID),
-				}
-
-				if err := mongo.Setup(instanceDoc); err != nil {
-					log.ErrorC("Was unable to run test", err, nil)
-					os.Exit(1)
-				}
-
-				datasetAPI.GET("/instances/{id}/dimensions/time/options", "789").
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
-
-				if err := mongo.Teardown(instanceDoc); err != nil {
-					if err != mgo.ErrNotFound {
-						log.ErrorC("Failed to tear down test data", err, nil)
-						os.Exit(1)
-					}
-				}
-			})
-		})
-
-		SkipConvey("when an invalid token is provided", func() {
-			Convey("then return status not found", func() {
-				datasetAPI.GET("/instances/{id}/dimensions/time/options", "789").WithHeader(internalToken, invalidInternalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
-			})
-		})
-
-		Convey("dimension_id does not match any dimensions within the instance", func() {
-			Convey("then return status not found", func() {
-				datasetAPI.GET("/instances/{id}/dimensions/timeeww2342/options", "789").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension node not found\n")
-			})
-		})
-	})
+	return docs, nil
 }

--- a/datasetAPI/get_instance_dimensions_test.go
+++ b/datasetAPI/get_instance_dimensions_test.go
@@ -123,10 +123,10 @@ func TestFailureToGetInstanceDimensions(t *testing.T) {
 		Convey("and return status not found", func() {
 			Convey("when instance document does not exist", func() {
 				datasetAPI.GET("/instances/{id}/dimensions", "7990").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound)
+					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
 			})
 		})
-		Convey("and return status request is forbidden", func() {
+		Convey("and return status not found", func() {
 			Convey("when an unauthorised user sends a GET request", func() {
 				if err := mongo.Setup(instance); err != nil {
 					log.ErrorC("Was unable to run test", err, nil)
@@ -134,14 +134,14 @@ func TestFailureToGetInstanceDimensions(t *testing.T) {
 				}
 
 				datasetAPI.GET("/instances/{id}/dimensions", "789").
-					Expect().Status(http.StatusForbidden)
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 
-		Convey("and return status not unauthorised", func() {
+		Convey("and return status not found", func() {
 			Convey("when an invalid token is provided", func() {
 				datasetAPI.GET("/instances/{id}/dimensions", "789").WithHeader(internalToken, invalidInternalTokenID).
-					Expect().Status(http.StatusUnauthorized)
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 	})

--- a/datasetAPI/get_instance_dimensions_test.go
+++ b/datasetAPI/get_instance_dimensions_test.go
@@ -107,7 +107,7 @@ func TestFailureToGetInstanceDimensions(t *testing.T) {
 			})
 		})
 
-		Convey("When an authenticated user sends a GET request of a list fo dimensions for instance", func() {
+		Convey("When an authenticated user sends a GET request of a list of dimensions for instance", func() {
 			Convey("Then return status not found (404) with a message `Instance not found`", func() {
 
 				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, internalTokenID).

--- a/datasetAPI/get_instance_dimensions_test.go
+++ b/datasetAPI/get_instance_dimensions_test.go
@@ -20,6 +20,179 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 
 	edition := "2017"
 
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given a list of dimensions for an instance exists", t, func() {
+		docs, err := getInstanceDimensionsSetup(datasetID, editionID, edition, instanceID)
+		if err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an authenticated user sends a GET request for a list of dimensions for instance", func() {
+			Convey("Then a list of dimensions is returned with a status of OK (200)", func() {
+
+				response := datasetAPI.GET("/instances/{instance_id}/dimensions", instanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				response.Value("items").Array().Length().Equal(2)
+
+				checkInstanceDimensionsResponse(response)
+			})
+		})
+
+		if err := mongo.Teardown(docs...); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Failed to tear down test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+
+	Convey("Given no dimensions exist for an existing instance", t, func() {
+		instance := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: "instances",
+			Key:        "_id",
+			Value:      instanceID,
+			Update:     validEditionConfirmedInstanceData(datasetID, edition, instanceID),
+		}
+
+		if err := mongo.Setup(instance); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an authenticated user sends a GET request for a list of dimensions for instance", func() {
+			Convey("Then return status OK (200) with an empty items array", func() {
+
+				dimensionsResource := datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusOK).JSON().Object()
+
+				dimensionsResource.Value("items").Null()
+			})
+		})
+
+		if err := mongo.Teardown(instance); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Failed to tear down test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+}
+
+func TestFailureToGetInstanceDimensions(t *testing.T) {
+	datasetID := uuid.NewV4().String()
+	instanceID := uuid.NewV4().String()
+
+	edition := "2017"
+
+	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+
+	Convey("Given an instance document does not exist", t, func() {
+		Convey("When a user sends a GET request of a list of dimensions for instance without sending a token", func() {
+			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions", instanceID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		Convey("When a user sends a GET request of a list of dimensions for instance with an invalid token", func() {
+			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, invalidInternalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		Convey("When an authenticated user sends a GET request of a list fo dimensions for instance", func() {
+			Convey("Then return status not found (404) with a message `Instance not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, internalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
+			})
+		})
+	})
+
+	Convey("Given an instance document does exist", t, func() {
+
+		instance := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: "instances",
+			Key:        "_id",
+			Value:      instanceID,
+			Update:     validEditionConfirmedInstanceData(datasetID, edition, instanceID),
+		}
+
+		if err := mongo.Setup(instance); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When a user sends a GET request for a list of dimensions for instance without sending a token", func() {
+			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions", instanceID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		Convey("When a user sends a GET request for a list of dimensions for instance with an invalid token", func() {
+			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+
+				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, invalidInternalTokenID).
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			})
+		})
+
+		if err := mongo.Teardown(instance); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("Failed to tear down test data", err, nil)
+				os.Exit(1)
+			}
+		}
+	})
+}
+
+func checkInstanceDimensionsResponse(response *httpexpect.Object) {
+
+	response.Value("items").Array().Element(0).Object().Value("dimension").Equal("time")
+
+	response.Value("items").Array().Element(0).Object().Value("label").Equal("")
+
+	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("code").Object().Value("id").Equal("202.45")
+	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("code").Object().Value("href").String().Match("(.+)/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/202.45$")
+
+	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("version").Object().Empty()
+
+	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("code_list").Object().Value("id").Equal("64d384f1-ea3b-445c-8fb8-aa453f96e58a")
+	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("code_list").Object().Value("href").String().Match("(.+)/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a$")
+
+	response.Value("items").Array().Element(0).Object().Value("option").Equal("202.45")
+
+	response.Value("items").Array().Element(0).Object().Value("node_id").Equal("")
+
+	response.Value("items").Array().Element(1).Object().Value("dimension").Equal("aggregate")
+
+	response.Value("items").Array().Element(1).Object().Value("label").Equal("CPI (Overall Index)")
+
+	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("code").Object().Value("id").Equal("cpi1dimA19")
+	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("code").Object().Value("href").String().Match("(.+)/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/cpi1dimA19$")
+
+	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("version").Object().Empty()
+
+	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("code_list").Object().Value("id").Equal("64d384f1-ea3b-445c-8fb8-aa453f96e58a")
+	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("code_list").Object().Value("href").String().Match("(.+)/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a$")
+
+	response.Value("items").Array().Element(1).Object().Value("option").Equal("cpi1dimA19")
+
+	response.Value("items").Array().Element(1).Object().Value("node_id").Equal("")
+
+}
+
+func getInstanceDimensionsSetup(datasetID, editionID, edition, instanceID string) ([]*mongo.Doc, error) {
 	var docs []*mongo.Doc
 
 	datasetDoc := &mongo.Doc{
@@ -65,127 +238,8 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)
 
 	if err := mongo.Setup(docs...); err != nil {
-		log.ErrorC("Was unable to run test", err, nil)
-		os.Exit(1)
-	}
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-
-	Convey("Get a list of all dimensions from an instance", t, func() {
-		Convey("When user is authenticated", func() {
-
-			response := datasetAPI.GET("/instances/{instance_id}/dimensions", instanceID).WithHeader(internalToken, internalTokenID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			response.Value("items").Array().Length().Equal(2)
-
-			checkInstanceDimensionsResponse(response)
-
-		})
-
-		Convey("When a user is not authenticated", func() {
-			response := datasetAPI.GET("/instances/{instance_id}/dimensions", instanceID).
-				Expect().Status(http.StatusOK).JSON().Object()
-
-			response.Value("items").Array().Length().Equal(2)
-
-			checkInstanceDimensionsResponse(response)
-
-		})
-	})
-
-	if err := mongo.Teardown(docs...); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Failed to tear down test data", err, nil)
-			os.Exit(1)
-		}
-	}
-}
-
-// TODO Remove skipped tests when code has been refactored (and hence fixed)
-// 1 test skipped
-func TestFailureToGetInstanceDimensions(t *testing.T) {
-	datasetID := uuid.NewV4().String()
-	instanceID := uuid.NewV4().String()
-
-	edition := "2017"
-
-	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
-
-	instance := &mongo.Doc{
-		Database:   cfg.MongoDB,
-		Collection: "instances",
-		Key:        "_id",
-		Value:      "799",
-		Update:     validEditionConfirmedInstanceData(datasetID, edition, instanceID),
+		return nil, err
 	}
 
-	SkipConvey("Fail to get instance document", t, func() {
-		Convey("and return status not found", func() {
-			Convey("when instance document does not exist", func() {
-				datasetAPI.GET("/instances/{id}/dimensions", "7990").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
-			})
-		})
-		Convey("and return status not found", func() {
-			Convey("when an unauthorised user sends a GET request", func() {
-				if err := mongo.Setup(instance); err != nil {
-					log.ErrorC("Was unable to run test", err, nil)
-					os.Exit(1)
-				}
-
-				datasetAPI.GET("/instances/{id}/dimensions", "789").
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
-			})
-		})
-
-		Convey("and return status not found", func() {
-			Convey("when an invalid token is provided", func() {
-				datasetAPI.GET("/instances/{id}/dimensions", "789").WithHeader(internalToken, invalidInternalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
-			})
-		})
-	})
-
-	if err := mongo.Teardown(instance); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Failed to tear down test data", err, nil)
-			os.Exit(1)
-		}
-	}
-}
-
-func checkInstanceDimensionsResponse(response *httpexpect.Object) {
-
-	response.Value("items").Array().Element(0).Object().Value("dimension").Equal("time")
-
-	response.Value("items").Array().Element(0).Object().Value("label").Equal("")
-
-	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("code").Object().Value("id").Equal("202.45")
-	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("code").Object().Value("href").String().Match("(.+)/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/202.45$")
-
-	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("version").Object().Empty()
-
-	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("code_list").Object().Value("id").Equal("64d384f1-ea3b-445c-8fb8-aa453f96e58a")
-	response.Value("items").Array().Element(0).Object().Value("links").Object().Value("code_list").Object().Value("href").String().Match("(.+)/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a$")
-
-	response.Value("items").Array().Element(0).Object().Value("option").Equal("202.45")
-
-	response.Value("items").Array().Element(0).Object().Value("node_id").Equal("")
-
-	response.Value("items").Array().Element(1).Object().Value("dimension").Equal("aggregate")
-
-	response.Value("items").Array().Element(1).Object().Value("label").Equal("CPI (Overall Index)")
-
-	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("code").Object().Value("id").Equal("cpi1dimA19")
-	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("code").Object().Value("href").String().Match("(.+)/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a/codes/cpi1dimA19$")
-
-	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("version").Object().Empty()
-
-	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("code_list").Object().Value("id").Equal("64d384f1-ea3b-445c-8fb8-aa453f96e58a")
-	response.Value("items").Array().Element(1).Object().Value("links").Object().Value("code_list").Object().Value("href").String().Match("(.+)/code-lists/64d384f1-ea3b-445c-8fb8-aa453f96e58a$")
-
-	response.Value("items").Array().Element(1).Object().Value("option").Equal("cpi1dimA19")
-
-	response.Value("items").Array().Element(1).Object().Value("node_id").Equal("")
-
+	return docs, nil
 }

--- a/datasetAPI/get_instance_test.go
+++ b/datasetAPI/get_instance_test.go
@@ -126,18 +126,18 @@ func TestFailureToGetInstance(t *testing.T) {
 			os.Exit(1)
 		}
 		Convey("When no authentication header is provided in request to get resource", func() {
-			Convey("Then return a status of unauthorised (401) with message `No authentication header provided`", func() {
+			Convey("Then return a status of not found (404) with message `Resource not found`", func() {
 
 				datasetAPI.GET("/instances/{id}", instanceID).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 
 		Convey("When an unauthorised request is made to get resource", func() {
-			Convey("Then return a status of unauthorised (401) with message `Unauthorised access to API`", func() {
+			Convey("Then return a status of not found (404) with message `Resource not found`", func() {
 
 				datasetAPI.GET("/instances/{id}", instanceID).WithHeader(internalToken, "wrong-header").
-					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 

--- a/datasetAPI/get_instances_test.go
+++ b/datasetAPI/get_instances_test.go
@@ -156,16 +156,16 @@ func TestFailureToGetAListOfInstances(t *testing.T) {
 		}
 
 		Convey("When no authentication header is provided in request to get list of resources", func() {
-			Convey("Then return a status of unauthorised (401) with message `No authentication header provided`", func() {
-				datasetAPI.GET("/instances").Expect().Status(http.StatusUnauthorized).
-					Body().Contains("No authentication header provided\n")
+			Convey("Then return a status of not found (404) with message `Resource not found`", func() {
+				datasetAPI.GET("/instances").Expect().Status(http.StatusNotFound).
+					Body().Contains("Resource not found\n")
 			})
 		})
 
 		Convey("When an unauthorised request is made to get resource", func() {
-			Convey("Then return a status of unauthorised (401) with message `Unauthorised access to API`", func() {
+			Convey("Then return a status of not found (404) with message `Resource not found`", func() {
 				datasetAPI.GET("/instances").WithHeader(internalToken, "wrong-header").
-					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 

--- a/datasetAPI/get_metadata_test.go
+++ b/datasetAPI/get_metadata_test.go
@@ -187,9 +187,9 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When an authorised request to get the metadata relevant to a version", func() {
-			Convey("Then return status bad request (400) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `Dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 	})
@@ -202,9 +202,9 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 
 		Convey("but an edition and version do not exist", func() {
 			Convey("When a request to get the metadata relevant to a version", func() {
-				Convey("Then return status bad request (400) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `Edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).WithHeader(internalToken, internalTokenID).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 		})
@@ -239,9 +239,9 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 		}
 
 		Convey("When an unauthorised request to get the metadate relevant to a version", func() {
-			Convey("Then return status bad request (400) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `Dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 
@@ -273,9 +273,9 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 			}
 
 			Convey("When an unauthorised request to get the metadata relevant to a version", func() {
-				Convey("Then return status bad request (400) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `Edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 

--- a/datasetAPI/get_version_test.go
+++ b/datasetAPI/get_version_test.go
@@ -149,9 +149,9 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When an authorised request to get the version of the dataset edition", func() {
-			Convey("Then return status bad request (400) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `Dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 	})
@@ -164,9 +164,9 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 		Convey("but an edition and version do not exist", func() {
 			Convey("When a request to get the version of the dataset edition", func() {
-				Convey("Then return status bad request (400) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `Edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", unpublishedDatasetID, edition).WithHeader(internalToken, internalTokenID).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 		})
@@ -201,9 +201,9 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 		}
 
 		Convey("When an unauthorised request to get the version of the dataset edition", func() {
-			Convey("Then return status bad request (400) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `Dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 
@@ -227,9 +227,9 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 			}
 
 			Convey("When an unauthorised request to get the version of the dataset edition", func() {
-				Convey("Then return status bad request (400) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `Edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 

--- a/datasetAPI/get_versions_test.go
+++ b/datasetAPI/get_versions_test.go
@@ -110,9 +110,9 @@ func TestGetVersions_Failed(t *testing.T) {
 
 	Convey("Given the dataset and subsequently the edition does not exist", t, func() {
 		Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
-			Convey("Then return status bad request (400)", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 	})
@@ -125,9 +125,9 @@ func TestGetVersions_Failed(t *testing.T) {
 
 		Convey("but the edition does not", func() {
 			Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
-				Convey("Then return status bad request (400)", func() {
+				Convey("Then return status not found (404)", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 		})
@@ -168,9 +168,9 @@ func TestGetVersions_Failed(t *testing.T) {
 		}
 
 		Convey("When an unauthenticated request is made to get a list of versions of the dataset edition", func() {
-			Convey("Then return status bad request (400)", func() {
+			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 
@@ -193,9 +193,9 @@ func TestGetVersions_Failed(t *testing.T) {
 			}
 
 			Convey("When an unauthenticated request is made to get a list of versions of the dataset edition", func() {
-				Convey("Then return status bad request (400)", func() {
+				Convey("Then return status not found (404)", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 				})
 			})
 

--- a/datasetAPI/post_dataset_test.go
+++ b/datasetAPI/post_dataset_test.go
@@ -92,18 +92,18 @@ func TestFailureToPostDataset(t *testing.T) {
 		})
 
 		Convey("When an unauthorised POST request is made to create a dataset resource with an invalid authentication header", func() {
-			Convey("Then return a status of unauthorized with a message `Unauthorised access to API`", func() {
+			Convey("Then return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 
 		Convey("When no authentication header is provided in POST request to create a dataset resource", func() {
-			Convey("Then return a status of unauthorized with a message `No authentication header provided`", func() {
+			Convey("Then return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 	})

--- a/datasetAPI/post_instance_test.go
+++ b/datasetAPI/post_instance_test.go
@@ -109,18 +109,18 @@ func TestFailureToPostInstance(t *testing.T) {
 
 	Convey("Given an unauthorised user wants to create an instance", t, func() {
 		Convey("When an unauthorised POST request is made to create an instance resource with an invalid authentication header", func() {
-			Convey("Then fail to create resource and return a status unauthorized (401) with a message `Unauthorised access to API`", func() {
+			Convey("Then fail to create resource and return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.POST("/instances").WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPOSTCreateInstanceJSON)).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 
 		Convey("When no authentication header is provided in PUT request to create an instance resource", func() {
-			Convey("Then fail to create resource and return a status of unauthorized (401) with a message `No authentication header provided`", func() {
+			Convey("Then fail to create resource and return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.POST("/instances").WithBytes([]byte(validPOSTCreateInstanceJSON)).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 	})

--- a/datasetAPI/put_dataset_test.go
+++ b/datasetAPI/put_dataset_test.go
@@ -185,18 +185,18 @@ func TestFailureToUpdateDataset(t *testing.T) {
 		}
 
 		Convey("When an unauthorised PUT request is made to update a dataset resource with an invalid authentication header", func() {
-			Convey("Then fail to update resource and return a status unauthorized (401) with a message `Unauthorised access to API`", func() {
+			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 
 		Convey("When no authentication header is provided in PUT request to update dataset resource", func() {
-			Convey("Then fail to update resource and return a status of unauthorized (401) with a message `No authentication header provided`", func() {
+			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 

--- a/datasetAPI/put_instance_test.go
+++ b/datasetAPI/put_instance_test.go
@@ -168,20 +168,19 @@ func TestFailureToPutInstance(t *testing.T) {
 		})
 
 		Convey("When an unauthorised PUT request is made to update an instance resource with an invalid authentication header", func() {
-			Convey("Then fail to update resource and return a status unauthorized (401) with a message `Unauthorised access to API`", func() {
+			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.PUT("/instances/{instance_id}", instanceID).WithBytes([]byte(validPUTFullInstanceJSON)).
-					WithHeader(internalToken, invalidInternalTokenID).Expect().Status(http.StatusUnauthorized).
-					Body().Contains("Unauthorised access to API\n")
+					WithHeader(internalToken, invalidInternalTokenID).Expect().Status(http.StatusNotFound).
+					Body().Contains("Resource not found\n")
 			})
 		})
 
 		Convey("When no authentication header is provided in PUT request to update an instance resource", func() {
-			Convey("Then fail to update resource and return a status of unauthorized (401) with a message `No authentication header provided`", func() {
+			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.PUT("/instances/{instance_id}", instanceID).WithBytes([]byte(validPUTFullInstanceJSON)).
-					Expect().Status(http.StatusUnauthorized).
-					Body().Contains("No authentication header provided\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 			})
 		})
 

--- a/datasetAPI/put_version_test.go
+++ b/datasetAPI/put_version_test.go
@@ -338,11 +338,11 @@ func TestFailureToUpdateVersion(t *testing.T) {
 		}
 
 		Convey("When an authorised PUT request is made to update version resource", func() {
-			Convey("Then fail to update resource and return a status of bad request (400) with a message `Dataset not found`", func() {
+			Convey("Then fail to update resource and return a status of not found (404) with a message `Dataset not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
 			})
 		})
 
@@ -364,11 +364,11 @@ func TestFailureToUpdateVersion(t *testing.T) {
 		}
 
 		Convey("When an authorised PUT request is made to update version resource", func() {
-			Convey("Then fail to update resource and return a status of bad request (400) with a message `Edition not found`", func() {
+			Convey("Then fail to update resource and return a status of not found (404) with a message `Edition not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Edition not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
 			})
 		})
 
@@ -451,22 +451,22 @@ func TestFailureToUpdateVersion(t *testing.T) {
 
 		// test for unauthorised request to update version
 		Convey("When an unauthorised PUT request is made to update version resource", func() {
-			Convey("Then fail to update resource and return a status of unauthorised (401) with a message `Unauthorised access to API`", func() {
+			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("Unauthorised access to API\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 
 			})
 		})
 
 		// test for missing auth header when making a request to update version
 		Convey("When a PUT request is made to update version resource without an authentication header", func() {
-			Convey("Then fail to update resource and return a status of unauthorised (401) with a message `No authentication header provided`", func() {
+			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).
-					Expect().Status(http.StatusUnauthorized).Body().Contains("No authentication header provided\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
 
 			})
 		})


### PR DESCRIPTION
### What

Update tests to reflect hiding authenticated endpoints. If a user calls an endpoint which requires authentication return not found to hide the fact that the endpoint exists due to securing unpublished data.

### How to review

Check changes make sense. Make sure tests pass when running `Make acceptance` on branch `feature/hide-auth-endpoints` on dp-dataset-api

### Who can review

Team B

#### Notes

This work is paired with this pull request: https://github.com/ONSdigital/dp-dataset-api/pull/89