### PR TITLE
Update import-api tests to use Authorization header

### DIFF
--- a/importAPI/get_job_test.go
+++ b/importAPI/get_job_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
-	"github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2"
 )
@@ -30,8 +29,8 @@ func TestSuccessfullyGetAnImportJob(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to get the job with a specific id and the user is authenticated", func() {
+	Convey("Given a request for a job that exists", t, func() {
+		Convey("When get job is called", func() {
 			Convey("Then the response returns status OK (200)", func() {
 
 				response := importAPI.GET("/jobs/{id}", jobID).
@@ -68,10 +67,10 @@ func TestFailureToGetAnImportJob(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to get the job with id does not exist", func() {
+	Convey("Given a request for a job that does not exist", t, func() {
+		Convey("When get job is called", func() {
 			Convey("Then the response returns status not found (404)", func() {
-				importAPI.GET("/jobs/{id}", uuid.NewV4().String()).
+				importAPI.GET("/jobs/{id}", invalidJobID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusNotFound)
 			})
@@ -103,8 +102,8 @@ func TestGetAnImportJobUnauthorised(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to get the job with id has no auth headers", func() {
+	Convey("Given a request with no Authorization header", t, func() {
+		Convey("When get job is called", func() {
 			Convey("Then the response returns status not found (404)", func() {
 				importAPI.GET("/jobs/{id}", jobID).
 					Expect().Status(http.StatusNotFound)
@@ -112,8 +111,8 @@ func TestGetAnImportJobUnauthorised(t *testing.T) {
 		})
 	})
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to get the job with id has an unauthorised service token", func() {
+	Convey("Given a request with an unauthorised Authorization header", t, func() {
+		Convey("When get job is called ", func() {
 			Convey("Then the response returns status 401 unauthorised", func() {
 				importAPI.GET("/jobs/{id}", jobID).
 					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).

--- a/importAPI/get_jobs_test.go
+++ b/importAPI/get_jobs_test.go
@@ -41,7 +41,7 @@ func TestSuccessfullyGetListOfImportJobs(t *testing.T) {
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
 	Convey("Given an import job exists", t, func() {
-		Convey("When a request to get a list of all jobs and the user is authenticated", func() {
+		Convey("When get jobs is called with an authenticated request", func() {
 			Convey("Then the response returns status OK (200)", func() {
 
 				response := importAPI.GET("/jobs").
@@ -82,7 +82,7 @@ func TestGetListOfImportJobsUnauthorised(t *testing.T) {
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
 	Convey("Given an import job exists", t, func() {
-		Convey("When a request to get a list of all jobs and the user is not authenticated", func() {
+		Convey("When get jobs is called with no Authorization header", func() {
 			Convey("Then the response returns status Not Found (404)", func() {
 				importAPI.GET("/jobs").
 					Expect().Status(http.StatusNotFound)
@@ -91,7 +91,7 @@ func TestGetListOfImportJobsUnauthorised(t *testing.T) {
 	})
 
 	Convey("Given an import job exists", t, func() {
-		Convey("When a request to get a list of all jobs and the request is not authorised", func() {
+		Convey("when get jobs is called with an unauthorised Authorization header", func() {
 			Convey("Then the response returns status 401 unauthorised", func() {
 				importAPI.GET("/jobs").
 					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).

--- a/importAPI/get_jobs_test.go
+++ b/importAPI/get_jobs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	. "github.com/smartystreets/goconvey/convey"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 )
 
 func TestSuccessfullyGetListOfImportJobs(t *testing.T) {
@@ -44,7 +44,10 @@ func TestSuccessfullyGetListOfImportJobs(t *testing.T) {
 		Convey("When a request to get a list of all jobs and the user is authenticated", func() {
 			Convey("Then the response returns status OK (200)", func() {
 
-				response := importAPI.GET("/jobs").WithHeader(tokenName, tokenSecret).Expect().Status(http.StatusOK).JSON().Array()
+				response := importAPI.GET("/jobs").
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusOK).
+					JSON().Array()
 				checkImportJobsResponse(response)
 			})
 		})
@@ -58,7 +61,7 @@ func TestSuccessfullyGetListOfImportJobs(t *testing.T) {
 	}
 }
 
-func TestGetListOfImportJobsWithNoAuthentication(t *testing.T) {
+func TestGetListOfImportJobsUnauthorised(t *testing.T) {
 
 	var docs []*mongo.Doc
 
@@ -81,9 +84,18 @@ func TestGetListOfImportJobsWithNoAuthentication(t *testing.T) {
 	Convey("Given an import job exists", t, func() {
 		Convey("When a request to get a list of all jobs and the user is not authenticated", func() {
 			Convey("Then the response returns status Not Found (404)", func() {
+				importAPI.GET("/jobs").
+					Expect().Status(http.StatusNotFound)
+			})
+		})
+	})
 
-				importAPI.GET("/jobs").Expect().Status(http.StatusNotFound)
-
+	Convey("Given an import job exists", t, func() {
+		Convey("When a request to get a list of all jobs and the request is not authorised", func() {
+			Convey("Then the response returns status 401 unauthorised", func() {
+				importAPI.GET("/jobs").
+					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 	})

--- a/importAPI/initialise.go
+++ b/importAPI/initialise.go
@@ -11,12 +11,13 @@ import (
 var cfg *config.Config
 
 const (
-	collection   = "imports"
-	jobID        = "42B41AE3-8EA6-4D0F-8526-71D1999B4A7D"
-	invalidJobID = "42B41AE38EA64D0F852671D1999B4A7D1234"
-	instanceID   = "da814aee-66f5-4020-a260-3b6bc7363170"
-	tokenName    = "Internal-Token"
-	tokenSecret  = "0C30662F-6CF6-43B0-A96A-954772267FF5"
+	collection                   = "imports"
+	jobID                        = "42B41AE3-8EA6-4D0F-8526-71D1999B4A7D"
+	invalidJobID                 = "42B41AE38EA64D0F852671D1999B4A7D1234"
+	instanceID                   = "da814aee-66f5-4020-a260-3b6bc7363170"
+	serviceAuthTokenName         = "Authorization"
+	serviceAuthToken             = "939616dc-7599-4ded-9a86-a9c66fbf98e0"
+	unauthorisedServiceAuthToken = "0dd023bd-9cc0-4c18-9b4f-e030a1f2b71c"
 )
 
 func init() {

--- a/importAPI/post_job_test.go
+++ b/importAPI/post_job_test.go
@@ -16,8 +16,8 @@ func TestSuccessfullyPostImportJob(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given a requirement to create an import job exists", t, func() {
-		Convey("When a post request with a valid json", func() {
+	Convey("Given a valid JSON request", t, func() {
+		Convey("When create job is called", func() {
 			Convey("Then the response returns import job created (201)", func() {
 
 				response := importAPI.POST("/jobs").
@@ -65,8 +65,8 @@ func TestFailureToPostImportJob(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given a requirement to create an import job exists", t, func() {
-		Convey("When a post request with an invalid json", func() {
+	Convey("Given an invalid JSON request", t, func() {
+		Convey("When create job is called", func() {
 			Convey("Then the response returns bad request (400)", func() {
 
 				importAPI.POST("/jobs").
@@ -82,14 +82,13 @@ func TestPostImportJobWithNoAuthentication(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given a requirement to create an import job exists", t, func() {
-		Convey("When a post request with an valid json body but no authentication header", func() {
+	Convey("Given a request with no Authorization header", t, func() {
+		Convey("When create job is called", func() {
 			Convey("Then the response returns not found (404)", func() {
 
 				importAPI.POST("/jobs").
 					WithBytes([]byte(validPOSTCreateJobJSON)).
 					Expect().Status(http.StatusNotFound)
-
 			})
 		})
 	})
@@ -99,8 +98,8 @@ func TestPostImportJobUnauthorised(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given a requirement to create an import job exists", t, func() {
-		Convey("When a post request is sent with an unauthorised service token", func() {
+	Convey("Given a request with an unauthorised Authorization header", t, func() {
+		Convey("When create job is called", func() {
 			Convey("Then the response is 401 unauthorised", func() {
 
 				importAPI.POST("/jobs").

--- a/importAPI/put_file_test.go
+++ b/importAPI/put_file_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	. "github.com/smartystreets/goconvey/convey"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 )
 
 func TestAddFileToImportJob(t *testing.T) {
@@ -42,16 +42,10 @@ func TestAddFileToImportJob(t *testing.T) {
 		Convey("When a request to add a file into a job and the user is authenticated", func() {
 			Convey("Then the response returns status OK (200)", func() {
 
-				importAPI.PUT("/jobs/{id}/files", jobID).WithHeader(tokenName, tokenSecret).WithHeader(tokenName, tokenSecret).
-					WithBytes([]byte(validPUTAddFilesJSON)).Expect().Status(http.StatusOK)
-			})
-		})
-
-		Convey("When a request to add a file into a job and the user is unauthenticated", func() {
-			Convey("Then the response returns status OK (200)", func() {
-
-				importAPI.PUT("/jobs/{id}/files", jobID).WithHeader(tokenName, tokenSecret).
-					WithBytes([]byte(validPUTAddFilesJSON)).Expect().Status(http.StatusOK)
+				importAPI.PUT("/jobs/{id}/files", jobID).
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					WithBytes([]byte(validPUTAddFilesJSON)).
+					Expect().Status(http.StatusOK)
 			})
 		})
 	})
@@ -84,8 +78,10 @@ func TestFailureToAddFileToAnImportJob(t *testing.T) {
 	Convey("Given an import job exists", t, func() {
 		Convey("When a request to add a file into a job with job id that does not exist", func() {
 			Convey("Then the response returns status not found (404)", func() {
-				importAPI.PUT("/jobs/{id}/files", invalidJobID).WithHeader(tokenName, tokenSecret).
-					WithBytes([]byte(validPUTAddFilesJSON)).Expect().Status(http.StatusNotFound)
+				importAPI.PUT("/jobs/{id}/files", invalidJobID).
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					WithBytes([]byte(validPUTAddFilesJSON)).
+					Expect().Status(http.StatusNotFound)
 			})
 		})
 	})
@@ -93,8 +89,10 @@ func TestFailureToAddFileToAnImportJob(t *testing.T) {
 	Convey("Given an import job exists", t, func() {
 		Convey("When a request to add a file into a job with invalid json", func() {
 			Convey("Then the response returns status bad request(400)", func() {
-				importAPI.PUT("/jobs/{id}/files", jobID).WithHeader(tokenName, tokenSecret).
-					WithBytes([]byte("{")).Expect().Status(http.StatusBadRequest)
+				importAPI.PUT("/jobs/{id}/files", jobID).
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					WithBytes([]byte("{")).
+					Expect().Status(http.StatusBadRequest)
 			})
 		})
 	})
@@ -103,12 +101,70 @@ func TestFailureToAddFileToAnImportJob(t *testing.T) {
 		Convey("When a request to add a file into a job with valid json but no authentication", func() {
 			Convey("Then the response returns status not found (404)", func() {
 				importAPI.PUT("/jobs/{id}/files", jobID).
-					WithBytes([]byte(validPUTAddFilesJSON)).Expect().Status(http.StatusNotFound)
+					WithBytes([]byte(validPUTAddFilesJSON)).
+					Expect().Status(http.StatusNotFound)
 			})
 		})
 	})
 
 	if err := mongo.Teardown(importJob); err != nil {
+		if err != mgo.ErrNotFound {
+			log.ErrorC("Failed to tear down test data", err, nil)
+			os.Exit(1)
+		}
+	}
+}
+
+func TestAddFileToImportJobUnauthorised(t *testing.T) {
+
+	importJob := &mongo.Doc{
+		Database:   cfg.MongoImportsDB,
+		Collection: collection,
+		Key:        "id",
+		Value:      jobID,
+		Update:     validCreatedImportJobData,
+	}
+
+	instance := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "instances",
+		Key:        "id",
+		Value:      instanceID,
+		Update:     validCreatedInstanceData,
+	}
+
+	if err := mongo.Setup(importJob, instance); err != nil {
+		log.ErrorC("Failed to set up test data", err, nil)
+		os.Exit(1)
+	}
+
+	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
+
+	// These tests needs to refine when authentication was handled in the code.
+	Convey("Given an import job exists", t, func() {
+		Convey("When a request to add a file into a job and no service token is provided", func() {
+			Convey("Then the response returns status 404 not found", func() {
+
+				importAPI.PUT("/jobs/{id}/files", jobID).
+					WithBytes([]byte(validPUTAddFilesJSON)).
+					Expect().Status(http.StatusNotFound)
+			})
+		})
+	})
+
+	Convey("Given an import job exists", t, func() {
+		Convey("When a request to add a file into a job and an unauthorised service token is provided", func() {
+			Convey("Then the response returns status 401 unauthorised", func() {
+
+				importAPI.PUT("/jobs/{id}/files", jobID).
+					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					WithBytes([]byte(validPUTAddFilesJSON)).
+					Expect().Status(http.StatusUnauthorized)
+			})
+		})
+	})
+
+	if err := mongo.Teardown(importJob, instance); err != nil {
 		if err != mgo.ErrNotFound {
 			log.ErrorC("Failed to tear down test data", err, nil)
 			os.Exit(1)

--- a/importAPI/put_file_test.go
+++ b/importAPI/put_file_test.go
@@ -38,8 +38,8 @@ func TestAddFileToImportJob(t *testing.T) {
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
 	// These tests needs to refine when authentication was handled in the code.
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to add a file into a job and the user is authenticated", func() {
+	Convey("Given a valid request", t, func() {
+		Convey("When add file is called", func() {
 			Convey("Then the response returns status OK (200)", func() {
 
 				importAPI.PUT("/jobs/{id}/files", jobID).
@@ -75,9 +75,10 @@ func TestFailureToAddFileToAnImportJob(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to add a file into a job with job id that does not exist", func() {
+	Convey("Given a request with a job ID that does not exist", t, func() {
+		Convey("When add file is called", func() {
 			Convey("Then the response returns status not found (404)", func() {
+
 				importAPI.PUT("/jobs/{id}/files", invalidJobID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(validPUTAddFilesJSON)).
@@ -86,23 +87,14 @@ func TestFailureToAddFileToAnImportJob(t *testing.T) {
 		})
 	})
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to add a file into a job with invalid json", func() {
+	Convey("Given a request with invalid json", t, func() {
+		Convey("When add file is called", func() {
 			Convey("Then the response returns status bad request(400)", func() {
+
 				importAPI.PUT("/jobs/{id}/files", jobID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte("{")).
 					Expect().Status(http.StatusBadRequest)
-			})
-		})
-	})
-
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to add a file into a job with valid json but no authentication", func() {
-			Convey("Then the response returns status not found (404)", func() {
-				importAPI.PUT("/jobs/{id}/files", jobID).
-					WithBytes([]byte(validPUTAddFilesJSON)).
-					Expect().Status(http.StatusNotFound)
 			})
 		})
 	})
@@ -140,10 +132,9 @@ func TestAddFileToImportJobUnauthorised(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	// These tests needs to refine when authentication was handled in the code.
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to add a file into a job and no service token is provided", func() {
-			Convey("Then the response returns status 404 not found", func() {
+	Convey("Given a request with no Authorization header", t, func() {
+		Convey("When add file is called", func() {
+			Convey("Then the response returns status not found (404)", func() {
 
 				importAPI.PUT("/jobs/{id}/files", jobID).
 					WithBytes([]byte(validPUTAddFilesJSON)).
@@ -152,8 +143,8 @@ func TestAddFileToImportJobUnauthorised(t *testing.T) {
 		})
 	})
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to add a file into a job and an unauthorised service token is provided", func() {
+	Convey("Given a request with an unauthorised Authorization header", t, func() {
+		Convey("When add file is called", func() {
 			Convey("Then the response returns status 401 unauthorised", func() {
 
 				importAPI.PUT("/jobs/{id}/files", jobID).

--- a/importAPI/put_job_test.go
+++ b/importAPI/put_job_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
-	"github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/mgo.v2"
 )
@@ -38,8 +37,8 @@ func TestUpdateImportJobState(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to update the jobs state with a specific id and the user is authenticated", func() {
+	Convey("Given a valid authenticated request", t, func() {
+		Convey("When update job is called", func() {
 			Convey("Then the response returns status OK (200)", func() {
 
 				importAPI.PUT("/jobs/{id}", jobID).
@@ -83,8 +82,8 @@ func TestUpdateImportJobStateUnauthorised(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request has no auth headers", func() {
+	Convey("Given a request with no Authorization header", t, func() {
+		Convey("When update job is called", func() {
 			Convey("Then the response returns status 404 not found", func() {
 				importAPI.PUT("/jobs/{id}", jobID).
 					WithBytes([]byte(validPUTJobJSON)).
@@ -93,8 +92,8 @@ func TestUpdateImportJobStateUnauthorised(t *testing.T) {
 		})
 	})
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request has an unauthorised service token", func() {
+	Convey("Given a request with an unauthorised Authorization header", t, func() {
+		Convey("When update job is called", func() {
 			Convey("Then the response returns status 401 unauthorised", func() {
 
 				importAPI.PUT("/jobs/{id}", jobID).
@@ -130,10 +129,10 @@ func TestFailureToUpdateAnImportJob(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to change job state with job id that does not exist", func() {
+	Convey("Given a request for a job that does not exist", t, func() {
+		Convey("When update job is called", func() {
 			Convey("Then the response returns status not found (404)", func() {
-				importAPI.PUT("/jobs/{id}", uuid.NewV4().String()).
+				importAPI.PUT("/jobs/{id}", invalidJobID).
 					WithBytes([]byte(validPUTJobJSON)).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusNotFound)
@@ -141,8 +140,8 @@ func TestFailureToUpdateAnImportJob(t *testing.T) {
 		})
 	})
 
-	Convey("Given an import job exists", t, func() {
-		Convey("When a request to change job state with invalid json", func() {
+	Convey("Given a request with an invalid job JSON body", t, func() {
+		Convey("When update job is called", func() {
 			Convey("Then the response returns status bad request (400)", func() {
 				importAPI.PUT("/jobs/{id}", jobID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).

--- a/importAPI/put_job_test.go
+++ b/importAPI/put_job_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gavv/httpexpect"
 	"github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 )
 
 func TestUpdateImportJobState(t *testing.T) {
@@ -42,16 +42,65 @@ func TestUpdateImportJobState(t *testing.T) {
 		Convey("When a request to update the jobs state with a specific id and the user is authenticated", func() {
 			Convey("Then the response returns status OK (200)", func() {
 
-				importAPI.PUT("/jobs/{id}", jobID).WithHeader(tokenName, tokenSecret).
-					WithBytes([]byte(validPUTJobJSON)).Expect().Status(http.StatusOK)
+				importAPI.PUT("/jobs/{id}", jobID).
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					WithBytes([]byte(validPUTJobJSON)).
+					Expect().Status(http.StatusOK)
 			})
 		})
+	})
 
-		Convey("When a request to update the jobs state with a specific id and the user is unauthenticated", func() {
-			Convey("When the user is unauthenticated", func() {
+	if err := mongo.Teardown(importJob, instance); err != nil {
+		if err != mgo.ErrNotFound {
+			log.ErrorC("Failed to tear down test data", err, nil)
+			os.Exit(1)
+		}
+	}
+}
 
-				importAPI.PUT("/jobs/{id}", jobID).WithBytes([]byte(validPUTJobJSON)).
+func TestUpdateImportJobStateUnauthorised(t *testing.T) {
+
+	importJob := &mongo.Doc{
+		Database:   cfg.MongoImportsDB,
+		Collection: collection,
+		Key:        "id",
+		Value:      jobID,
+		Update:     validCreatedImportJobData,
+	}
+
+	instance := &mongo.Doc{
+		Database:   cfg.MongoDB,
+		Collection: "instances",
+		Key:        "id",
+		Value:      instanceID,
+		Update:     validCreatedInstanceData,
+	}
+
+	if err := mongo.Setup(importJob, instance); err != nil {
+		log.ErrorC("Failed to set up test data", err, nil)
+		os.Exit(1)
+	}
+
+	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
+
+	Convey("Given an import job exists", t, func() {
+		Convey("When a request has no auth headers", func() {
+			Convey("Then the response returns status 404 not found", func() {
+				importAPI.PUT("/jobs/{id}", jobID).
+					WithBytes([]byte(validPUTJobJSON)).
 					Expect().Status(http.StatusNotFound)
+			})
+		})
+	})
+
+	Convey("Given an import job exists", t, func() {
+		Convey("When a request has an unauthorised service token", func() {
+			Convey("Then the response returns status 401 unauthorised", func() {
+
+				importAPI.PUT("/jobs/{id}", jobID).
+					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					WithBytes([]byte(validPUTJobJSON)).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 	})
@@ -84,8 +133,10 @@ func TestFailureToUpdateAnImportJob(t *testing.T) {
 	Convey("Given an import job exists", t, func() {
 		Convey("When a request to change job state with job id that does not exist", func() {
 			Convey("Then the response returns status not found (404)", func() {
-				importAPI.PUT("/jobs/{id}", uuid.NewV4().String()).WithBytes([]byte(validPUTJobJSON)).
-					WithHeader(tokenName, tokenSecret).Expect().Status(http.StatusNotFound)
+				importAPI.PUT("/jobs/{id}", uuid.NewV4().String()).
+					WithBytes([]byte(validPUTJobJSON)).
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound)
 			})
 		})
 	})
@@ -94,7 +145,9 @@ func TestFailureToUpdateAnImportJob(t *testing.T) {
 		Convey("When a request to change job state with invalid json", func() {
 			Convey("Then the response returns status bad request (400)", func() {
 				importAPI.PUT("/jobs/{id}", jobID).
-					WithHeader(tokenName, tokenSecret).WithBytes([]byte("{")).Expect().Status(http.StatusBadRequest)
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					WithBytes([]byte("{")).
+					Expect().Status(http.StatusBadRequest)
 			})
 		})
 	})


### PR DESCRIPTION
### What

The import API has been updated to use the identity authentication endpoint provided by Zebedee. The tests have been updated to add the required headers.

Requires import api branch: https://github.com/ONSdigital/dp-import-api/pull/41
Requires identity api stub: https://github.com/ONSdigital/dp-auth-api-stub/pull/2

### How to review

review changes / test

### Who can review

Anyone
