### PR TITLE
Fix tests to work with new edition subdocs current and next

### DIFF
--- a/datasetAPI/delete_dataset_test.go
+++ b/datasetAPI/delete_dataset_test.go
@@ -1,11 +1,12 @@
 package datasetAPI
 
 import (
+	"net/http"
 	"testing"
+
 	"github.com/gavv/httpexpect"
 	"github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
-	"net/http"
 )
 
 func TestDeleteDataset(t *testing.T) {

--- a/datasetAPI/get_edition_test.go
+++ b/datasetAPI/get_edition_test.go
@@ -64,12 +64,12 @@ func TestSuccessfullyGetDatasetEdition(t *testing.T) {
 				Expect().Status(http.StatusOK).JSON().Object()
 
 			response.Value("id").Equal(unpublishedEditionID)
-			response.Value("edition").Equal(unpublishedEdition)
-			response.Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
-			response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
-			response.Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + unpublishedEdition + "$")
-			response.Value("links").Object().Value("versions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + unpublishedEdition + "/versions$")
-			response.Value("state").Equal("edition-confirmed")
+			response.Value("next").Object().Value("edition").Equal(unpublishedEdition)
+			response.Value("next").Object().Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
+			response.Value("next").Object().Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")
+			response.Value("next").Object().Value("links").Object().Value("self").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + unpublishedEdition + "$")
+			response.Value("next").Object().Value("links").Object().Value("versions").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "/editions/" + unpublishedEdition + "/versions$")
+			response.Value("next").Object().Value("state").Equal("edition-confirmed")
 		})
 
 		Convey("When user is unauthenticated", func() {
@@ -77,7 +77,6 @@ func TestSuccessfullyGetDatasetEdition(t *testing.T) {
 			response := datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, edition).
 				Expect().Status(http.StatusOK).JSON().Object()
 
-			response.Value("id").Equal(editionID)
 			response.Value("edition").Equal(edition)
 			response.Value("links").Object().Value("dataset").Object().Value("id").Equal(datasetID)
 			response.Value("links").Object().Value("dataset").Object().Value("href").String().Match("(.+)/datasets/" + datasetID + "$")

--- a/datasetAPI/json.go
+++ b/datasetAPI/json.go
@@ -332,17 +332,26 @@ func validAggregateDimensionsData(instanceID string) bson.M {
 func ValidPublishedEditionData(datasetID, editionID, edition string) bson.M {
 	return bson.M{
 		"$set": bson.M{
-			"edition":                   edition,
-			"id":                        editionID,
-			"last_updated":              "2017-09-08", // TODO Should be isodate
-			"links.dataset.id":          datasetID,
-			"links.dataset.href":        cfg.DatasetAPIURL + "/datasets/" + datasetID,
-			"links.latest_version.id":   "1",
-			"links.latest_version.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/1",
-			"links.self.href":           cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
-			"links.versions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions",
-			"state":                     "published",
-			"test_data":                 "true",
+			"id":                                editionID,
+			"current.edition":                   edition,
+			"current.last_updated":              "2017-09-08", // TODO Should be isodate
+			"current.links.dataset.id":          datasetID,
+			"current.links.dataset.href":        cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"current.links.latest_version.id":   "1",
+			"current.links.latest_version.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/1",
+			"current.links.self.href":           cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
+			"current.links.versions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions",
+			"current.state":                     "published",
+			"next.edition":                      edition,
+			"next.last_updated":                 "2017-09-08", // TODO Should be isodate
+			"next.links.dataset.id":             datasetID,
+			"next.links.dataset.href":           cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"next.links.latest_version.id":      "2",
+			"next.links.latest_version.href":    cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/2",
+			"next.links.self.href":              cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
+			"next.links.versions.href":          cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions",
+			"next.state":                        "edition-confirmed",
+			"test_data":                         "true",
 		},
 	}
 }
@@ -350,15 +359,17 @@ func ValidPublishedEditionData(datasetID, editionID, edition string) bson.M {
 func validUnpublishedEditionData(datasetID, editionID, edition string) bson.M {
 	return bson.M{
 		"$set": bson.M{
-			"edition":             edition,
-			"id":                  editionID,
-			"last_updated":        "2017-10-08", // TODO Should be isodate
-			"links.dataset.id":    datasetID,
-			"links.dataset.href":  cfg.DatasetAPIURL + "/datasets/" + datasetID,
-			"links.self.href":     cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
-			"links.versions.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions",
-			"state":               "edition-confirmed",
-			"test_data":           "true",
+			"next.edition":                   edition,
+			"id":                             editionID,
+			"next.last_updated":              "2017-10-08", // TODO Should be isodate
+			"next.links.dataset.id":          datasetID,
+			"next.links.dataset.href":        cfg.DatasetAPIURL + "/datasets/" + datasetID,
+			"next.links.self.href":           cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition,
+			"next.links.versions.href":       cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions",
+			"next.links.latest_version.id":   "2",
+			"next.links.latest_version.href": cfg.DatasetAPIURL + "/datasets/" + datasetID + "/editions/" + edition + "/versions/2",
+			"next.state":                     "edition-confirmed",
+			"test_data":                      "true",
 		},
 	}
 }

--- a/datasetAPI/put_instance_test.go
+++ b/datasetAPI/put_instance_test.go
@@ -93,7 +93,7 @@ func TestSuccessfullyPutInstance(t *testing.T) {
 					So(instance.Version, ShouldEqual, 2)
 
 					// Check edition document has been created
-					edition, err := mongo.GetEdition(cfg.MongoDB, "editions", "links.self.href", instance.Links.Edition.HRef)
+					edition, err := mongo.GetEdition(cfg.MongoDB, "editions", "next.links.self.href", instance.Links.Edition.HRef)
 					if err != nil {
 						if err != mgo.ErrNotFound {
 							log.ErrorC("Was unable to remove test data", err, nil)
@@ -101,7 +101,7 @@ func TestSuccessfullyPutInstance(t *testing.T) {
 						}
 					}
 
-					checkEditionDoc(datasetID, instanceID, edition)
+					checkEditionDoc(datasetID, instanceID, edition.Next)
 
 					if instance.Links.Edition != nil {
 						e := &mongo.Doc{
@@ -130,7 +130,6 @@ func TestSuccessfullyPutInstance(t *testing.T) {
 }
 
 // TODO test to be able to update version after being published with an alert?
-
 func TestFailureToPutInstance(t *testing.T) {
 
 	datasetID := uuid.NewV4().String()
@@ -380,7 +379,8 @@ func checkInstanceDoc(datasetID, instanceID, state string, instance mongo.Instan
 	return
 }
 
-func checkEditionDoc(datasetID, instanceID string, editionDoc mongo.Edition) {
+func checkEditionDoc(datasetID, instanceID string, editionDoc *mongo.Edition) {
+	log.Info("edition", log.Data{"edition": editionDoc})
 	So(editionDoc.Edition, ShouldEqual, "2017")
 	So(editionDoc.Links.Dataset.ID, ShouldEqual, datasetID)
 	So(editionDoc.Links.Dataset.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID)
@@ -388,7 +388,7 @@ func checkEditionDoc(datasetID, instanceID string, editionDoc mongo.Edition) {
 	So(editionDoc.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017/versions/1")
 	So(editionDoc.Links.Self.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017")
 	So(editionDoc.Links.Versions.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017/versions")
-	So(editionDoc.State, ShouldEqual, "created")
+	So(editionDoc.State, ShouldEqual, "edition-confirmed")
 
 	return
 }

--- a/datasetAPI/put_version_test.go
+++ b/datasetAPI/put_version_test.go
@@ -144,7 +144,9 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 
 				// Check edition has been updated
 				So(updatedEdition.ID, ShouldEqual, editionID)
-				So(updatedEdition.State, ShouldEqual, "published")
+				So(updatedEdition.Next.State, ShouldEqual, "published")
+				So(updatedEdition.Current, ShouldNotBeNil)
+				So(updatedEdition.Current.State, ShouldEqual, "published")
 
 				updatedDataset, err := mongo.GetDataset(cfg.MongoDB, collection, "_id", datasetID)
 				if err != nil {
@@ -232,10 +234,11 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 
 				// Check edition has been updated
 				So(updatedEdition.ID, ShouldEqual, editionID)
-				So(updatedEdition.State, ShouldEqual, "published")
-				log.Debug("latest version?", log.Data{"latest_version": updatedEdition.Links.LatestVersion})
-				So(updatedEdition.Links.LatestVersion.ID, ShouldEqual, "2")
-				So(updatedEdition.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2018/versions/2")
+				So(updatedEdition.Next.State, ShouldEqual, "published")
+				So(updatedEdition.Current, ShouldNotBeNil)
+				So(updatedEdition.Current.State, ShouldEqual, "published")
+				So(updatedEdition.Current.Links.LatestVersion.ID, ShouldEqual, "2")
+				So(updatedEdition.Current.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2018/versions/2")
 
 				updatedDataset, err := mongo.GetDataset(cfg.MongoDB, collection, "_id", datasetID)
 				if err != nil {
@@ -293,9 +296,11 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 
 				// Check edition has been updated
 				So(updatedEdition.ID, ShouldEqual, editionID)
-				So(updatedEdition.State, ShouldEqual, "published")
-				So(updatedEdition.Links.LatestVersion.ID, ShouldEqual, "2")
-				So(updatedEdition.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017/versions/2")
+				So(updatedEdition.Next.State, ShouldEqual, "published")
+				So(updatedEdition.Current, ShouldNotBeNil)
+				So(updatedEdition.Current.State, ShouldEqual, "published")
+				So(updatedEdition.Current.Links.LatestVersion.ID, ShouldEqual, "2")
+				So(updatedEdition.Current.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetID+"/editions/2017/versions/2")
 
 				updatedDataset, err := mongo.GetDataset(cfg.MongoDB, collection, "_id", datasetID)
 				if err != nil {

--- a/testDataSetup/mongo/mongo.go
+++ b/testDataSetup/mongo/mongo.go
@@ -207,6 +207,13 @@ type Publisher struct {
 	HRef string `bson:"href,omitempty" json:"href,omitempty"`
 }
 
+// EditionUpdate represents an evolving edition containing both the next and current edition
+type EditionUpdate struct {
+	ID      string   `bson:"_id,omitempty"         json:"id,omitempty"`
+	Current *Edition `bson:"current,omitempty"     json:"current,omitempty"`
+	Next    *Edition `bson:"next,omitempty"        json:"next,omitempty"`
+}
+
 // Edition represents information related to a single edition for a dataset
 type Edition struct {
 	Edition     string        `bson:"edition,omitempty"      json:"edition,omitempty"`
@@ -385,11 +392,11 @@ func GetDataset(database, collection, key, value string) (DatasetUpdate, error) 
 }
 
 // GetEdition retrieves an edition document from mongo
-func GetEdition(database, collection, key, value string) (Edition, error) {
+func GetEdition(database, collection, key, value string) (EditionUpdate, error) {
 	s := session.Copy()
 	defer s.Close()
 
-	var edition Edition
+	var edition EditionUpdate
 	if err := s.DB(database).C(collection).Find(bson.M{key: value}).One(&edition); err != nil {
 		return edition, err
 	}


### PR DESCRIPTION
### What

Edition document split into current and next sub documents to handle latest version links

### How to review

Run acceptance tests against `dp-dataset-api` run on branch `feature/stop-edition-prepublish`

Also the end to end tests wont pass unless you are running the `dp-dataset-exporter-xlsx` on branch `fix/null-observation` until this fix has been merged into `cmd-develop`

### Who can review

Team B
