### PR TITLE
Update dataset API acceptance tests

### DIFF
--- a/datasetAPI/README.md
+++ b/datasetAPI/README.md
@@ -1,0 +1,21 @@
+Dataset API Tests
+================
+
+### Getting started
+
+This package will test all endpoints that exist within the Dataset API
+
+#### Services and software
+
+The following software needs to be running for acceptance tests to be able to
+pass:
+
+```text
+mongo db
+zookeeper
+kafka
+dp-dataset-api
+dp-auth-api-stub (mimics zebedee authentication)
+```
+
+`dp-dataset-api` should be run with `make acceptance`

--- a/datasetAPI/delete_dataset_test.go
+++ b/datasetAPI/delete_dataset_test.go
@@ -2,29 +2,62 @@ package datasetAPI
 
 import (
 	"net/http"
+	"os"
 	"testing"
 
+	mgo "gopkg.in/mgo.v2"
+
+	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
+	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	"github.com/satori/go.uuid"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestDeleteDataset(t *testing.T) {
+func TestSuccessfullyDeleteDataset(t *testing.T) {
 
 	datasetID := uuid.NewV4().String()
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
 	Convey("Given a dataset with the an id of ["+datasetID+"] exists", t, func() {
 
-		datasetAPI.POST("/datasets/{id}", datasetID).
-			WithHeader(internalToken, internalTokenID).
-			WithBytes([]byte(validPOSTCreateDatasetJSON)).
-			Expect().Status(http.StatusCreated).JSON().Object()
+		associatedDataset := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: collection,
+			Key:        "_id",
+			Value:      datasetID,
+			Update:     validAssociatedDatasetData(datasetID),
+		}
+
+		if err := mongo.Setup(associatedDataset); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
 
 		Convey("When an authorised DELETE request is made to delete a dataset resource", func() {
 
 			request := datasetAPI.DELETE("/datasets/{id}", datasetID).
-				WithHeader(internalToken, internalTokenID)
+				WithHeader(serviceAuthTokenName, serviceAuthToken)
+
+			Convey("Then the expected response is returned", func() {
+				request.Expect().Status(http.StatusNoContent)
+			})
+		})
+
+		if err := mongo.Teardown(associatedDataset); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
+	})
+
+	// Check idempotent request, if resource is already deleted it should respond with 204
+	Convey("Given a dataset with the an id of ["+datasetID+"] does not already exist", t, func() {
+
+		Convey("When an authorised DELETE request is made to delete a dataset resource", func() {
+
+			request := datasetAPI.DELETE("/datasets/{id}", datasetID).
+				WithHeader(serviceAuthTokenName, serviceAuthToken)
 
 			Convey("Then the expected response is returned", func() {
 				request.Expect().Status(http.StatusNoContent)
@@ -33,21 +66,81 @@ func TestDeleteDataset(t *testing.T) {
 	})
 }
 
-func TestDeleteDataset_Idempotent(t *testing.T) {
+func TestFailureToDeleteDataset(t *testing.T) {
 
 	datasetID := uuid.NewV4().String()
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
+	secondDatasetID := uuid.NewV4().String()
 
-	Convey("Given a dataset with the an id of ["+datasetID+"] does not already exist", t, func() {
+	Convey("Given a published dataset with the an id of ["+datasetID+"] exists", t, func() {
+		publishedDataset := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: collection,
+			Key:        "_id",
+			Value:      datasetID,
+			Update:     ValidPublishedWithUpdatesDatasetData(datasetID),
+		}
+
+		if err := mongo.Setup(publishedDataset); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
 
 		Convey("When an authorised DELETE request is made to delete a dataset resource", func() {
 
 			request := datasetAPI.DELETE("/datasets/{id}", datasetID).
-				WithHeader(internalToken, internalTokenID)
+				WithHeader(serviceAuthTokenName, serviceAuthToken)
 
 			Convey("Then the expected response is returned", func() {
-				request.Expect().Status(http.StatusNoContent)
+				request.Expect().Status(http.StatusForbidden).Body().Contains("forbidden - a published dataset cannot be deleted")
 			})
 		})
+
+		if err := mongo.Teardown(publishedDataset); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
+	})
+
+	Convey("Given an associated dataset with the an id of ["+secondDatasetID+"] exists", t, func() {
+
+		associatedDataset := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: collection,
+			Key:        "_id",
+			Value:      secondDatasetID,
+			Update:     validAssociatedDatasetData(secondDatasetID),
+		}
+
+		if err := mongo.Setup(associatedDataset); err != nil {
+			log.ErrorC("Was unable to run test", err, nil)
+			os.Exit(1)
+		}
+
+		Convey("When an unauthorised DELETE request is made to delete a dataset resource", func() {
+
+			request := datasetAPI.DELETE("/datasets/{id}", datasetID).
+				WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken)
+
+			Convey("Then the expected response is returned", func() {
+				request.Expect().Status(http.StatusUnauthorized)
+			})
+		})
+
+		Convey("When a DELETE request is made to delete a dataset resource without authentication", func() {
+
+			request := datasetAPI.DELETE("/datasets/{id}", datasetID)
+
+			Convey("Then the expected response is returned", func() {
+				request.Expect().Status(http.StatusNotFound)
+			})
+		})
+
+		if err := mongo.Teardown(associatedDataset); err != nil {
+			if err != mgo.ErrNotFound {
+				os.Exit(1)
+			}
+		}
 	})
 }

--- a/datasetAPI/get_dataset_dimensions_test.go
+++ b/datasetAPI/get_dataset_dimensions_test.go
@@ -51,14 +51,14 @@ func TestGetDimensions_ReturnsAllDimensionsFromADataset(t *testing.T) {
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9811",
-		Update:     validTimeDimensionsData(instanceID),
+		Update:     validTimeDimensionsData("9811", instanceID),
 	}
 	dimensionTwoDoc := &mongo.Doc{
 		Database:   cfg.MongoDB,
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9812",
-		Update:     validAggregateDimensionsData(instanceID),
+		Update:     validAggregateDimensionsData("9812", instanceID),
 	}
 
 	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)
@@ -72,7 +72,7 @@ func TestGetDimensions_ReturnsAllDimensionsFromADataset(t *testing.T) {
 	Convey("Get a list of all dimensions of a dataset", t, func() {
 		Convey("When user is authenticated", func() {
 
-			response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/{version}/dimensions", datasetID, edition, 1).WithHeader(internalToken, internalTokenID).
+			response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/{version}/dimensions", datasetID, edition, 1).WithHeader(serviceAuthTokenName, serviceAuthToken).
 				Expect().Status(http.StatusOK).JSON().Object()
 
 			checkDimensionsResponse(datasetID, edition, instanceID, response)
@@ -144,23 +144,23 @@ func TestGetDimensions_Failed(t *testing.T) {
 		// TODO Remove skip on test once endpoint fixed
 		SkipConvey("When user is authenticated and the dataset does not exist", func() {
 			Convey("Then return status not found (404)", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 
 		// TODO Remove skip on test once endpoint fixed
 		SkipConvey("When user is authenticated and the edition does not exist", func() {
 			Convey("Then return status not found (404)", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 			})
 		})
 
 		Convey("When user is authenticated and there are no versions", func() {
 			Convey("Then return status not found (404)", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
 			})
 		})
 
@@ -168,7 +168,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 		SkipConvey("When user is unauthenticated and the dataset does not exist", func() {
 			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 
@@ -176,7 +176,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 		SkipConvey("When user is unauthenticated and the edition does not exist", func() {
 			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").
-					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 			})
 
 			Convey("When there are no published versions", func() {
@@ -191,7 +191,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 
 				mongo.Setup(unpublishedInstance)
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).
-					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
 
 				mongo.Teardown(unpublishedInstance)
 			})
@@ -201,15 +201,15 @@ func TestGetDimensions_Failed(t *testing.T) {
 	Convey("Given a valid dataset id, edition and version with no dimensions", t, func() {
 		Convey("When authenticated", func() {
 			Convey("Then return status not found (404)", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimensions not found\n")
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dimensions not found")
 			})
 		})
 
 		Convey("When user is unauthenticated", func() {
 			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimensions not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dimensions not found")
 			})
 		})
 	})

--- a/datasetAPI/get_dataset_test.go
+++ b/datasetAPI/get_dataset_test.go
@@ -37,7 +37,7 @@ func TestSuccessfullyGetADataset(t *testing.T) {
 		Convey("When the user is authenticated", func() {
 			Convey("Then response includes the expected current and next sub documents and returns a status ok (200)", func() {
 
-				response := datasetAPI.GET("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				response.Value("id").Equal(datasetID)
@@ -78,8 +78,8 @@ func TestFailureToGetADataset(t *testing.T) {
 	Convey("Given the dataset document does not exist", t, func() {
 		Convey("When requesting for document", func() {
 			Convey("Then return a status not found (404)", func() {
-				datasetAPI.GET("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound)
+				datasetAPI.GET("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 	})
@@ -102,7 +102,7 @@ func TestFailureToGetADataset(t *testing.T) {
 			Convey("Then return a status not found (404)", func() {
 
 				datasetAPI.GET("/datasets/{id}", datasetID).
-					Expect().Status(http.StatusNotFound)
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 

--- a/datasetAPI/get_datasets_test.go
+++ b/datasetAPI/get_datasets_test.go
@@ -63,11 +63,16 @@ func TestSuccessfulGetAListOfDatasets(t *testing.T) {
 					response.Value("items").Array().Element(i).Object().Value("id").Equal(datasetID)
 					checkDatasetResponse(datasetID, response.Value("items").Array().Element(i).Object())
 				}
+
+				if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == "133" {
+					// user is not authenticated to see this item, if it is returned force failure
+					t.Fail()
+				}
 			}
 		})
 
 		Convey("when the user is authorised", func() {
-			response := datasetAPI.GET("/datasets").WithHeader(internalToken, internalTokenID).
+			response := datasetAPI.GET("/datasets").WithHeader(serviceAuthTokenName, serviceAuthToken).
 				Expect().Status(http.StatusOK).JSON().Object()
 
 			response.Value("items").Array().Element(0).Object().Value("id").NotNull()

--- a/datasetAPI/get_datasets_test.go
+++ b/datasetAPI/get_datasets_test.go
@@ -66,6 +66,7 @@ func TestSuccessfulGetAListOfDatasets(t *testing.T) {
 
 				if response.Value("items").Array().Element(i).Object().Value("id").String().Raw() == "133" {
 					// user is not authenticated to see this item, if it is returned force failure
+					t.Log("user is not authenticated to see this item, forced test failure")
 					t.Fail()
 				}
 			}

--- a/datasetAPI/get_edition_test.go
+++ b/datasetAPI/get_edition_test.go
@@ -60,7 +60,7 @@ func TestSuccessfullyGetDatasetEdition(t *testing.T) {
 	Convey("Get an edition of a dataset", t, func() {
 		Convey("When user is authenticated and edition is not published", func() {
 
-			response := datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).WithHeader(internalToken, internalTokenID).
+			response := datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).WithHeader(serviceAuthTokenName, serviceAuthToken).
 				Expect().Status(http.StatusOK).JSON().Object()
 
 			response.Value("id").Equal(unpublishedEditionID)
@@ -120,8 +120,8 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 	Convey("When the dataset does not exist", t, func() {
 		Convey("Given a request to get an edition of the dataset", func() {
 			Convey("Then the response returns status not found (404)", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+				datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 	})
@@ -135,8 +135,8 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 		Convey("but no editions exist against the dataset", func() {
 			Convey("Given a request to get an edition of the dataset", func() {
 				Convey("Then the response returns status not found (404)", func() {
-					datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).WithHeader(internalToken, internalTokenID).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+					datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).WithHeader(serviceAuthTokenName, serviceAuthToken).
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 				})
 			})
 		})
@@ -152,7 +152,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 				Convey("Then the response returns status not found (404)", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 				})
 			})
 		})

--- a/datasetAPI/get_editions_test.go
+++ b/datasetAPI/get_editions_test.go
@@ -61,7 +61,7 @@ func TestSuccessfullyGetListOfDatasetEditions(t *testing.T) {
 		Convey("When a user is authenticated", func() {
 			Convey("Then the response contains both dataset editions", func() {
 
-				response := datasetAPI.GET("/datasets/{id}/editions", datasetID).WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/datasets/{id}/editions", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				response.Value("items").Array().Length().Equal(2)
@@ -120,7 +120,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 			Convey("Then return a status not found (404)", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions", datasetID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 	})
@@ -135,8 +135,8 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 			Convey("When a request to get editions for a dataset is made", func() {
 				Convey("Then return a status not found (404)", func() {
 
-					datasetAPI.GET("/datasets/{id}/editions", datasetID).WithHeader(internalToken, internalTokenID).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+					datasetAPI.GET("/datasets/{id}/editions", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 				})
 			})
 		})
@@ -152,7 +152,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 				Convey("Then return a status not found (404)", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions", datasetID).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 				})
 			})
 		})

--- a/datasetAPI/get_instance_dimension_options_test.go
+++ b/datasetAPI/get_instance_dimension_options_test.go
@@ -33,7 +33,7 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 		Convey("When an authenticated user sends a GET request for a list of time options for instance", func() {
 			Convey("Then a list of time options is returned with a status of OK (200)", func() {
 
-				response := datasetAPI.GET("/instances/{instance_id}/dimensions/time/options", instanceID).WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/instances/{instance_id}/dimensions/time/options", instanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				response.Value("dimension").Equal("time")
@@ -44,7 +44,7 @@ func TestGetInstanceDimensionOptions_ReturnsAllDimensionOptionsFromAnInstance(t 
 		Convey("When an authenticated user sends a GET request for a list of aggregate options for instance", func() {
 			Convey("Then a list of aggregate options is returned with a status of OK (200)", func() {
 
-				response := datasetAPI.GET("/instances/{instance_id}/dimensions/aggregate/options", instanceID).WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/instances/{instance_id}/dimensions/aggregate/options", instanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				response.Value("dimension").Equal("aggregate")
@@ -70,27 +70,27 @@ func TestFailureToGetInstanceDimensionOptions(t *testing.T) {
 	datasetAPI := httpexpect.New(t, cfg.DatasetAPIURL)
 
 	Convey("Given an instance document does not exist", t, func() {
-		Convey("When a user sends a GET request for an instances dimension options without sending a token", func() {
-			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+		Convey("When an unauthenticated request to get an instances dimension options", func() {
+			Convey("Then return status not found (404) with a message `requested resource not found`", func() {
 
 				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 			})
 		})
 
-		Convey("When a user sends a GET request for an instances dimension options with an invalid token", func() {
-			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+		Convey("When a user sends a GET request for an instances dimension options with an invalid Authentication header", func() {
+			Convey("Then return status unauthorized (401)", func() {
 
-				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(internalToken, invalidInternalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When an authenticated user sends a GET request for an instances dimension options", func() {
 			Convey("Then return status not found (404) with a message `Instance not found`", func() {
 
-				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found")
 			})
 		})
 	})
@@ -111,25 +111,25 @@ func TestFailureToGetInstanceDimensionOptions(t *testing.T) {
 		}
 
 		Convey("When a user sends a GET request for an instances dimension options without sending a token", func() {
-			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+			Convey("Then return status not found (404) with a message `requested resource not found`", func() {
 
 				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 			})
 		})
 
 		Convey("When a user sends a GET request for an instances dimension options with an invalid token", func() {
-			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+			Convey("Then return status unauthorized (401)", func() {
 
-				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(internalToken, invalidInternalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When an authenticated user sends a GET request for an instances dimension options", func() {
 			Convey("Then return status not found (404) with a message `Dimension node not found`", func() {
 
-				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(internalToken, internalTokenID).
+				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusNotFound).Body().Contains("Dimension node not found\n")
 			})
 		})
@@ -175,7 +175,7 @@ func getInstanceDimensionOptionsSetup(datasetID, editionID, edition, instanceID 
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9811",
-		Update:     validTimeDimensionsData(instanceID),
+		Update:     validTimeDimensionsData("9811", instanceID),
 	}
 
 	dimensionTwoDoc := &mongo.Doc{
@@ -183,7 +183,7 @@ func getInstanceDimensionOptionsSetup(datasetID, editionID, edition, instanceID 
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9812",
-		Update:     validAggregateDimensionsData(instanceID),
+		Update:     validAggregateDimensionsData("9812", instanceID),
 	}
 
 	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)

--- a/datasetAPI/get_instance_dimensions_test.go
+++ b/datasetAPI/get_instance_dimensions_test.go
@@ -51,7 +51,7 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9811",
-		Update:     validTimeDimensionsData(instanceID),
+		Update:     validTimeDimensionsData("9811", instanceID),
 	}
 
 	dimensionTwoDoc := &mongo.Doc{
@@ -59,7 +59,7 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9812",
-		Update:     validAggregateDimensionsData(instanceID),
+		Update:     validAggregateDimensionsData("9812", instanceID),
 	}
 
 	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)
@@ -80,7 +80,7 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 		Convey("When an authenticated user sends a GET request for a list of dimensions for instance", func() {
 			Convey("Then a list of dimensions is returned with a status of OK (200)", func() {
 
-				response := datasetAPI.GET("/instances/{instance_id}/dimensions", instanceID).WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/instances/{instance_id}/dimensions", instanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				response.Value("items").Array().Length().Equal(2)
@@ -114,7 +114,7 @@ func TestGetInstanceDimensions_ReturnsAllDimensionsFromAnInstance(t *testing.T) 
 		Convey("When an authenticated user sends a GET request for a list of dimensions for instance", func() {
 			Convey("Then return status OK (200) with an empty items array", func() {
 
-				dimensionsResource := datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, internalTokenID).
+				dimensionsResource := datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				dimensionsResource.Value("items").Null()
@@ -143,22 +143,22 @@ func TestFailureToGetInstanceDimensions(t *testing.T) {
 			Convey("Then return status not found (404) with a message `Resource not found`", func() {
 
 				datasetAPI.GET("/instances/{id}/dimensions", instanceID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 			})
 		})
 
 		Convey("When a user sends a GET request of a list of dimensions for instance with an invalid token", func() {
-			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+			Convey("Then return status unauthorized (401)", func() {
 
-				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, invalidInternalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When an authenticated user sends a GET request of a list of dimensions for instance", func() {
 			Convey("Then return status not found (404) with a message `Instance not found`", func() {
 
-				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, internalTokenID).
+				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
 			})
 		})
@@ -180,18 +180,18 @@ func TestFailureToGetInstanceDimensions(t *testing.T) {
 		}
 
 		Convey("When a user sends a GET request for a list of dimensions for instance without sending a token", func() {
-			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+			Convey("Then return status not found (404) with a message `requested resource not found`", func() {
 
 				datasetAPI.GET("/instances/{id}/dimensions", instanceID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 			})
 		})
 
 		Convey("When a user sends a GET request for a list of dimensions for instance with an invalid token", func() {
-			Convey("Then return status not found (404) with a message `Resource not found`", func() {
+			Convey("Then return status unauthorized (401)", func() {
 
-				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(internalToken, invalidInternalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+				datasetAPI.GET("/instances/{id}/dimensions", instanceID).WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
@@ -272,7 +272,7 @@ func getInstanceDimensionsSetup(datasetID, editionID, edition, instanceID string
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9811",
-		Update:     validTimeDimensionsData(instanceID),
+		Update:     validTimeDimensionsData("9811", instanceID),
 	}
 
 	dimensionTwoDoc := &mongo.Doc{
@@ -280,7 +280,7 @@ func getInstanceDimensionsSetup(datasetID, editionID, edition, instanceID string
 		Collection: "dimension.options",
 		Key:        "_id",
 		Value:      "9812",
-		Update:     validAggregateDimensionsData(instanceID),
+		Update:     validAggregateDimensionsData("9812", instanceID),
 	}
 
 	docs = append(docs, datasetDoc, editionDoc, dimensionOneDoc, dimensionTwoDoc, instanceOneDoc)

--- a/datasetAPI/get_instance_test.go
+++ b/datasetAPI/get_instance_test.go
@@ -41,7 +41,7 @@ func TestSuccessfullyGetInstance(t *testing.T) {
 
 		Convey("When an authenticated request to get instance", func() {
 			Convey("Then response contains the expected json object and a status ok (200)", func() {
-				response := datasetAPI.GET("/instances/{id}", publishedInstanceID).WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/instances/{id}", publishedInstanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				response.Value("alerts").Array().Element(0).Object().Value("date").String().Equal("2017-12-10")
@@ -77,7 +77,7 @@ func TestSuccessfullyGetInstance(t *testing.T) {
 
 		Convey("When an authenticated request to get instance", func() {
 			Convey("Then response contains the expected json object and a status ok (200)", func() {
-				response := datasetAPI.GET("/instances/{id}", unpublishedInstanceID).WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/instances/{id}", unpublishedInstanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				checkResponse(datasetID, edition, unpublishedInstanceID, "2", response)
@@ -106,8 +106,8 @@ func TestFailureToGetInstance(t *testing.T) {
 	Convey("Given an instance resource does not exist", t, func() {
 		Convey("When an authorised request is made to get instance", func() {
 			Convey("Then return a status not found (404) with message `Instance not found`", func() {
-				datasetAPI.GET("/instances/{id}", instanceID).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
+				datasetAPI.GET("/instances/{id}", instanceID).WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found")
 			})
 		})
 	})
@@ -126,18 +126,18 @@ func TestFailureToGetInstance(t *testing.T) {
 			os.Exit(1)
 		}
 		Convey("When no authentication header is provided in request to get resource", func() {
-			Convey("Then return a status of not found (404) with message `Resource not found`", func() {
+			Convey("Then return a status of not found (404) with message `requested resource not found`", func() {
 
 				datasetAPI.GET("/instances/{id}", instanceID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 			})
 		})
 
 		Convey("When an unauthorised request is made to get resource", func() {
-			Convey("Then return a status of not found (404) with message `Resource not found`", func() {
+			Convey("Then return a status of unauthorized (401)", func() {
 
-				datasetAPI.GET("/instances/{id}", instanceID).WithHeader(internalToken, "wrong-header").
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+				datasetAPI.GET("/instances/{id}", instanceID).WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 

--- a/datasetAPI/get_instances_test.go
+++ b/datasetAPI/get_instances_test.go
@@ -39,7 +39,7 @@ func TestSuccessfullyGetAListOfInstances(t *testing.T) {
 
 		Convey("When an authorised request to get a list of instances is received", func() {
 			Convey("Then a list of instances are returned", func() {
-				response := datasetAPI.GET("/instances").WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/instances").WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				response.Value("items").Array().Element(0).Object().Value("id").NotNull()
@@ -78,10 +78,10 @@ func TestSuccessfullyGetAListOfInstances(t *testing.T) {
 			os.Exit(1)
 		}
 
-		Convey("When the authorised request contains a query parameter 'state' of value completed", func() {
+		Convey("When the authorised request Contains a query parameter 'state' of value completed", func() {
 			Convey("Then return only instances that contain a 'state' of value completed", func() {
 
-				response := datasetAPI.GET("/instances").WithQuery("state", "completed").WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/instances").WithQuery("state", "completed").WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				var foundInstance bool
@@ -98,10 +98,10 @@ func TestSuccessfullyGetAListOfInstances(t *testing.T) {
 			})
 		})
 
-		Convey("When the authorised request contains a query parameter 'state' of value `completed` and `edition-confirmed`", func() {
+		Convey("When the authorised request Contains a query parameter 'state' of value `completed` and `edition-confirmed`", func() {
 			Convey("Then return all instances that contain a 'state' of value `completed` or `edition-confirmed`", func() {
 
-				response := datasetAPI.GET("/instances").WithQuery("state", "completed,edition-confirmed").WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/instances").WithQuery("state", "completed,edition-confirmed").WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				count := 0
@@ -156,23 +156,23 @@ func TestFailureToGetAListOfInstances(t *testing.T) {
 		}
 
 		Convey("When no authentication header is provided in request to get list of resources", func() {
-			Convey("Then return a status of not found (404) with message `Resource not found`", func() {
+			Convey("Then return a status of not found (404) with message `requested resource not found`", func() {
 				datasetAPI.GET("/instances").Expect().Status(http.StatusNotFound).
-					Body().Contains("Resource not found\n")
+					Body().Contains("requested resource not found")
 			})
 		})
 
 		Convey("When an unauthorised request is made to get resource", func() {
-			Convey("Then return a status of not found (404) with message `Resource not found`", func() {
-				datasetAPI.GET("/instances").WithHeader(internalToken, "wrong-header").
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+			Convey("Then return a status of unauthorized (401)", func() {
+				datasetAPI.GET("/instances").WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When an authorised request to get a list of resources is made with an invalid filter value for 'state'", func() {
 			Convey("Then return a status of bad request (400) with message `Bad request - invalid filter state values`", func() {
-				datasetAPI.GET("/instances").WithQuery("state", "foo").WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusBadRequest).Body().Contains("bad request - invalid filter state values: [foo]\n")
+				datasetAPI.GET("/instances").WithQuery("state", "foo").WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusBadRequest).Body().Contains("bad request - invalid filter state values: [foo]")
 			})
 		})
 

--- a/datasetAPI/get_metadata_test.go
+++ b/datasetAPI/get_metadata_test.go
@@ -33,7 +33,7 @@ func TestSuccessfullyGetMetadataRelevantToVersion(t *testing.T) {
 
 		Convey("When an authenticated request is made to get the unpublished version", func() {
 			Convey("Then the response body contains the expected metadata", func() {
-				response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/metadata", datasetID, edition).WithHeader(internalToken, internalTokenID).
+				response := datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/metadata", datasetID, edition).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusOK).JSON().Object()
 
 				response.Value("contacts").Array().Element(0).Object().Value("email").Equal("cpi@onstest.gov.uk")
@@ -188,8 +188,8 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When an authorised request to get the metadata relevant to a version", func() {
 			Convey("Then return status not found (404) with message `Dataset not found`", func() {
-				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 	})
@@ -203,8 +203,8 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 		Convey("but an edition and version do not exist", func() {
 			Convey("When a request to get the metadata relevant to a version", func() {
 				Convey("Then return status not found (404) with message `Edition not found`", func() {
-					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).WithHeader(internalToken, internalTokenID).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).WithHeader(serviceAuthTokenName, serviceAuthToken).
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 				})
 			})
 		})
@@ -218,8 +218,8 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 			Convey("but a version does not exist", func() {
 				Convey("When a request to get the metadata relevant to a version", func() {
 					Convey("Then return status bad request (404) with message `Version not found`", func() {
-						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).WithHeader(internalToken, internalTokenID).
-							Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).WithHeader(serviceAuthTokenName, serviceAuthToken).
+							Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
 					})
 				})
 			})
@@ -241,7 +241,7 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 		Convey("When an unauthorised request to get the metadate relevant to a version", func() {
 			Convey("Then return status not found (404) with message `Dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 
@@ -275,7 +275,7 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 			Convey("When an unauthorised request to get the metadata relevant to a version", func() {
 				Convey("Then return status not found (404) with message `Edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 				})
 			})
 
@@ -310,7 +310,7 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 			Convey("When an unauthorised request to get the metadata relevant to a version", func() {
 				Convey("Then return status not found (404) with message `Version not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).
-						Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+						Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
 				})
 			})
 

--- a/datasetAPI/initialise.go
+++ b/datasetAPI/initialise.go
@@ -13,11 +13,12 @@ var cfg *config.Config
 const (
 	collection = "datasets"
 
-	internalToken              = "Internal-Token"
 	downloadServiceAuthToken   = "X-Download-Service-Token"
 	downloadServiceAuthTokenID = "QB0108EZ-825D-412C-9B1D-41EF7747F462"
-	internalTokenID            = "FD0108EA-825D-411C-9B1D-41EF7727F465"
-	invalidInternalTokenID     = "FD0108EA-825D-411C-9B1D-41EF7727F465A"
+
+	serviceAuthTokenName         = "Authorization"
+	serviceAuthToken             = "939616dc-7599-4ded-9a86-a9c66fbf98e0"
+	unauthorisedServiceAuthToken = "0dd023bd-9cc0-4c18-9b4f-e030a1f2b71c"
 )
 
 func init() {

--- a/datasetAPI/json.go
+++ b/datasetAPI/json.go
@@ -275,10 +275,10 @@ func validCreatedDatasetData(datasetID string) bson.M {
 	}
 }
 
-func validTimeDimensionsData(instanceID string) bson.M {
+func validTimeDimensionsData(dimensionID, instanceID string) bson.M {
 	return bson.M{
 		"$set": bson.M{
-			"_id":                  "9811",
+			"_id":                  dimensionID,
 			"instance_id":          instanceID,
 			"name":                 "time",
 			"option":               "202.45",
@@ -293,10 +293,10 @@ func validTimeDimensionsData(instanceID string) bson.M {
 	}
 }
 
-func validTimeDimensionsDataWithOutOptions(instanceID string) bson.M {
+func validTimeDimensionsDataWithOutOptions(dimensionID, instanceID string) bson.M {
 	return bson.M{
 		"$set": bson.M{
-			"_id":                  "9811",
+			"_id":                  dimensionID,
 			"instance_id":          instanceID,
 			"name":                 "time",
 			"links.code_list.id":   "64d384f1-ea3b-445c-8fb8-aa453f96e58a",
@@ -310,10 +310,10 @@ func validTimeDimensionsDataWithOutOptions(instanceID string) bson.M {
 	}
 }
 
-func validAggregateDimensionsData(instanceID string) bson.M {
+func validAggregateDimensionsData(dimensionID, instanceID string) bson.M {
 	return bson.M{
 		"$set": bson.M{
-			"_id":                  "9812",
+			"_id":                  dimensionID,
 			"instance_id":          instanceID,
 			"name":                 "aggregate",
 			"option":               "cpi1dimA19",

--- a/datasetAPI/post_dataset_test.go
+++ b/datasetAPI/post_dataset_test.go
@@ -28,7 +28,7 @@ func TestSuccessfullyPostDataset(t *testing.T) {
 
 		Convey("When an authorised POST request is made to create a dataset resource", func() {
 			Convey("Then return a status ok and the expected response body", func() {
-				response := datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
+				response := datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPOSTCreateDatasetJSON)).
 					Expect().Status(http.StatusCreated).JSON().Object()
 
 				response.Value("id").Equal(datasetID)
@@ -86,24 +86,24 @@ func TestFailureToPostDataset(t *testing.T) {
 
 			Convey("Then return a status of bad request with a message `Failed to parse json body`", func() {
 
-				datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte("{")).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body\n")
+				datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte("{")).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body")
 			})
 		})
 
 		Convey("When an unauthorised POST request is made to create a dataset resource with an invalid authentication header", func() {
-			Convey("Then return a status not found (404) with a message `Resource not found`", func() {
+			Convey("Then return a status unauthorized (401)", func() {
 
-				datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+				datasetAPI.POST("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).WithBytes([]byte(validPOSTCreateDatasetJSON)).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When no authentication header is provided in POST request to create a dataset resource", func() {
-			Convey("Then return a status not found (404) with a message `Resource not found`", func() {
+			Convey("Then return a status not found (404) with a message `requested resource not found`", func() {
 
 				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPOSTCreateDatasetJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 			})
 		})
 	})
@@ -125,8 +125,8 @@ func TestFailureToPostDataset(t *testing.T) {
 		Convey("When an authorised POST request to create the same dataset resource is made", func() {
 			Convey("Then return a status of forbidden with a message `forbidden - dataset already exists`", func() {
 
-				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPOSTCreateDatasetJSON)).WithHeader(internalToken, internalTokenID).
-					Expect().Status(http.StatusForbidden).Body().Contains("forbidden - dataset already exists\n")
+				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPOSTCreateDatasetJSON)).WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusForbidden).Body().Contains("forbidden - dataset already exists")
 			})
 		})
 

--- a/datasetAPI/post_instance_test.go
+++ b/datasetAPI/post_instance_test.go
@@ -19,7 +19,7 @@ func TestSuccessfullyPostInstance(t *testing.T) {
 		Convey("When a valid authorised PUT request is made with a job properties", func() {
 			Convey("Then the expected response body is returned and a status of created (201)", func() {
 
-				response := datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPOSTCreateInstanceJSON)).
+				response := datasetAPI.POST("/instances").WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPOSTCreateInstanceJSON)).
 					Expect().Status(http.StatusCreated).JSON().Object()
 
 				instanceUniqueID := response.Value("id").String().Raw()
@@ -49,7 +49,7 @@ func TestSuccessfullyPostInstance(t *testing.T) {
 		Convey("When a valid authorised PUT request is made with dimensions and dataset as well as a job properties", func() {
 			Convey("Then the expected response body is returned and a status of created (201)", func() {
 
-				response := datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPOSTCreateFullInstanceJSON)).
+				response := datasetAPI.POST("/instances").WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPOSTCreateFullInstanceJSON)).
 					Expect().Status(http.StatusCreated).JSON().Object()
 
 				instanceUniqueID := response.Value("id").String().Raw()
@@ -91,8 +91,8 @@ func TestFailureToPostInstance(t *testing.T) {
 		Convey("When an authorised POST request is made to create an instance resource with invalid json", func() {
 			Convey("Then fail to create resource and return a status bad request (400) with a message `Failed to parse json body: unexpected end of JSON input`", func() {
 
-				datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{`)).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body: unexpected end of JSON input\n")
+				datasetAPI.POST("/instances").WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(`{`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body: unexpected end of JSON input")
 			})
 		})
 	})
@@ -101,26 +101,26 @@ func TestFailureToPostInstance(t *testing.T) {
 		Convey("When an authorised POST request is made to create an instance resource with missing job properties", func() {
 			Convey("Then fail to create resource and return a status bad request (400) with a message `Missing job properties`", func() {
 
-				datasetAPI.POST("/instances").WithHeader(internalToken, internalTokenID).WithBytes([]byte(invalidPOSTCreateInstanceJSON)).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Missing job properties\n")
+				datasetAPI.POST("/instances").WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(invalidPOSTCreateInstanceJSON)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Missing job properties")
 			})
 		})
 	})
 
 	Convey("Given an unauthorised user wants to create an instance", t, func() {
 		Convey("When an unauthorised POST request is made to create an instance resource with an invalid authentication header", func() {
-			Convey("Then fail to create resource and return a status not found (404) with a message `Resource not found`", func() {
+			Convey("Then fail to create resource and return a status unauthorized (401)", func() {
 
-				datasetAPI.POST("/instances").WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPOSTCreateInstanceJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+				datasetAPI.POST("/instances").WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).WithBytes([]byte(validPOSTCreateInstanceJSON)).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When no authentication header is provided in PUT request to create an instance resource", func() {
-			Convey("Then fail to create resource and return a status not found (404) with a message `Resource not found`", func() {
+			Convey("Then fail to create resource and return a status not found (404) with a message `requested resource not found`", func() {
 
 				datasetAPI.POST("/instances").WithBytes([]byte(validPOSTCreateInstanceJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 			})
 		})
 	})

--- a/datasetAPI/put_dataset_test.go
+++ b/datasetAPI/put_dataset_test.go
@@ -56,7 +56,7 @@ func TestSuccessfullyUpdateDataset(t *testing.T) {
 
 		Convey("When a Put request is made to update the dataset including state", func() {
 			Convey("Then the dataset resource is updated and response contains a status ok (200)", func() {
-				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPUTUpdateDatasetJSON)).
 					Expect().Status(http.StatusOK)
 
 				expectedNextSubDoc := expectedNextSubDoc(datasetID, "2018", "associated")
@@ -79,7 +79,7 @@ func TestSuccessfullyUpdateDataset(t *testing.T) {
 
 		Convey("When a Put request is made to update the dataset without state", func() {
 			Convey("Then the dataset next resource is updated to a state of created and response contains a status ok (200)", func() {
-				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateDatasetWithoutStateJSON)).
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPUTUpdateDatasetWithoutStateJSON)).
 					Expect().Status(http.StatusOK)
 
 				expectedNextSubDoc := expectedNextSubDoc(datasetID, "2018", "created")
@@ -127,7 +127,7 @@ func TestSuccessfullyUpdateDataset(t *testing.T) {
 
 		Convey("When a Put request is made to update the dataset state to published", func() {
 			Convey("Then the dataset resource is updated and response contains a status ok (200)", func() {
-				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state":"published"}`)).
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(`{"state":"published"}`)).
 					Expect().Status(http.StatusOK)
 
 				expectedSubDoc := expectedPublishedSubDoc(datasetID, "2018")
@@ -171,8 +171,8 @@ func TestFailureToUpdateDataset(t *testing.T) {
 		Convey("When an authorised PUT request is made to update dataset resource", func() {
 			Convey("Then fail to update resource and return a status of not found (404) with a message `Dataset not found`", func() {
 
-				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPUTUpdateDatasetJSON)).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 	})
@@ -185,26 +185,26 @@ func TestFailureToUpdateDataset(t *testing.T) {
 		}
 
 		Convey("When an unauthorised PUT request is made to update a dataset resource with an invalid authentication header", func() {
-			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
+			Convey("Then fail to update resource and return a status unauthorized (401)", func() {
 
-				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).WithBytes([]byte(validPUTUpdateDatasetJSON)).
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When no authentication header is provided in PUT request to update dataset resource", func() {
-			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
+			Convey("Then fail to update resource and return a status not found (404) with a message `requested resource not found`", func() {
 
 				datasetAPI.POST("/datasets/{id}", datasetID).WithBytes([]byte(validPUTUpdateDatasetJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 			})
 		})
 
 		Convey("When an authorised PUT request is made to update dataset resource with an invalid body", func() {
 			Convey("Then fail to update resource and return a status of bad request (400) with a message `Failed to parse json body`", func() {
 
-				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(internalToken, internalTokenID).WithBytes([]byte("{")).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body\n")
+				datasetAPI.PUT("/datasets/{id}", datasetID).WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte("{")).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body")
 			})
 		})
 

--- a/datasetAPI/put_version_test.go
+++ b/datasetAPI/put_version_test.go
@@ -35,7 +35,7 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 
 		Convey("When a PUT request to update meta data against the version resource", func() {
 			Convey("Then version resource is updated and returns a status ok (200)", func() {
-				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).Expect().Status(http.StatusOK)
 
 				updatedVersion, err := mongo.GetVersion(cfg.MongoDB, "instances", "_id", instanceID)
@@ -90,7 +90,7 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 
 		Convey("When a PUT request to update version resource with a collection id and state of associated", func() {
 			Convey("Then the dataset and version resources are updated and returns a status ok (200)", func() {
-				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(validPUTUpdateVersionToAssociatedJSON)).Expect().Status(http.StatusOK)
 
 				updatedVersion, err := mongo.GetVersion(cfg.MongoDB, "instances", "_id", instanceID)
@@ -120,7 +120,7 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 		Convey("When a PUT request to update version resource with a collection id and state of published", func() {
 			Convey("Then the dataset, edition and version resources are updated and returns a status ok (200)", func() {
 
-				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(validPUTUpdateVersionToPublishedWithCollectionIDJSON)).Expect().Status(http.StatusOK)
 
 				updatedVersion, err := mongo.GetVersion(cfg.MongoDB, "instances", "_id", instanceID)
@@ -183,7 +183,7 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 		// 1 test skipped
 		SkipConvey("When a PUT request to update version resource to remove collection id", func() {
 			Convey("Then the dataset and version resources are updated accordingly and returns a status ok (200)", func() {
-				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(validPUTUpdateVersionFromAssociatedToEditionConfirmedJSON)).Expect().Status(http.StatusOK)
 
 				updatedVersion, err := mongo.GetVersion(cfg.MongoDB, "instances", "_id", instanceID)
@@ -213,7 +213,7 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 		Convey("When a PUT request to update version resource with a state of published", func() {
 			Convey("Then the dataset, edition and version resources are updated and returns a status ok (200)", func() {
 
-				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).Expect().Status(http.StatusOK)
 
 				updatedVersion, err := mongo.GetVersion(cfg.MongoDB, "instances", "_id", instanceID)
@@ -275,7 +275,7 @@ func TestSuccessfullyUpdateVersion(t *testing.T) {
 		Convey("When a PUT request to update version resource with a state of published", func() {
 			Convey("Then the dataset, edition and version resources are updated and returns a status ok (200)", func() {
 
-				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(internalToken, internalTokenID).
+				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).Expect().Status(http.StatusOK)
 
 				updatedVersion, err := mongo.GetVersion(cfg.MongoDB, "instances", "_id", instanceID)
@@ -349,8 +349,8 @@ func TestFailureToUpdateVersion(t *testing.T) {
 			Convey("Then fail to update resource and return a status of not found (404) with a message `Dataset not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found\n")
+					WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
+					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
 			})
 		})
 
@@ -375,8 +375,8 @@ func TestFailureToUpdateVersion(t *testing.T) {
 			Convey("Then fail to update resource and return a status of not found (404) with a message `Edition not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found\n")
+					WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
+					Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
 			})
 		})
 
@@ -401,8 +401,8 @@ func TestFailureToUpdateVersion(t *testing.T) {
 			Convey("Then fail to update resource and return a status of not found (404) with a message `Version not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, internalTokenID).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+					WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
+					Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
 			})
 		})
 
@@ -419,8 +419,8 @@ func TestFailureToUpdateVersion(t *testing.T) {
 		Convey("When an authorised PUT request is made to update version resource with invalid json", func() {
 			Convey("Then fail to update resource and return a status of bad request (400) with a message ``", func() {
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{`)).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body\n")
+					WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(`{`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body")
 			})
 		})
 	})
@@ -440,8 +440,8 @@ func TestFailureToUpdateVersion(t *testing.T) {
 			Convey("Then fail to update resource and return a status of bad request (400) with a message `Missing collection_id for association between version and a collection`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "associated"}`)).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Missing collection_id for association between version and a collection\n")
+					WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(`{"state": "associated"}`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Missing collection_id for association between version and a collection")
 
 			})
 		})
@@ -451,30 +451,30 @@ func TestFailureToUpdateVersion(t *testing.T) {
 			Convey("Then fail to update resource and return a status of bad request (400) with a message `Missing collection_id for association between version and a collection`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "published"}`)).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Missing collection_id for association between version and a collection\n")
+					WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(`{"state": "published"}`)).
+					Expect().Status(http.StatusBadRequest).Body().Contains("Missing collection_id for association between version and a collection")
 
 			})
 		})
 
 		// test for unauthorised request to update version
 		Convey("When an unauthorised PUT request is made to update version resource", func() {
-			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
+			Convey("Then fail to update resource and return a status unauthorized (401)", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, invalidInternalTokenID).WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).
+					Expect().Status(http.StatusUnauthorized)
 
 			})
 		})
 
 		// test for missing auth header when making a request to update version
 		Convey("When a PUT request is made to update version resource without an authentication header", func() {
-			Convey("Then fail to update resource and return a status not found (404) with a message `Resource not found`", func() {
+			Convey("Then fail to update resource and return a status not found (404) with a message `requested resource not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithBytes([]byte(validPUTUpdateVersionMetaDataJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Resource not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("requested resource not found")
 
 			})
 		})
@@ -502,8 +502,8 @@ func TestFailureToUpdateVersion(t *testing.T) {
 			Convey("Then fail to update resource and return a status of forbidden (403) with a message `Unable to update document, already published`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"state": "edition-confirmed"}`)).
-					Expect().Status(http.StatusForbidden).Body().Contains("unable to update version as it has been published\n")
+					WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(`{"state": "edition-confirmed"}`)).
+					Expect().Status(http.StatusForbidden).Body().Contains("unable to update version as it has been published")
 			})
 		})
 
@@ -512,8 +512,8 @@ func TestFailureToUpdateVersion(t *testing.T) {
 			Convey("Then fail to update resource and return a status of forbidden (403) with a message `Unable to update document, already published`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
-					WithHeader(internalToken, internalTokenID).WithBytes([]byte(`{"links":{"spatial":{"href": "http://ons.gov.uk/spatial-notes"}}}`)).
-					Expect().Status(http.StatusForbidden).Body().Contains("unable to update version as it has been published\n")
+					WithHeader(serviceAuthTokenName, serviceAuthToken).WithBytes([]byte(`{"links":{"spatial":{"href": "http://ons.gov.uk/spatial-notes"}}}`)).
+					Expect().Status(http.StatusForbidden).Body().Contains("unable to update version as it has been published")
 			})
 		})
 

--- a/endToEndTests/README.md
+++ b/endToEndTests/README.md
@@ -50,4 +50,5 @@ import tracker
 import reporter
 dataset exporter
 xlsx dataset exporter
+auth api stub (mimics zebedee)
 ```

--- a/endToEndTests/initialise.go
+++ b/endToEndTests/initialise.go
@@ -23,11 +23,18 @@ const (
 	datasetName      = "cpih01"
 	genericHierarchy = "cpih1dim1aggid"
 
-	internalTokenHeader    = "Internal-Token"
-	internalTokenID        = "FD0108EA-825D-411C-9B1D-41EF7727F465"
-	invalidInternalTokenID = "FD0108EA-825D-411C-9B1D-41EF7727F465A"
-	importAPIInternalToken = "0C30662F-6CF6-43B0-A96A-954772267FF5"
+	florenceTokenHeader      = "X-Florence-Token"
+	florenceToken            = "85c718c3-9ba4-4f31-99bb-3e4eaabb2cc1"
+	authorizationTokenHeader = "Authorization"
+	authorizationToken       = "939616dc-7599-4ded-9a86-a9c66fbf98e0"
+
+	invalidToken = "FD0108EA-825D-411C-9B1D-41EF7727F465A"
 )
+
+var headers = map[string]string{
+	florenceTokenHeader:      florenceToken,
+	authorizationTokenHeader: authorizationToken,
+}
 
 var dropDatabases = []string{"test"}
 


### PR DESCRIPTION
### What

Dataset API test updated to handle new authentication (service token or florence token)

### How to review

Make sure all changes make logical sense and make sure dataset API acceptance tests pass while running `dp-dataset-api` with the following command `make acceptance` on branch `feature/identity`, e2e tests will fail until all services have authentication built in (e.g. new headers will need to be set on import/export services when calling out to API's)

### Who can review

Team B
