### PR TITLE
Fix filter API tests and refer to version over instance

### DIFF
--- a/datasetAPI/get_dataset_dimensions_test.go
+++ b/datasetAPI/get_dataset_dimensions_test.go
@@ -27,7 +27,7 @@ func TestGetDimensions_ReturnsAllDimensionsFromADataset(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	editionDoc := &mongo.Doc{
@@ -35,7 +35,7 @@ func TestGetDimensions_ReturnsAllDimensionsFromADataset(t *testing.T) {
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceOneDoc := &mongo.Doc{
@@ -112,7 +112,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	editionDoc := &mongo.Doc{
@@ -120,7 +120,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceOneDoc := &mongo.Doc{

--- a/datasetAPI/get_dataset_test.go
+++ b/datasetAPI/get_dataset_test.go
@@ -23,7 +23,7 @@ func TestSuccessfullyGetADataset(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	if err := mongo.Setup(dataset); err != nil {

--- a/datasetAPI/get_datasets_test.go
+++ b/datasetAPI/get_datasets_test.go
@@ -27,7 +27,7 @@ func TestSuccessfulGetAListOfDatasets(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	unpublishedDatasetDoc := &mongo.Doc{

--- a/datasetAPI/get_dimension_options_test.go
+++ b/datasetAPI/get_dimension_options_test.go
@@ -27,7 +27,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	editionDoc := &mongo.Doc{
@@ -35,7 +35,7 @@ func TestGetDimensionOptions_ReturnsAllDimensionOptionsFromADataset(t *testing.T
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceOneDoc := &mongo.Doc{
@@ -137,7 +137,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	editionDoc := &mongo.Doc{
@@ -145,7 +145,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceOneDoc := &mongo.Doc{

--- a/datasetAPI/get_edition_test.go
+++ b/datasetAPI/get_edition_test.go
@@ -29,7 +29,7 @@ func TestSuccessfullyGetDatasetEdition(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	publishedEditionDoc := &mongo.Doc{
@@ -37,7 +37,7 @@ func TestSuccessfullyGetDatasetEdition(t *testing.T) {
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	unpublishedEditionDoc := &mongo.Doc{
@@ -107,7 +107,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	unpublishedEditionDoc := &mongo.Doc{

--- a/datasetAPI/get_editions_test.go
+++ b/datasetAPI/get_editions_test.go
@@ -27,7 +27,7 @@ func TestSuccessfullyGetListOfDatasetEditions(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	publishedEditionDoc := &mongo.Doc{
@@ -35,7 +35,7 @@ func TestSuccessfullyGetListOfDatasetEditions(t *testing.T) {
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, "2017"),
+		Update:     ValidPublishedEditionData(datasetID, editionID, "2017"),
 	}
 
 	unpublishedEditionDoc := &mongo.Doc{
@@ -103,7 +103,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	unpublishedEdition := &mongo.Doc{

--- a/datasetAPI/get_instance_dimension_options_test.go
+++ b/datasetAPI/get_instance_dimension_options_test.go
@@ -151,7 +151,7 @@ func getInstanceDimensionOptionsSetup(datasetID, editionID, edition, instanceID 
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	editionDoc := &mongo.Doc{
@@ -159,7 +159,7 @@ func getInstanceDimensionOptionsSetup(datasetID, editionID, edition, instanceID 
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceOneDoc := &mongo.Doc{

--- a/datasetAPI/get_instance_dimensions_test.go
+++ b/datasetAPI/get_instance_dimensions_test.go
@@ -20,6 +20,54 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 
 	edition := "2017"
 
+	var docs []*mongo.Doc
+
+	datasetDoc := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
+	}
+
+	editionDoc := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "editions",
+		Key:        "_id",
+		Value:      editionID,
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
+	}
+
+	instanceOneDoc := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "instances",
+		Key:        "_id",
+		Value:      instanceID,
+		Update:     validPublishedInstanceData(datasetID, edition, instanceID),
+	}
+
+	dimensionOneDoc := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "dimension.options",
+		Key:        "_id",
+		Value:      "9811",
+		Update:     validTimeDimensionsData(instanceID),
+	}
+
+	dimensionTwoDoc := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "dimension.options",
+		Key:        "_id",
+		Value:      "9812",
+		Update:     validAggregateDimensionsData(instanceID),
+	}
+
+	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)
+
+	if err := mongo.Setup(docs...); err != nil {
+		log.ErrorC("Was unable to run test", err, nil)
+		os.Exit(1)
+	}
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
 	Convey("Given a list of dimensions for an instance exists", t, func() {
@@ -200,7 +248,7 @@ func getInstanceDimensionsSetup(datasetID, editionID, edition, instanceID string
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	editionDoc := &mongo.Doc{
@@ -208,7 +256,7 @@ func getInstanceDimensionsSetup(datasetID, editionID, edition, instanceID string
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceOneDoc := &mongo.Doc{

--- a/datasetAPI/get_metadata_test.go
+++ b/datasetAPI/get_metadata_test.go
@@ -257,7 +257,7 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 			Collection: collection,
 			Key:        "_id",
 			Value:      datasetID,
-			Update:     validPublishedWithUpdatesDatasetData(datasetID),
+			Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 		}
 
 		if err := mongo.Setup(publishedDataset); err != nil {
@@ -291,7 +291,7 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 				Collection: "editions",
 				Key:        "_id",
 				Value:      editionID,
-				Update:     validPublishedEditionData(datasetID, editionID, edition),
+				Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 			}
 
 			associatedInstance := &mongo.Doc{
@@ -335,7 +335,7 @@ func setupMetadataDocs(datasetID, editionID, edition, instanceID, unpublishedIns
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	publishedEditionDoc := &mongo.Doc{
@@ -343,7 +343,7 @@ func setupMetadataDocs(datasetID, editionID, edition, instanceID, unpublishedIns
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	publishedVersionDoc := &mongo.Doc{

--- a/datasetAPI/get_version_test.go
+++ b/datasetAPI/get_version_test.go
@@ -136,7 +136,7 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	unpublishedEdition := &mongo.Doc{
@@ -245,7 +245,7 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 				Collection: "editions",
 				Key:        "_id",
 				Value:      editionID,
-				Update:     validPublishedEditionData(datasetID, editionID, edition),
+				Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 			}
 
 			unpublishedInstance := &mongo.Doc{
@@ -284,7 +284,7 @@ func setupPublishedAndUnpublishedVersions(datasetID, editionID, edition, instanc
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	publishedEditionDoc := &mongo.Doc{
@@ -292,7 +292,7 @@ func setupPublishedAndUnpublishedVersions(datasetID, editionID, edition, instanc
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	publishedVersionDoc := &mongo.Doc{

--- a/datasetAPI/get_versions_test.go
+++ b/datasetAPI/get_versions_test.go
@@ -89,7 +89,7 @@ func TestGetVersions_Failed(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	publishedEdition := &mongo.Doc{
@@ -97,7 +97,7 @@ func TestGetVersions_Failed(t *testing.T) {
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	unpublishedEdition := &mongo.Doc{
@@ -283,7 +283,7 @@ func setUpDatasetEditionVersions(datasetID, editionID, edition, instanceID, unpu
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	editionDoc := &mongo.Doc{
@@ -291,7 +291,7 @@ func setUpDatasetEditionVersions(datasetID, editionID, edition, instanceID, unpu
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	instanceDoc := &mongo.Doc{

--- a/datasetAPI/json.go
+++ b/datasetAPI/json.go
@@ -67,7 +67,8 @@ var temporal = mongo.TemporalFrequency{
 	StartDate: "2014-09-09",
 }
 
-func validPublishedWithUpdatesDatasetData(datasetID string) bson.M {
+// ValidPublishedWithUpdatesDatasetData returns an example of a published dataset
+func ValidPublishedWithUpdatesDatasetData(datasetID string) bson.M {
 	return bson.M{
 		"$set": bson.M{
 			"id": datasetID,
@@ -327,7 +328,8 @@ func validAggregateDimensionsData(instanceID string) bson.M {
 	}
 }
 
-func validPublishedEditionData(datasetID, editionID, edition string) bson.M {
+// ValidPublishedEditionData returns an example bson object fo a published edition resource
+func ValidPublishedEditionData(datasetID, editionID, edition string) bson.M {
 	return bson.M{
 		"$set": bson.M{
 			"edition":                   edition,

--- a/datasetAPI/post_dataset_test.go
+++ b/datasetAPI/post_dataset_test.go
@@ -114,7 +114,7 @@ func TestFailureToPostDataset(t *testing.T) {
 			Collection: collection,
 			Key:        "_id",
 			Value:      datasetID,
-			Update:     validPublishedWithUpdatesDatasetData(datasetID),
+			Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 		}
 
 		if err := mongo.Setup(publishedDataset); err != nil {

--- a/datasetAPI/put_dataset_test.go
+++ b/datasetAPI/put_dataset_test.go
@@ -33,7 +33,7 @@ func TestSuccessfullyUpdateDataset(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	Convey("Given a published dataset already exists", t, func() {
@@ -164,7 +164,7 @@ func TestFailureToUpdateDataset(t *testing.T) {
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	Convey("Given a published dataset does not exist", t, func() {

--- a/datasetAPI/put_instance_test.go
+++ b/datasetAPI/put_instance_test.go
@@ -271,7 +271,7 @@ func setupInstance(datasetID, edition, instanceID string) ([]*mongo.Doc, error) 
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	instanceOneDoc := &mongo.Doc{

--- a/datasetAPI/put_version_test.go
+++ b/datasetAPI/put_version_test.go
@@ -526,7 +526,7 @@ func setupResources(datasetID, editionID, edition, instanceID string, setup int)
 		Collection: "datasets",
 		Key:        "_id",
 		Value:      datasetID,
-		Update:     validPublishedWithUpdatesDatasetData(datasetID),
+		Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
 	}
 
 	associatedDatasetDoc := &mongo.Doc{
@@ -550,7 +550,7 @@ func setupResources(datasetID, editionID, edition, instanceID string, setup int)
 		Collection: "editions",
 		Key:        "_id",
 		Value:      editionID,
-		Update:     validPublishedEditionData(datasetID, editionID, edition),
+		Update:     ValidPublishedEditionData(datasetID, editionID, edition),
 	}
 
 	unpublishedEditionDoc := &mongo.Doc{

--- a/endToEndTests/end_to_end_api_test.go
+++ b/endToEndTests/end_to_end_api_test.go
@@ -524,8 +524,10 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 				So(xlsFileSize, ShouldResemble, &expectedXLSFileSize)
 
 				Convey("Then an api customer should be able to filter a dataset and be able to download a csv and xlsx download of the data", func() {
+					json := GetValidPOSTCreateFilterJSON(datasetName, "2017", "1")
+					log.Info("ajhgjlabfjlarebvjkrbvqlj", log.Data{"json": json})
 					filterBlueprintResponse := filterAPI.POST("/filters").WithQuery("submitted", "true").
-						WithBytes([]byte(GetValidPOSTCreateFilterJSON(instanceID))).Expect().Status(http.StatusCreated).JSON().Object()
+						WithBytes([]byte(json)).Expect().Status(http.StatusCreated).JSON().Object()
 
 					filterBlueprintID := filterBlueprintResponse.Value("filter_id").String().Raw()
 
@@ -543,6 +545,8 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 					filterBlueprintResponse.Value("links").Object().Value("version").Object().Value("id").Equal("1")
 					filterBlueprintResponse.Value("links").Object().Value("filter_output").Object().Value("href").String().Match("/filter-outputs/(.+)$")
 					filterBlueprintResponse.Value("links").Object().Value("filter_output").Object().Value("id").NotNull()
+
+					log.Info("filter response", log.Data{"resp": filterBlueprintResponse.Raw()})
 
 					filterOutputID := filterBlueprintResponse.Value("links").Object().Value("filter_output").Object().Value("id").String().Raw()
 

--- a/endToEndTests/json.go
+++ b/endToEndTests/json.go
@@ -13,9 +13,13 @@ func createValidJobJSON(recipe, location string) string {
 	return body
 }
 
-func GetValidPOSTCreateFilterJSON(instanceID string) string {
+func GetValidPOSTCreateFilterJSON(datasetID, edition, version string) string {
 	return `{
-	"instance_id": "` + instanceID + `" ,
+	"dataset": {
+		"id": "` + datasetID + `",
+		"edition": "` + edition + `",
+		"version": ` + version + `
+	},
 	"dimensions": [
   	{
 	  	"name": "geography",

--- a/filterAPI/delete_dimension_option_test.go
+++ b/filterAPI/delete_dimension_option_test.go
@@ -19,13 +19,16 @@ func TestSuccessfullyDeleteDimensionOptions(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	instance := &mongo.Doc{
 		Database:   cfg.MongoDB,
 		Collection: "instances",
 		Key:        "instance_id",
 		Value:      instanceID,
-		Update:     GetValidPublishedInstanceDataBSON(instanceID),
+		Update:     GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition, version),
 	}
 
 	filter := &mongo.Doc{
@@ -33,7 +36,7 @@ func TestSuccessfullyDeleteDimensionOptions(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	docs := []*mongo.Doc{instance, filter}
@@ -82,13 +85,16 @@ func TestFailureToDeleteDimensionOptions(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filter := &mongo.Doc{
 		Database:   cfg.MongoFiltersDB,
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given filter job does not exist", t, func() {

--- a/filterAPI/delete_dimension_test.go
+++ b/filterAPI/delete_dimension_test.go
@@ -17,6 +17,9 @@ func TestSuccessfullyDeleteDimension(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -25,7 +28,7 @@ func TestSuccessfullyDeleteDimension(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given an existing filter blueprint", t, func() {
@@ -85,6 +88,9 @@ func TestFailureToDeleteDimension(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -93,7 +99,7 @@ func TestFailureToDeleteDimension(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given filter blueprint does not exist", t, func() {

--- a/filterAPI/expectedTestData/filterJobWithDimensions.go
+++ b/filterAPI/expectedTestData/filterJobWithDimensions.go
@@ -1,6 +1,10 @@
 package expectedTestData
 
-import "github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
+import (
+	"strconv"
+
+	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
+)
 
 func age(host, filterBlueprintID string) mongo.Dimension {
 	if filterBlueprintID == "" {
@@ -145,7 +149,7 @@ func ExpectedFilterOutput(host, instanceID, filterOutputID, filterBlueprintID st
 }
 
 // ExpectedFilterOutputOnPost represents the expected data stored against a filter output resource
-func ExpectedFilterOutputOnPost(host, instanceID, filterOutputID, filterBlueprintID string) mongo.Filter {
+func ExpectedFilterOutputOnPost(host, datasetID, edition, instanceID, filterOutputID, filterBlueprintID string, version int) mongo.Filter {
 	return mongo.Filter{
 		FilterID:   filterOutputID,
 		InstanceID: instanceID,
@@ -176,7 +180,7 @@ func ExpectedFilterOutputOnPost(host, instanceID, filterOutputID, filterBlueprin
 			},
 			Version: mongo.LinkObject{
 				ID:   "1",
-				HRef: "http://localhost:8080/datasets/123/editions/2017/versions/1",
+				HRef: "http://localhost:8080/datasets/" + datasetID + "/editions/" + edition + "/versions/" + strconv.Itoa(version),
 			},
 		},
 		State: "created",

--- a/filterAPI/get_dimension_option_test.go
+++ b/filterAPI/get_dimension_option_test.go
@@ -17,6 +17,9 @@ func TestSuccessfullyGetDimensionOption(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -25,7 +28,7 @@ func TestSuccessfullyGetDimensionOption(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given an existing filter", t, func() {
@@ -88,6 +91,9 @@ func TestFailureToGetDimensionOption(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -96,7 +102,7 @@ func TestFailureToGetDimensionOption(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given a filter blueprint does not exist", t, func() {

--- a/filterAPI/get_dimension_options_test.go
+++ b/filterAPI/get_dimension_options_test.go
@@ -17,6 +17,9 @@ func TestSuccessfullyGetListOfDimensionOptions(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -25,7 +28,7 @@ func TestSuccessfullyGetListOfDimensionOptions(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given an existing filter blueprint with dimensions and options", t, func() {
@@ -106,6 +109,9 @@ func TestFailureToGetListOfDimensionOptions(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -114,7 +120,7 @@ func TestFailureToGetListOfDimensionOptions(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given a filter blueprint does not exist", t, func() {

--- a/filterAPI/get_dimension_test.go
+++ b/filterAPI/get_dimension_test.go
@@ -17,6 +17,9 @@ func TestSuccessfullyGetDimension(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -25,7 +28,7 @@ func TestSuccessfullyGetDimension(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given an existing filter", t, func() {
@@ -70,6 +73,9 @@ func TestFailureToGetDimension(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -78,7 +84,7 @@ func TestFailureToGetDimension(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given filter blueprint does not exist", t, func() {

--- a/filterAPI/get_dimensions_test.go
+++ b/filterAPI/get_dimensions_test.go
@@ -17,6 +17,9 @@ func TestSuccessfullyGetListOfDimensions(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -25,7 +28,7 @@ func TestSuccessfullyGetListOfDimensions(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given an existing filter", t, func() {

--- a/filterAPI/get_filter_blueprint_test.go
+++ b/filterAPI/get_filter_blueprint_test.go
@@ -17,6 +17,9 @@ func TestSuccessfullyGetFilterBlueprint(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -25,7 +28,7 @@ func TestSuccessfullyGetFilterBlueprint(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	Convey("Given an existing filter", t, func() {

--- a/filterAPI/json.go
+++ b/filterAPI/json.go
@@ -1,16 +1,20 @@
 package filterAPI
 
 import (
+	"strconv"
 	"time"
 
 	"gopkg.in/mgo.v2/bson"
 )
 
-func GetValidPublishedInstanceDataBSON(instanceID string) bson.M {
+func GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition string, version int) bson.M {
 	return bson.M{
 		"$set": bson.M{
 			"_id":                   instanceID,
 			"collection_id":         "108064B3-A808-449B-9041-EA3A2F72CFAA",
+			"dataset.id":            datasetID,
+			"dataset.edition":       edition,
+			"dataset.version":       version,
 			"downloads.csv.url":     "http://localhost:8080/aws/census-2017-1-csv",
 			"downloads.csv.size":    "10mb",
 			"downloads.xls.url":     "http://localhost:8080/aws/census-2017-1-xls",
@@ -22,29 +26,32 @@ func GetValidPublishedInstanceDataBSON(instanceID string) bson.M {
 			"license":               "ONS License",
 			"links.job.id":          "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
 			"links.job.href":        "http://localhost:8080/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-			"links.dataset.id":      "123",
-			"links.dataset.href":    "http://localhost:8080/datasets/123",
-			"links.dimensions.href": "http://localhost:8080/datasets/123/editions/2017/versions/1/dimensions",
-			"links.edition.id":      "2017",
-			"links.edition.href":    "http://localhost:8080/datasets/123/editions/2017",
+			"links.dataset.id":      datasetID,
+			"links.dataset.href":    "http://localhost:8080/datasets/" + datasetID,
+			"links.dimensions.href": "http://localhost:8080/datasets/" + datasetID + "/editions/" + edition + "/versions/" + strconv.Itoa(version) + "/dimensions",
+			"links.edition.id":      edition,
+			"links.edition.href":    "http://localhost:8080/datasets/" + datasetID + "/editions/" + edition,
 			"links.self.href":       "http://localhost:8080/instances/" + instanceID,
-			"links.version.href":    "http://localhost:8080/datasets/123/editions/2017/versions/1",
-			"links.version.id":      "1",
+			"links.version.href":    "http://localhost:8080/datasets/" + datasetID + "/editions/" + edition + "/versions/" + strconv.Itoa(version),
+			"links.version.id":      strconv.Itoa(version),
 			"release_date":          "2017-12-12", // TODO Should be isodate
 			"state":                 "published",
 			"total_inserted_observations": 1000,
 			"total_observations":          1000,
-			"version":                     1,
+			"version":                     version,
 			"test_data":                   "true",
 		},
 	}
 }
 
-func GetUnpublishedInstanceDataBSON(instanceID string) bson.M {
+func GetUnpublishedInstanceDataBSON(instanceID string, datasetID, edition string, version int) bson.M {
 	return bson.M{
 		"$set": bson.M{
 			"_id":                   instanceID,
 			"collection_id":         "108064B3-A808-449B-9041-EA3A2F72CFAA",
+			"dataset.id":            datasetID,
+			"dataset.edition":       edition,
+			"dataset.version":       version,
 			"downloads.csv.url":     "http://localhost:8080/aws/census-2017-1-csv",
 			"downloads.csv.size":    "10mb",
 			"downloads.xls.url":     "http://localhost:8080/aws/census-2017-1-xls",
@@ -56,10 +63,10 @@ func GetUnpublishedInstanceDataBSON(instanceID string) bson.M {
 			"license":               "ONS License",
 			"links.job.id":          "042e216a-7822-4fa0-a3d6-e3f5248ffc35",
 			"links.job.href":        "http://localhost:8080/jobs/042e216a-7822-4fa0-a3d6-e3f5248ffc35",
-			"links.dataset.id":      "123",
+			"links.dataset.id":      datasetID,
 			"links.dataset.href":    "http://localhost:8080/datasets/123",
 			"links.dimensions.href": "http://localhost:8080/datasets/123/editions/2017/versions/1/dimensions",
-			"links.edition.id":      "2017",
+			"links.edition.id":      edition,
 			"links.edition.href":    "http://localhost:8080/datasets/123/editions/2017",
 			"links.self.href":       "http://localhost:8080/instances/" + instanceID,
 			"links.version.href":    "http://localhost:8080/datasets/123/editions/2017/versions/1",
@@ -88,10 +95,13 @@ func dimension(host, filterBlueprintID string) Dimension {
 	}
 }
 
-func GetValidCreatedFilterBlueprintBSON(host, filterID, instanceID, filterBlueprintID string) bson.M {
+func GetValidCreatedFilterBlueprintBSON(host, filterID, instanceID, filterBlueprintID, datasetID, edition string, version int) bson.M {
 	return bson.M{
 		"$set": bson.M{
-			"_id": filterID,
+			"_id":             filterID,
+			"dataset.id":      datasetID,
+			"dataset.edition": edition,
+			"dataset.version": version,
 			"dimensions": []Dimension{
 				dimension(host, filterBlueprintID),
 			},
@@ -162,10 +172,13 @@ func timeDimension(host, filterID string) Dimension {
 	}
 }
 
-func GetValidFilterWithMultipleDimensionsBSON(host, filterID, instanceID, filterBlueprintID string) bson.M {
+func GetValidFilterWithMultipleDimensionsBSON(host, filterID, instanceID, datasetID, edition, filterBlueprintID string, version int) bson.M {
 	return bson.M{
 		"$set": bson.M{
 			"_id":                   filterID,
+			"dataset.id":            datasetID,
+			"dataset.edition":       edition,
+			"dataset.version":       version,
 			"dimensions":            []Dimension{ageDimension(host, filterBlueprintID), sexDimension(host, filterBlueprintID), goodsAndServicesDimension(host, filterBlueprintID), timeDimension(host, filterBlueprintID)},
 			"instance_id":           instanceID,
 			"filter_id":             filterBlueprintID,
@@ -249,10 +262,13 @@ func GetValidFilterOutputNoDimensionsBSON(host, filterID, instanceID, filterOutp
 	}
 }
 
-func GetValidFilterOutputWithoutDownloadsBSON(host, filterID, instanceID, filterOutputID string) bson.M {
+func GetValidFilterOutputWithoutDownloadsBSON(host, filterID, instanceID, filterOutputID, datasetID, edition string, version int) bson.M {
 	return bson.M{
 		"$set": bson.M{
 			"_id":                filterID,
+			"dataset.id":         datasetID,
+			"dataset.edition":    edition,
+			"dataset.version":    version,
 			"dimensions":         []Dimension{ageDimension(host, ""), sexDimension(host, ""), goodsAndServicesDimension(host, ""), timeDimension(host, "")},
 			"instance_id":        instanceID,
 			"filter_id":          filterOutputID,
@@ -384,22 +400,26 @@ func GetValidResidenceTypeDimensionData(instanceID, option string) bson.M {
 	}
 }
 
-func GetValidPOSTCreateFilterJSON(instanceID string) string {
+func GetValidPOSTCreateFilterJSON(datasetID, edition string, version int) string {
 	return `{
-	"instance_id": "` + instanceID + `" ,
+	"dataset": {
+		"id": "` + datasetID + `",
+		"edition": "` + edition + `",
+		"version": ` + strconv.Itoa(version) + `
+	},
 	"dimensions": [
 	  {
-		"name": "age",
-		"options": [
-		  "27", "42"
-		]
+		  "name": "age",
+		  "options": [
+		    "27", "42"
+		  ]
 	  }
 	]
-  }`
+}`
 }
 
 // Invalid Json body without dataset filter id
-func GetInvalidJSON(instanceID string) string {
+func GetInvalidJSON() string {
 	return `
 {
 	"dimensions": [
@@ -414,50 +434,58 @@ func GetInvalidJSON(instanceID string) string {
 }
 
 // GetInvalidDimensionJSON contains an invalid dimension for instance
-func GetInvalidDimensionJSON(instanceID string) string {
+func GetInvalidDimensionJSON(datasetID, edition string, version int) string {
 	return `
-{
-	"instance_id": "` + instanceID + `",
-	"dimensions": [
-	  {
-		"name": "weight",
-		"options": [
-		  "27", "42"
+	{
+		"dataset": {
+			"id": "` + datasetID + `",
+			"edition": "` + edition + `",
+			"version": ` + strconv.Itoa(version) + `
+		},
+		"dimensions": [
+	  	{
+			"name": "weight",
+			"options": [
+		  	"27", "42"
+				]
+	  	}
 		]
-	  }
-	]
 	}`
 }
 
 // GetInvalidDimensionOptionJSON contains an invalid dimension for instance
-func GetInvalidDimensionOptionJSON(instanceID string) string {
+func GetInvalidDimensionOptionJSON(datasetID, edition string, version int) string {
 	return `
-{
-	"instance_id": "` + instanceID + `",
-	"dimensions": [
-	  {
-		"name": "age",
-		"options": [
-		  "27", "33"
+	{
+		"dataset": {
+			"id": "` + datasetID + `",
+			"edition": "` + edition + `",
+			"version": ` + strconv.Itoa(version) + `
+		},
+		"dimensions": [
+	  	{
+			"name": "age",
+			"options": [
+		  	"27", "33"
+				]
+	  	}
 		]
-	  }
-	]
 	}`
 }
 
 // GetValidPUTUpdateFilterBlueprintJSON Json body with state and new dimension options
 func GetValidPUTUpdateFilterBlueprintJSON(instanceID string) string {
 	return `
-{
-	"instance_id": "` + instanceID + `" ,
-	"dimensions": [
-	  {
-		"name": "sex",
-		"options": [
-		  "intersex", "other"
+	{
+		"instance_id": "` + instanceID + `" ,
+		"dimensions": [
+	  	{
+				"name": "sex",
+				"options": [
+		  		"intersex", "other"
+				]
+	  	}
 		]
-	  }
-	]
 	}`
 }
 
@@ -494,9 +522,11 @@ func GetInvalidPOSTDimensionToFilterBlueprintJSON() string {
 }`
 }
 
-func GetValidPUTFilterBlueprintJSON(instanceID string, time time.Time) string {
+func GetValidPUTFilterBlueprintJSON(version int, time time.Time) string {
 	return `{
-	  "instance_id": "` + instanceID + `",
+	  "dataset": {
+			"version": ` + strconv.Itoa(version) + `
+		},
 	  "events": {
 		  "info": [
 		    {
@@ -507,6 +537,22 @@ func GetValidPUTFilterBlueprintJSON(instanceID string, time time.Time) string {
 	    ]
 		}
   }`
+}
+
+func GetInValidPUTFilterBlueprintJSON(id, edition string, version int, time time.Time) string {
+	json := `{"dataset": {`
+
+	if id != "" {
+		json = json + `"id": "` + id + `",`
+	}
+
+	if edition != "" {
+		json = json + `"edition": "` + edition + `",`
+	}
+
+	json = json + `"version": ` + strconv.Itoa(version) + `}}`
+
+	return json
 }
 
 func GetValidPUTFilterOutputWithCSVDownloadJSON() string {

--- a/filterAPI/post_dimension_option_test.go
+++ b/filterAPI/post_dimension_option_test.go
@@ -17,6 +17,9 @@ func TestSuccessfulPostDimensionOptions(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -25,7 +28,7 @@ func TestSuccessfulPostDimensionOptions(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	instance := &mongo.Doc{
@@ -33,9 +36,8 @@ func TestSuccessfulPostDimensionOptions(t *testing.T) {
 		Collection: "instances",
 		Key:        "instance_id",
 		Value:      instanceID,
-		Update:     GetValidPublishedInstanceDataBSON(instanceID),
+		Update:     GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition, version),
 	}
-
 	docs := setupMultipleDimensionsAndOptions(instanceID)
 	docs = append(docs, instance, filter)
 
@@ -84,6 +86,9 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -94,7 +99,7 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidCreatedFilterBlueprintBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidCreatedFilterBlueprintBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID, datasetID, edition, version),
 	}
 
 	instance := &mongo.Doc{
@@ -102,7 +107,7 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 		Collection: "instances",
 		Key:        "instance_id",
 		Value:      instanceID,
-		Update:     GetValidPublishedInstanceDataBSON(instanceID),
+		Update:     GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition, version),
 	}
 
 	option := setupDimensionOptions(uuid.NewV4().String(), GetValidAgeDimensionData(instanceID, "27"))
@@ -128,15 +133,15 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 			os.Exit(1)
 		}
 
-		Convey("When a post request to add an option for a dimension for an instance that does not exist", func() {
+		Convey("When a post request to add an option for a dimension for a version of a dataset that does not exist", func() {
 			Convey("Then return status unprocessable entity (422)", func() {
 
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/sex/options/male", filterBlueprintID).
-					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("Unprocessable entity - instance for filter blueprint no longer exists\n")
+					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("Unprocessable entity - version for filter blueprint no longer exists\n")
 			})
 		})
 
-		Convey("And the instance that is associated with this filter blueprint does exist", func() {
+		Convey("And the version that is associated with this filter blueprint does exist", func() {
 			if err := mongo.Setup(instance); err != nil {
 				log.ErrorC("Unable to setup instance test resource", err, nil)
 				os.Exit(1)

--- a/filterAPI/post_dimension_test.go
+++ b/filterAPI/post_dimension_test.go
@@ -18,6 +18,9 @@ func TestSuccessfullyPostDimension(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -26,7 +29,7 @@ func TestSuccessfullyPostDimension(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	instance := &mongo.Doc{
@@ -34,7 +37,7 @@ func TestSuccessfullyPostDimension(t *testing.T) {
 		Collection: "instances",
 		Key:        "instance_id",
 		Value:      instanceID,
-		Update:     GetValidPublishedInstanceDataBSON(instanceID),
+		Update:     GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition, version),
 	}
 
 	docs := setupMultipleDimensionsAndOptions(instanceID)
@@ -110,6 +113,9 @@ func TestFailureToPostDimension(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -120,7 +126,7 @@ func TestFailureToPostDimension(t *testing.T) {
 		Collection: collection,
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, filterBlueprintID),
+		Update:     GetValidFilterWithMultipleDimensionsBSON(cfg.FilterAPIURL, filterID, instanceID, datasetID, edition, filterBlueprintID, version),
 	}
 
 	instance := &mongo.Doc{
@@ -128,7 +134,7 @@ func TestFailureToPostDimension(t *testing.T) {
 		Collection: "instances",
 		Key:        "instance_id",
 		Value:      instanceID,
-		Update:     GetValidPublishedInstanceDataBSON(instanceID),
+		Update:     GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition, version),
 	}
 
 	dimensions := setupMultipleDimensionsAndOptions(instanceID)
@@ -163,23 +169,23 @@ func TestFailureToPostDimension(t *testing.T) {
 			})
 		})
 
-		Convey("When the instance does not exist for filter blueprint", func() {
+		Convey("When the version associated with filter blueprint no longer exists", func() {
 			Convey("Then the response returns a status unprocessable entity (422)", func() {
 
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "Residence Type").
 					WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("Unprocessable entity - instance for filter blueprint no longer exists\n")
+					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("Unprocessable entity - version for filter blueprint no longer exists\n")
 			})
 		})
 
-		Convey("And the instance exists", func() {
+		Convey("And the version associated with filter blueprint exists", func() {
 
 			if err := mongo.Setup(instance); err != nil {
 				log.ErrorC("Unable to setup instance test resource", err, nil)
 				os.Exit(1)
 			}
 
-			Convey("When the dimension does not exist against instance", func() {
+			Convey("When the dimension does not exist against version", func() {
 				Convey("Then the response returns a status bad request (400)", func() {
 
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "foobar").
@@ -188,7 +194,7 @@ func TestFailureToPostDimension(t *testing.T) {
 				})
 			})
 
-			Convey("When the option for a valid dimension does not exist against instance", func() {
+			Convey("When the option for a valid dimension does not exist against version", func() {
 
 				if err := mongo.Setup(dimensions...); err != nil {
 					log.ErrorC("Unable to setup dimension option test resources", err, nil)

--- a/filterAPI/post_filter_blueprint_test.go
+++ b/filterAPI/post_filter_blueprint_test.go
@@ -3,8 +3,10 @@ package filterAPI
 import (
 	"net/http"
 	"os"
+	"strconv"
 	"testing"
 
+	datasetJSON "github.com/ONSdigital/dp-api-tests/datasetAPI"
 	"github.com/ONSdigital/dp-api-tests/filterAPI/expectedTestData"
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
@@ -18,38 +20,58 @@ func TestSuccessfullyPostFilterBlueprintForPublishedInstance(t *testing.T) {
 	instanceID := uuid.NewV4().String()
 	dimensionOptionOneID := uuid.NewV4().String()
 	dimensionOptionTwoID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
 	var docs []*mongo.Doc
+
+	dataset := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     datasetJSON.ValidPublishedWithUpdatesDatasetData(datasetID),
+	}
+
+	editionDoc := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "editions",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     datasetJSON.ValidPublishedEditionData(datasetID, editionID, edition),
+	}
 
 	instance := &mongo.Doc{
 		Database:   cfg.MongoDB,
 		Collection: "instances",
 		Key:        "instance_id",
 		Value:      instanceID,
-		Update:     GetValidPublishedInstanceDataBSON(instanceID),
+		Update:     GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition, version),
 	}
 
-	docs = append(docs, instance)
+	docs = append(docs, dataset, editionDoc, instance)
 	docs = append(docs, setupDimensionOptions(dimensionOptionOneID, GetValidAgeDimensionData(instanceID, "27")))
 	docs = append(docs, setupDimensionOptions(dimensionOptionTwoID, GetValidAgeDimensionData(instanceID, "42")))
 
 	if err := mongo.Setup(docs...); err != nil {
-		log.ErrorC("Unable to setup instance test resources", err, nil)
+		log.ErrorC("Unable to setup test resources", err, nil)
 		os.Exit(1)
 	}
 
 	Convey("Given a valid json input to create a filter", t, func() {
 		Convey("Then the response returns a status of created (201)", func() {
-
-			response := filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(instanceID))).
+			response := filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(datasetID, edition, version))).
 				Expect().Status(http.StatusCreated).JSON().Object()
+
 			response.Value("filter_id").NotNull()
 			response.Value("instance_id").Equal(instanceID)
 			response.Value("links").Object().Value("dimensions").Object().Value("href").String().Match("/filters/(.+)/dimensions$")
 			response.Value("links").Object().Value("self").Object().Value("href").String().Match("/filters/(.+)$")
-			response.Value("links").Object().Value("version").Object().Value("href").String().Match("/datasets/123/editions/2017/versions/1$")
+			response.Value("links").Object().Value("version").Object().Value("href").String().Match("/datasets/" + datasetID + "/editions/" + edition + "/versions/" + strconv.Itoa(version) + "$")
 			response.Value("links").Object().Value("version").Object().Value("id").Equal("1")
 		})
 	})
@@ -59,7 +81,7 @@ func TestSuccessfullyPostFilterBlueprintForPublishedInstance(t *testing.T) {
 
 			response := filterAPI.POST("/filters").
 				WithQuery("submitted", "true").
-				WithBytes([]byte(GetValidPOSTCreateFilterJSON(instanceID))).
+				WithBytes([]byte(GetValidPOSTCreateFilterJSON(datasetID, edition, version))).
 				Expect().Status(http.StatusCreated).JSON().Object()
 
 			filterBlueprintID := response.Value("filter_id").String().Raw()
@@ -68,7 +90,7 @@ func TestSuccessfullyPostFilterBlueprintForPublishedInstance(t *testing.T) {
 			response.Value("instance_id").Equal(instanceID)
 			response.Value("links").Object().Value("dimensions").Object().Value("href").String().Match("/filters/" + filterBlueprintID + "/dimensions$")
 			response.Value("links").Object().Value("self").Object().Value("href").String().Match("/filters/" + filterBlueprintID + "$")
-			response.Value("links").Object().Value("version").Object().Value("href").String().Match("/datasets/123/editions/2017/versions/1$")
+			response.Value("links").Object().Value("version").Object().Value("href").String().Match("/datasets/" + datasetID + "/editions/" + edition + "/versions/" + strconv.Itoa(version) + "$")
 			response.Value("links").Object().Value("version").Object().Value("id").Equal("1")
 
 			Convey("Then filter blueprint is created, a filter output document is created and in the response is a link to the output resource", func() {
@@ -84,7 +106,7 @@ func TestSuccessfullyPostFilterBlueprintForPublishedInstance(t *testing.T) {
 					log.ErrorC("Unable to retrieve updated document", err, nil)
 				}
 
-				So(filterOutput, ShouldResemble, expectedTestData.ExpectedFilterOutputOnPost(cfg.FilterAPIURL, instanceID, filterOutputID, filterBlueprintID))
+				So(filterOutput, ShouldResemble, expectedTestData.ExpectedFilterOutputOnPost(cfg.FilterAPIURL, datasetID, edition, instanceID, filterOutputID, filterBlueprintID, version))
 
 				//enable teardown of resources created during test
 				docs = append(docs, &mongo.Doc{
@@ -115,56 +137,76 @@ func TestFailureToPostfilterBlueprintForPublishedInstance(t *testing.T) {
 	instanceID := uuid.NewV4().String()
 	dimensionOptionID := uuid.NewV4().String()
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
+
+	dataset := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     datasetJSON.ValidPublishedWithUpdatesDatasetData(datasetID),
+	}
+
+	editonDoc := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "editions",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     datasetJSON.ValidPublishedEditionData(datasetID, editionID, edition),
+	}
 
 	instance := &mongo.Doc{
 		Database:   cfg.MongoDB,
 		Collection: "instances",
 		Key:        "instance_id",
 		Value:      instanceID,
-		Update:     GetValidPublishedInstanceDataBSON(instanceID),
+		Update:     GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition, version),
 	}
 
 	dimension := setupDimensionOptions(dimensionOptionID, GetValidAgeDimensionData(instanceID, "27"))
 
 	Convey("Given invalid json input to create a filter", t, func() {
-		Convey("When the request body does not contain an instance id", func() {
+		Convey("When the request body does not contain the dataset object details", func() {
 			Convey("Then the response returns status bad request (400)", func() {
 
-				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidJSON(instanceID))).
+				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidJSON())).
 					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - Invalid request body\n")
 			})
 		})
 	})
 
 	Convey("Given a request to create a filter", t, func() {
-		Convey("When the request body contains an instance id which does not exist", func() {
+		Convey("When the request body contains a dataset version which does not exist", func() {
 			Convey("Then the response returns status not found (404)", func() {
 
-				filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(instanceID))).
-					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
+				filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(datasetID, edition, version))).
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
 			})
 		})
 	})
 
 	Convey("Given that a dataset version is published", t, func() {
 
-		if err := mongo.Setup(instance, dimension); err != nil {
+		if err := mongo.Setup(dataset, editonDoc, instance, dimension); err != nil {
 			log.ErrorC("Unable to setup dimension option", err, nil)
 			os.Exit(1)
 		}
 
-		Convey("When the request contains a valid instance id but a dimension that does not exist", func() {
+		Convey("When the request contains a valid version of an editon for a dataset but a dimension that does not exist", func() {
 			Convey("Then the response returns status bad request (400)", func() {
 
-				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidDimensionJSON(instanceID))).
+				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidDimensionJSON(datasetID, edition, version))).
 					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimensions chosen: [weight]\n")
 			})
 		})
 
-		Convey("When the request contains a valid instance id and dimension but dimension options is invalid", func() {
+		Convey("When the request contains a valid version of an editon for a dataset and dimension but dimension options is invalid", func() {
 			Convey("Then the response returns status bad request (400)", func() {
 
-				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidDimensionOptionJSON(instanceID))).
+				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidDimensionOptionJSON(datasetID, edition, version))).
 					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimension options chosen: [33]\n")
 			})
 		})
@@ -181,19 +223,40 @@ func TestPostFilterBlueprintForUnpublishedInstance(t *testing.T) {
 	instanceID := uuid.NewV4().String()
 	dimensionOptionOneID := uuid.NewV4().String()
 	dimensionOptionTwoID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	editionID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
+
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
 	var docs []*mongo.Doc
+
+	dataset := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "datasets",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     datasetJSON.ValidPublishedWithUpdatesDatasetData(datasetID),
+	}
+
+	editionDoc := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "editions",
+		Key:        "_id",
+		Value:      datasetID,
+		Update:     datasetJSON.ValidPublishedEditionData(datasetID, editionID, edition),
+	}
 
 	instance := &mongo.Doc{
 		Database:   cfg.MongoDB,
 		Collection: "instances",
 		Key:        "instance_id",
 		Value:      instanceID,
-		Update:     GetUnpublishedInstanceDataBSON(instanceID),
+		Update:     GetUnpublishedInstanceDataBSON(instanceID, datasetID, edition, version),
 	}
 
-	docs = append(docs, instance)
+	docs = append(docs, dataset, editionDoc, instance)
 	docs = append(docs, setupDimensionOptions(dimensionOptionOneID, GetValidAgeDimensionData(instanceID, "27")))
 	docs = append(docs, setupDimensionOptions(dimensionOptionTwoID, GetValidAgeDimensionData(instanceID, "42")))
 
@@ -202,24 +265,24 @@ func TestPostFilterBlueprintForUnpublishedInstance(t *testing.T) {
 		os.Exit(1)
 	}
 
-	Convey("Given an unpublished instance", t, func() {
+	Convey("Given an unpublished version", t, func() {
 		Convey("When no authentication is provided on the POST request", func() {
 			Convey("Then the response returns a status of not found (404)", func() {
-				filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(instanceID))).
+				filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(datasetID, edition, version))).
 					Expect().Status(http.StatusNotFound)
 			})
 		})
 
 		Convey("When invalid authentication is provided on the POST request", func() {
 			Convey("Then the response returns a status of not found (404)", func() {
-				filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(instanceID))).
+				filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(datasetID, edition, version))).
 					WithHeader(internalTokenHeader, "failure").Expect().Status(http.StatusNotFound)
 			})
 		})
 
 		Convey("When valid authentication is provided on the POST request", func() {
 			Convey("Then the response returns a status of created (201)", func() {
-				response := filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(instanceID))).
+				response := filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(datasetID, edition, version))).
 					WithHeader(internalTokenHeader, internalTokenID).Expect().Status(http.StatusCreated).JSON().Object()
 				response.Value("filter_id").NotNull()
 				response.Value("instance_id").Equal(instanceID)
@@ -237,7 +300,6 @@ func TestPostFilterBlueprintForUnpublishedInstance(t *testing.T) {
 				})
 			})
 		})
-
 	})
 	if err := mongo.Teardown(docs...); err != nil {
 		log.ErrorC("Unable to teardown instance", err, nil)

--- a/filterAPI/put_filter_output_test.go
+++ b/filterAPI/put_filter_output_test.go
@@ -17,6 +17,9 @@ func TestSuccessfulPutFilterOutput(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterOutputID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -25,7 +28,7 @@ func TestSuccessfulPutFilterOutput(t *testing.T) {
 		Collection: "filterOutputs",
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterOutputWithoutDownloadsBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID),
+		Update:     GetValidFilterOutputWithoutDownloadsBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID, datasetID, edition, version),
 	}
 
 	Convey("Given an existing filter output", t, func() {
@@ -98,6 +101,9 @@ func TestFailureToPutFilterOutput(t *testing.T) {
 	filterID := uuid.NewV4().String()
 	filterOutputID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
+	datasetID := uuid.NewV4().String()
+	edition := "2017"
+	version := 1
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
@@ -106,7 +112,7 @@ func TestFailureToPutFilterOutput(t *testing.T) {
 		Collection: "filterOutputs",
 		Key:        "_id",
 		Value:      filterID,
-		Update:     GetValidFilterOutputWithoutDownloadsBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID),
+		Update:     GetValidFilterOutputWithoutDownloadsBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID, datasetID, edition, version),
 	}
 
 	Convey("Given a filter output does not exist", t, func() {


### PR DESCRIPTION
### What

Filter API now only creates and acts on filter blueprints and filter outputs in reference to a version instead of instance.

### How to review

Run filterAPI tests against filter API branch `feature/use-dataset-edition-version-to-filter` and you will need to run dataset API too. Both can be run using the make acceptance command.

Check e2e test also pass

### Who can review

Team B
