### PR TITLE
Update filter API tests to include new download structure

### DIFF
--- a/endToEndTests/end_to_end_api_test.go
+++ b/endToEndTests/end_to_end_api_test.go
@@ -580,7 +580,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 					So(filterOutputResource.Downloads.CSV, ShouldNotBeNil)
 					So(filterOutputResource.Downloads.XLS, ShouldNotBeNil)
 
-					filteredCSVURL := filterOutputResource.Downloads.CSV.URL
+					filteredCSVURL := filterOutputResource.Downloads.CSV.Public
 					filteredCSVFilename := strings.TrimPrefix(filteredCSVURL, "https://"+bucket+".s3."+region+".amazonaws.com/")
 
 					// read csv download from s3
@@ -597,7 +597,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 						os.Exit(1)
 					}
 
-					filteredXLSURL := filterOutputResource.Downloads.XLS.URL
+					filteredXLSURL := filterOutputResource.Downloads.XLS.Public
 					filteredXLSFilename := strings.TrimPrefix(filteredXLSURL, "https://"+bucket+".s3-"+region+".amazonaws.com/")
 
 					// read xls download from s3

--- a/endToEndTests/end_to_end_api_test.go
+++ b/endToEndTests/end_to_end_api_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	. "github.com/smartystreets/goconvey/convey"
+	"fmt"
+	"net/url"
 )
 
 var timeout = time.Duration(15 * time.Second)
@@ -58,7 +60,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 
 		Convey("When a job is imported and the version of the dataset is published", func() {
 
-			// STEP 1 - Create job with state created
+			log.Info("Create job with state created", nil)
 			postJobResponse := importAPI.POST("/jobs").WithBytes([]byte(createValidJobJSON(recipe, location))).
 				WithHeaders(headers).Expect().Status(http.StatusCreated).JSON().Object()
 
@@ -91,14 +93,14 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 			So(instanceResource.Links.Self.HRef, ShouldEqual, cfg.DatasetAPIURL+"/instances/"+instanceID)
 			So(instanceResource.State, ShouldEqual, "created")
 
-			// STEP 2 - Create dataset with dataset id from previous response
+			log.Info("Create dataset with dataset id from previous response", nil)
 			postDatasetResponse := datasetAPI.POST("/datasets/{id}", datasetName).WithHeaders(headers).WithBytes([]byte(validPOSTCreateDatasetJSON)).
 				Expect().Status(http.StatusCreated).JSON().Object()
 
 			postDatasetResponse.Value("next").Object().Value("links").Object().Value("self").Object().Value("href").String().Match(cfg.DatasetAPIURL + "/datasets/" + datasetName + "$")
 			postDatasetResponse.Value("next").Object().Value("state").Equal("created")
 
-			// STEP 3 - Update job state to submitted
+			log.Info("Update job state to submitted", nil)
 			importAPI.PUT("/jobs/{id}", jobID).WithHeaders(headers).WithBytes([]byte(`{"state":"submitted"}`)).
 				Expect().Status(http.StatusOK)
 
@@ -292,7 +294,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 			So(instanceResource.State, ShouldEqual, "completed")
 			So(instanceResource.ImportTasks.SearchTasks[0].DimensionName, ShouldEqual, "aggregate")
 
-			// STEP 4 - Update instance with meta data and change state to `edition-confirmed`
+			log.Info("Update instance with meta data and change state to `edition-confirmed`", nil)
 			datasetAPI.PUT("/instances/{instance_id}", instanceID).WithHeaders(headers).
 				WithBytes([]byte(validPUTInstanceMetadataJSON)).Expect().Status(http.StatusOK)
 
@@ -333,7 +335,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 			So(editionResource.Next.Links.Versions.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions")
 			So(editionResource.Next.State, ShouldEqual, "edition-confirmed")
 
-			// STEP 5 - Update version with collection_id and change state to associated
+			log.Info("Update version with collection_id and change state to associated", nil)
 			datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetName, "2017", "1").WithHeaders(headers).
 				WithBytes([]byte(validPUTUpdateVersionToAssociatedJSON)).Expect().Status(http.StatusOK)
 
@@ -381,16 +383,20 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 						log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
 						os.Exit(1)
 					}
+
 					if instanceResource.Downloads != nil {
 						if instanceResource.Downloads.XLS != nil {
-							if instanceResource.Downloads.XLS.URL != "" {
+
+							fmt.Printf("%+v\n", instanceResource.Downloads.XLS)
+
+							if instanceResource.Downloads.XLS.Private != "" {
 								XLSSize, err = strconv.Atoi(instanceResource.Downloads.XLS.Size)
 								if err != nil {
 									log.ErrorC("cannot convert xls size of type string to integer", err, log.Data{"xls_size": instanceResource.Downloads.XLS.Size})
 									os.Exit(1)
 								}
 								So(XLSSize, ShouldBeBetweenOrEqual, 19000, 20000)
-								So(instanceResource.Downloads.XLS.URL, ShouldNotBeEmpty)
+								So(instanceResource.Downloads.XLS.Private, ShouldNotBeEmpty)
 								CSVSize, err := strconv.Atoi(instanceResource.Downloads.CSV.Size)
 								if err != nil {
 									log.ErrorC("cannot convert csv size of type string to integer", err, log.Data{"csv_size": instanceResource.Downloads.CSV.Size})
@@ -404,6 +410,8 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 					} else {
 						So(instanceResource.State, ShouldEqual, "associated")
 					}
+
+					time.Sleep(time.Millisecond * 200)
 				}
 			}
 
@@ -413,7 +421,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 				os.Exit(1)
 			}
 
-			// STEP 6 -  Update version to a state of published
+			log.Info("STEP 6 - Update version to a state of published", nil)
 			datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetName, "2017", "1").WithHeaders(headers).
 				WithBytes([]byte(`{"state":"published"}`)).Expect().Status(http.StatusOK)
 
@@ -425,7 +433,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 
 			So(versionResource.State, ShouldEqual, "published")
 
-			// Check edition has updated
+			log.Info("Check edition has updated", nil)
 			editionResource, err = mongo.GetEdition(cfg.MongoDB, "editions", "current.links.self.href", instanceResource.Links.Edition.HRef)
 			if err != nil {
 				log.ErrorC("Unable to retrieve dataset resource", err, log.Data{"dataset_id": datasetName})
@@ -436,7 +444,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 			So(editionResource.Current, ShouldNotBeNil)
 			So(editionResource.Current.State, ShouldEqual, "published")
 
-			// Check dataset has updated
+			log.Info("Check dataset has updated", nil)
 			datasetResource, err = mongo.GetDataset(cfg.MongoDB, "datasets", "_id", datasetName)
 			if err != nil {
 				log.ErrorC("Unable to retrieve dataset resource", err, log.Data{"dataset_id": datasetName})
@@ -447,7 +455,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 			So(datasetResource.Current.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
 			So(datasetResource.Current.State, ShouldEqual, "published")
 
-			// Check data exists in elaticsearch by calling search API to find dimension option
+			log.Info("Check data exists in elaticsearch by calling search API to find dimension option", nil)
 			getSearchResponse := searchAPI.GET("/search/datasets/{id}/editions/{edition}/versions/{version}/dimensions/{dimension}", datasetName, versionResource.Edition, strconv.Itoa(versionResource.Version), "aggregate").
 				WithQuery("q", "Overall Index").Expect().Status(http.StatusOK).JSON().Object()
 
@@ -468,7 +476,8 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 			getSearchResponse.Value("offset").Equal(0)
 
 			Convey("Then an api customer should be able to get a csv and xls download link", func() {
-				// Get downloads link from version document
+
+				log.Info("Get downloads link from version document", nil)
 				csvURL := versionResource.Downloads.CSV.URL
 
 				response, err := http.Get(csvURL)
@@ -486,7 +495,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 
 				So(len(headerRow), ShouldEqual, 7)
 
-				// check the number of rows and anything else (e.g. meta data)
+				log.Info("check the number of rows and anything else (e.g. meta data)", nil)
 				numberOfCSVRows := 0
 				for {
 					_, err = csvReader.Read()
@@ -517,6 +526,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 				expectedXLSFileSize := XLSSize
 				So(xlsFileSize, ShouldResemble, expectedXLSFileSize)
 
+				log.Info("Then an api customer should be able to filter a dataset and be able to download", nil)
 				Convey("Then an api customer should be able to filter a dataset and be able to download a csv and xlsx download of the data", func() {
 					json := GetValidPOSTCreateFilterJSON(datasetName, "2017", "1")
 					log.Info("ajhgjlabfjlarebvjkrbvqlj", log.Data{"json": json})
@@ -554,16 +564,19 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 					So(filterOutputResource.InstanceID, ShouldEqual, instanceID)
 					So(filterOutputResource.State, ShouldEqual, "created")
 
-					filterOutputResourceCompleted := true
-					for filterOutputResourceCompleted {
+					for i := 0; i < 10 ;i++  {
+
 						filterOutputResource, err = mongo.GetFilter(cfg.MongoFiltersDB, "filterOutputs", "filter_id", filterOutputID)
 						if err != nil {
 							log.ErrorC("Unable to retrieve filter output document", err, log.Data{"filter_output_id": filterOutputID})
 							os.Exit(1)
 						}
 						if filterOutputResource.State == "completed" {
-							filterOutputResourceCompleted = false
+							break
 						}
+
+						log.Info("waiting for filter to be complete", log.Data{"state": filterOutputResource.State})
+						time.Sleep(time.Millisecond * 200)
 					}
 
 					So(filterOutputResource.FilterID, ShouldEqual, filterOutputID)
@@ -590,7 +603,11 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 					}
 
 					filteredXLSURL := filterOutputResource.Downloads.XLS.Public
-					filteredXLSFilename := strings.TrimPrefix(filteredXLSURL, "https://"+bucket+".s3-"+region+".amazonaws.com/")
+					u, err := url.Parse(filteredXLSURL)
+					if err != nil {
+						panic(err)
+					}
+					filteredXLSFilename := u.Path
 
 					// read xls download from s3
 					filteredXLSFile, err := getS3File(region, bucket, filteredXLSFilename, false)

--- a/endToEndTests/end_to_end_api_test.go
+++ b/endToEndTests/end_to_end_api_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	. "github.com/smartystreets/goconvey/convey"
-	"fmt"
 	"net/url"
 )
 
@@ -386,9 +385,6 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 
 					if instanceResource.Downloads != nil {
 						if instanceResource.Downloads.XLS != nil {
-
-							fmt.Printf("%+v\n", instanceResource.Downloads.XLS)
-
 							if instanceResource.Downloads.XLS.Private != "" {
 								XLSSize, err = strconv.Atoi(instanceResource.Downloads.XLS.Size)
 								if err != nil {
@@ -564,7 +560,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 					So(filterOutputResource.InstanceID, ShouldEqual, instanceID)
 					So(filterOutputResource.State, ShouldEqual, "created")
 
-					for i := 0; i < 10 ;i++  {
+					for i := 0; i < 10; i++ {
 
 						filterOutputResource, err = mongo.GetFilter(cfg.MongoFiltersDB, "filterOutputs", "filter_id", filterOutputID)
 						if err != nil {

--- a/filterAPI/expectedTestData/filterJobWithDimensions.go
+++ b/filterAPI/expectedTestData/filterJobWithDimensions.go
@@ -119,16 +119,16 @@ func ExpectedFilterOutput(host, instanceID, filterOutputID, filterBlueprintID st
 		},
 		Downloads: &mongo.Downloads{
 			CSV: &mongo.DownloadItem{
-				Size: "",
-				URL:  "",
-			},
-			JSON: &mongo.DownloadItem{
-				Size: "",
-				URL:  "",
+				HRef:    "",
+				Private: "",
+				Public:  "",
+				Size:    "",
 			},
 			XLS: &mongo.DownloadItem{
-				Size: "",
-				URL:  "",
+				HRef:    "",
+				Private: "",
+				Public:  "",
+				Size:    "",
 			},
 		},
 		Links: mongo.LinkMap{
@@ -158,16 +158,16 @@ func ExpectedFilterOutputOnPost(host, datasetID, edition, instanceID, filterOutp
 		},
 		Downloads: &mongo.Downloads{
 			CSV: &mongo.DownloadItem{
-				Size: "",
-				URL:  "",
-			},
-			JSON: &mongo.DownloadItem{
-				Size: "",
-				URL:  "",
+				HRef:    "",
+				Private: "",
+				Public:  "",
+				Size:    "",
 			},
 			XLS: &mongo.DownloadItem{
-				Size: "",
-				URL:  "",
+				HRef:    "",
+				Private: "",
+				Public:  "",
+				Size:    "",
 			},
 		},
 		Links: mongo.LinkMap{

--- a/filterAPI/expectedTestData/filterJobWithDimensions.go
+++ b/filterAPI/expectedTestData/filterJobWithDimensions.go
@@ -103,6 +103,7 @@ func ExpectedFilterBlueprint(host, instanceID, filterBlueprintID string) mongo.F
 				HRef: "http://localhost:8080/datasets/123/editions/2017/versions/1",
 			},
 		},
+		Published: &mongo.Published,
 	}
 }
 
@@ -144,7 +145,8 @@ func ExpectedFilterOutput(host, instanceID, filterOutputID, filterBlueprintID st
 				HRef: "http://localhost:8080/datasets/123/editions/2017/versions/1",
 			},
 		},
-		State: "created",
+		Published: &mongo.Published,
+		State:     "created",
 	}
 }
 
@@ -183,7 +185,8 @@ func ExpectedFilterOutputOnPost(host, datasetID, edition, instanceID, filterOutp
 				HRef: "http://localhost:8080/datasets/" + datasetID + "/editions/" + edition + "/versions/" + strconv.Itoa(version),
 			},
 		},
-		State: "created",
+		Published: &mongo.Published,
+		State:     "created",
 	}
 }
 
@@ -247,5 +250,6 @@ func ExpectedFilterBlueprintUpdated(host, instanceID, filterBlueprintID string) 
 				HRef: "http://localhost:8080/datasets/123/editions/2017/versions/1",
 			},
 		},
+		Published: &mongo.Published,
 	}
 }

--- a/filterAPI/get_filter_blueprint_test.go
+++ b/filterAPI/get_filter_blueprint_test.go
@@ -67,6 +67,7 @@ func TestSuccessfullyGetFilterBlueprint(t *testing.T) {
 				response.Value("links").Object().Value("self").Object().Value("href").String().Match("/filters/(.+)$")
 				response.Value("links").Object().Value("version").Object().Value("href").String().Match("/datasets/123/editions/2017/versions/1$")
 				response.Value("links").Object().Value("version").Object().Value("id").Equal("1")
+				response.Value("published").Equal(true)
 			})
 		})
 
@@ -96,6 +97,7 @@ func TestSuccessfullyGetFilterBlueprint(t *testing.T) {
 				response.Value("links").Object().Value("self").Object().Value("href").String().Match("/filters/(.+)$")
 				response.Value("links").Object().Value("version").Object().Value("href").String().Match("/datasets/123/editions/2017/versions/1$")
 				response.Value("links").Object().Value("version").Object().Value("id").Equal("1")
+				response.Value("published").Equal(false)
 			})
 		})
 

--- a/filterAPI/get_filter_preview_test.go
+++ b/filterAPI/get_filter_preview_test.go
@@ -30,7 +30,7 @@ func TestSuccessfullyGetFilterOutputPreview(t *testing.T) {
 			Collection: "filterOutputs",
 			Key:        "_id",
 			Value:      filterID,
-			Update:     GetValidFilterOutputBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID, filterBlueprintID, dimensions),
+			Update:     GetValidFilterOutputBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID, filterBlueprintID, "test-cpih01", "2017", "", "", 1, dimensions),
 		}
 
 		if err := mongo.Setup(output); err != nil {

--- a/filterAPI/initialise.go
+++ b/filterAPI/initialise.go
@@ -13,8 +13,9 @@ var cfg *config.Config
 const (
 	collection = "filters"
 
-	serviceAuthTokenName = "Authorization"
-	serviceAuthToken     = "939616dc-7599-4ded-9a86-a9c66fbf98e0"
+	serviceAuthTokenName    = "Authorization"
+	serviceAuthToken        = "939616dc-7599-4ded-9a86-a9c66fbf98e0"
+	invalidServiceAuthToken = "invalid-auth-token"
 )
 
 func init() {

--- a/filterAPI/json.go
+++ b/filterAPI/json.go
@@ -15,9 +15,9 @@ func GetValidPublishedInstanceDataBSON(instanceID, datasetID, edition string, ve
 			"dataset.id":            datasetID,
 			"dataset.edition":       edition,
 			"dataset.version":       version,
-			"downloads.csv.url":     "http://localhost:8080/aws/census-2017-1-csv",
+			"downloads.csv.href":    "http://localhost:8080/aws/census-2017-1-csv",
 			"downloads.csv.size":    "10mb",
-			"downloads.xls.url":     "http://localhost:8080/aws/census-2017-1-xls",
+			"downloads.xls.href":    "http://localhost:8080/aws/census-2017-1-xls",
 			"downloads.xls.size":    "24mb",
 			"edition":               "2017",
 			"headers":               []string{"time", "geography"},
@@ -52,9 +52,9 @@ func GetUnpublishedInstanceDataBSON(instanceID string, datasetID, edition string
 			"dataset.id":            datasetID,
 			"dataset.edition":       edition,
 			"dataset.version":       version,
-			"downloads.csv.url":     "http://localhost:8080/aws/census-2017-1-csv",
+			"downloads.csv.href":    "http://localhost:8080/aws/census-2017-1-csv",
 			"downloads.csv.size":    "10mb",
-			"downloads.xls.url":     "http://localhost:8080/aws/census-2017-1-xls",
+			"downloads.xls.href":    "http://localhost:8080/aws/census-2017-1-xls",
 			"downloads.xls.size":    "24mb",
 			"edition":               "2017",
 			"headers":               []string{"time", "geography"},
@@ -194,16 +194,21 @@ func GetValidFilterWithMultipleDimensionsBSON(host, filterID, instanceID, datase
 	}
 }
 
-func GetValidFilterOutputWithMultipleDimensionsBSON(host, filterID, instanceID, filterOutputID, filterBlueprintID string, published bool) bson.M {
+func GetValidFilterOutputWithMultipleDimensionsBSON(host, filterID, instanceID, filterOutputID, filterBlueprintID, datasetID, edition string, version int, published bool) bson.M {
 	return bson.M{
 		"$set": bson.M{
 			"_id":                         filterID,
+			"dataset.id":                  datasetID,
+			"dataset.edition":             edition,
+			"dataset.version":             version,
 			"dimensions":                  []Dimension{ageDimension(host, ""), sexDimension(host, ""), goodsAndServicesDimension(host, ""), timeDimension(host, "")},
-			"downloads.csv.url":           "s3-csv-location",
+			"downloads.csv.href":          "download-service-url.csv",
+			"downloads.csv.private":       "private-s3-csv-location",
+			"downloads.csv.public":        "public-s3-csv-location",
 			"downloads.csv.size":          "12mb",
-			"downloads.json.url":          "s3-json-location",
-			"downloads.json.size":         "6mb",
-			"downloads.xls.url":           "s3-xls-location",
+			"downloads.xls.href":          "download-service-url.xlsx",
+			"downloads.xls.private":       "private-s3-xls-location",
+			"downloads.xls.public":        "public-s3-xls-location",
 			"downloads.xls.size":          "24mb",
 			"instance_id":                 instanceID,
 			"filter_id":                   filterOutputID,
@@ -219,26 +224,31 @@ func GetValidFilterOutputWithMultipleDimensionsBSON(host, filterID, instanceID, 
 	}
 }
 
-func GetValidFilterOutputBSON(host, filterID, instanceID, filterOutputID, filterBlueprintID string, dimension Dimension) bson.M {
+func GetValidFilterOutputBSON(host, filterID, instanceID, filterOutputID, filterBlueprintID, datasetID, edition, csvPublicLink, xlsPublicLink string, version int, dimension Dimension) bson.M {
 	return bson.M{
 		"$set": bson.M{
 			"_id":                         filterID,
+			"dataset.id":                  datasetID,
+			"dataset.edition":             edition,
+			"dataset.version":             version,
 			"dimensions":                  []Dimension{dimension},
-			"downloads.csv.url":           "s3-csv-location",
+			"downloads.csv.href":          "download-service-url.csv",
+			"downloads.csv.private":       "private-s3-csv-location",
+			"downloads.csv.public":        csvPublicLink,
 			"downloads.csv.size":          "12mb",
-			"downloads.json.url":          "s3-json-location",
-			"downloads.json.size":         "6mb",
-			"downloads.xls.url":           "s3-xls-location",
+			"downloads.xls.href":          "download-service-url.xlsx",
+			"downloads.xls.private":       "private-s3-xls-location",
+			"downloads.xls.public":        xlsPublicLink,
 			"downloads.xls.size":          "24mb",
-			"instance_id":                 instanceID,
 			"filter_id":                   filterOutputID,
+			"instance_id":                 instanceID,
 			"links.filter_blueprint.href": host + "/filters/" + filterBlueprintID,
 			"links.filter_blueprint.id":   filterBlueprintID,
 			"links.self.href":             host + "/filter-outputs/" + filterOutputID,
 			"links.version.id":            "1",
 			"links.version.href":          "http://localhost:8080/datasets/123/editions/2017/versions/1",
-			"state":                       "completed",
 			"published":                   true,
+			"state":                       "completed",
 			"test_data":                   "true",
 		},
 	}
@@ -248,11 +258,10 @@ func GetValidFilterOutputNoDimensionsBSON(host, filterID, instanceID, filterOutp
 	return bson.M{
 		"$set": bson.M{
 			"_id":                         filterID,
-			"downloads.csv.url":           "s3-csv-location",
+			"downloads.csv.href":          "download-service-url.csv",
 			"downloads.csv.size":          "12mb",
-			"downloads.json.url":          "s3-json-location",
 			"downloads.json.size":         "6mb",
-			"downloads.xls.url":           "s3-xls-location",
+			"downloads.xls.href":          "download-service-url.xlsx",
 			"downloads.xls.size":          "24mb",
 			"instance_id":                 instanceID,
 			"filter_id":                   filterOutputID,
@@ -566,22 +575,44 @@ func GetValidPUTFilterOutputWithCSVDownloadJSON() string {
 	return `{
 	  "downloads": {
 			"csv": {
-			  "url": "s3-csv-location",
+			  "href": "download-service-url.csv",
+				"private": "private-s3-csv-location",
 				"size": "12mb"
 		  }
 		}
   }`
 }
 
+func GetValidPUTFilterOutputWithCSVPublicLinkJSON() string {
+	return `{
+		"downloads": {
+			"csv" : {
+			  "public": "public-s3-csv-location"
+		  }
+	  }
+	}`
+}
+
 func GetValidPUTFilterOutputWithXLSDownloadJSON() string {
 	return `{
 	  "downloads": {
 			"xls": {
-			  "url": "s3-xls-location",
+			  "href": "download-service-url.xlsx",
+				"private": "private-s3-xls-location",
 				"size": "24mb"
 		  }
 		}
   }`
+}
+
+func GetValidPUTFilterOutputWithXLSPublicLinkJSON() string {
+	return `{
+		"downloads": {
+			"xls" : {
+			  "public": "public-s3-xls-location"
+		  }
+	  }
+	}`
 }
 
 func GetValidPUTFilterOutputWithDimensionsJSON() string {

--- a/filterAPI/put_filter_output_test.go
+++ b/filterAPI/put_filter_output_test.go
@@ -31,14 +31,14 @@ func TestSuccessfulPutFilterOutput(t *testing.T) {
 		Update:     GetValidFilterOutputWithoutDownloadsBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID, datasetID, edition, version),
 	}
 
+	if err := mongo.Setup(output); err != nil {
+		log.ErrorC("Unable to setup test data", err, nil)
+		os.Exit(1)
+	}
+
 	Convey("Given an existing filter output", t, func() {
 
-		if err := mongo.Setup(output); err != nil {
-			log.ErrorC("Unable to setup test data", err, nil)
-			os.Exit(1)
-		}
-
-		Convey("When an authorised request to update the filter output with csv download", func() {
+		Convey("When an authorised request to update the filter output with csv download without a public link", func() {
 
 			filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
 				WithHeader(serviceAuthTokenName, serviceAuthToken).
@@ -53,24 +53,54 @@ func TestSuccessfulPutFilterOutput(t *testing.T) {
 					log.ErrorC("Unable to retrieve updated document", err, nil)
 				}
 
-				So(filterOutput.Downloads.CSV.URL, ShouldEqual, "s3-csv-location")
+				So(filterOutput.Downloads.CSV, ShouldNotBeNil)
+				So(filterOutput.Downloads.CSV.HRef, ShouldEqual, "download-service-url.csv")
+				So(filterOutput.Downloads.CSV.Private, ShouldEqual, "private-s3-csv-location")
+				So(filterOutput.Downloads.CSV.Public, ShouldBeEmpty)
 				So(filterOutput.Downloads.CSV.Size, ShouldEqual, "12mb")
-				So(filterOutput.Downloads.XLS.URL, ShouldEqual, "")
-				So(filterOutput.Downloads.XLS.Size, ShouldEqual, "")
+				So(filterOutput.Downloads.XLS, ShouldBeNil)
 				So(filterOutput.State, ShouldEqual, "created")
 			})
 		})
 
-		Convey("When an authorised request to update the filter output with csv download and xls download", func() {
-
-			filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
-				WithHeader(serviceAuthTokenName, serviceAuthToken).
-				WithBytes([]byte(GetValidPUTFilterOutputWithCSVDownloadJSON())).
-				Expect().Status(http.StatusOK)
+		Convey("When an authorised request to update the filter output with xls download without a public link", func() {
 
 			filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
 				WithHeader(serviceAuthTokenName, serviceAuthToken).
 				WithBytes([]byte(GetValidPUTFilterOutputWithXLSDownloadJSON())).
+				Expect().Status(http.StatusOK)
+
+			Convey("Then the filter output resource contains a non empty xls download object", func() {
+
+				// Check data has been updated as expected
+				filterOutput, err := mongo.GetFilter(cfg.MongoFiltersDB, "filterOutputs", "filter_id", filterOutputID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve updated document", err, nil)
+				}
+
+				So(filterOutput.Downloads.CSV, ShouldNotBeNil)
+				So(filterOutput.Downloads.CSV.HRef, ShouldEqual, "download-service-url.csv")
+				So(filterOutput.Downloads.CSV.Private, ShouldEqual, "private-s3-csv-location")
+				So(filterOutput.Downloads.CSV.Size, ShouldEqual, "12mb")
+				So(filterOutput.Downloads.XLS, ShouldNotBeNil)
+				So(filterOutput.Downloads.XLS.HRef, ShouldEqual, "download-service-url.xlsx")
+				So(filterOutput.Downloads.XLS.Private, ShouldEqual, "private-s3-xls-location")
+				So(filterOutput.Downloads.XLS.Size, ShouldEqual, "24mb")
+				So(filterOutput.State, ShouldEqual, "completed")
+			})
+		})
+
+		Convey("When an authorised request to update the filter output with csv public download link and"+
+			"a second authorised request to update the filter output with xls public download link", func() {
+
+			filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
+				WithHeader(serviceAuthTokenName, serviceAuthToken).
+				WithBytes([]byte(GetValidPUTFilterOutputWithCSVPublicLinkJSON())).
+				Expect().Status(http.StatusOK)
+
+			filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
+				WithHeader(serviceAuthTokenName, serviceAuthToken).
+				WithBytes([]byte(GetValidPUTFilterOutputWithXLSPublicLinkJSON())).
 				Expect().Status(http.StatusOK)
 
 			Convey("Then the filter output resource contains a non empty csv and xls download objects and the state is set to `completed`", func() {
@@ -80,26 +110,34 @@ func TestSuccessfulPutFilterOutput(t *testing.T) {
 				if err != nil {
 					log.ErrorC("Unable to retrieve updated document", err, nil)
 				}
+				log.Debug("filter output", log.Data{"filter_output": filterOutput.Downloads})
 
-				So(filterOutput.Downloads.CSV.URL, ShouldEqual, "s3-csv-location")
+				So(filterOutput.Downloads.CSV, ShouldNotBeNil)
+				So(filterOutput.Downloads.CSV.HRef, ShouldEqual, "download-service-url.csv")
+				So(filterOutput.Downloads.CSV.Private, ShouldEqual, "private-s3-csv-location")
+				So(filterOutput.Downloads.CSV.Public, ShouldEqual, "public-s3-csv-location")
 				So(filterOutput.Downloads.CSV.Size, ShouldEqual, "12mb")
-				So(filterOutput.Downloads.XLS.URL, ShouldEqual, "s3-xls-location")
+				So(filterOutput.Downloads.XLS, ShouldNotBeNil)
+				So(filterOutput.Downloads.XLS.HRef, ShouldEqual, "download-service-url.xlsx")
+				So(filterOutput.Downloads.XLS.Private, ShouldEqual, "private-s3-xls-location")
+				So(filterOutput.Downloads.XLS.Public, ShouldEqual, "public-s3-xls-location")
 				So(filterOutput.Downloads.XLS.Size, ShouldEqual, "24mb")
 				So(filterOutput.State, ShouldEqual, "completed")
 			})
 		})
-
-		if err := mongo.Teardown(output); err != nil {
-			log.ErrorC("Unable to remove test data from mongo db", err, nil)
-			os.Exit(1)
-		}
 	})
+
+	if err := mongo.Teardown(output); err != nil {
+		log.ErrorC("Unable to remove test data from mongo db", err, nil)
+		os.Exit(1)
+	}
 }
 
 func TestFailureToPutFilterOutput(t *testing.T) {
 
 	filterID := uuid.NewV4().String()
 	filterOutputID := uuid.NewV4().String()
+	filterBlueprintID := uuid.NewV4().String()
 	instanceID := uuid.NewV4().String()
 	datasetID := uuid.NewV4().String()
 	edition := "2017"
@@ -107,12 +145,32 @@ func TestFailureToPutFilterOutput(t *testing.T) {
 
 	filterAPI := httpexpect.New(t, cfg.FilterAPIURL)
 
-	output := &mongo.Doc{
+	filterOutput := &mongo.Doc{
 		Database:   cfg.MongoFiltersDB,
 		Collection: "filterOutputs",
 		Key:        "_id",
 		Value:      filterID,
 		Update:     GetValidFilterOutputWithoutDownloadsBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID, datasetID, edition, version),
+	}
+
+	dimensions := goodsAndServicesDimension(cfg.FilterAPIURL, filterBlueprintID)
+	csvPublicLink := "public-s3-csv-location"
+	xlsPublicLink := "public-s3-xls-location"
+
+	publishedFilterOutput := &mongo.Doc{
+		Database:   cfg.MongoFiltersDB,
+		Collection: "filterOutputs",
+		Key:        "_id",
+		Value:      filterID,
+		Update:     GetValidFilterOutputBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID, filterBlueprintID, datasetID, edition, csvPublicLink, xlsPublicLink, version, dimensions),
+	}
+
+	unpublishedFilterOutput := &mongo.Doc{
+		Database:   cfg.MongoFiltersDB,
+		Collection: "filterOutputs",
+		Key:        "_id",
+		Value:      filterID,
+		Update:     GetValidFilterOutputBSON(cfg.FilterAPIURL, filterID, instanceID, filterOutputID, filterBlueprintID, datasetID, edition, "", "", version, dimensions),
 	}
 
 	Convey("Given a filter output does not exist", t, func() {
@@ -127,9 +185,9 @@ func TestFailureToPutFilterOutput(t *testing.T) {
 		})
 	})
 
-	Convey("Given an existing filter output", t, func() {
+	Convey("Given an existing filter output without downloads object", t, func() {
 
-		if err := mongo.Setup(output); err != nil {
+		if err := mongo.Setup(filterOutput); err != nil {
 			log.ErrorC("Unable to setup test data", err, nil)
 			os.Exit(1)
 		}
@@ -167,10 +225,66 @@ func TestFailureToPutFilterOutput(t *testing.T) {
 					Expect().Status(http.StatusForbidden).Body().Contains("Forbidden from updating the following fields: [instance_id]")
 			})
 		})
+
+		if err := mongo.Teardown(filterOutput); err != nil {
+			log.ErrorC("Unable to remove test data from mongo db", err, nil)
+			os.Exit(1)
+		}
 	})
 
-	if err := mongo.Teardown(output); err != nil {
-		log.ErrorC("Unable to remove test data from mongo db", err, nil)
-		os.Exit(1)
-	}
+	Convey("Given an existing filter output with downloads object", t, func() {
+		Convey("But the document is unpublished and does not have a csv or xls publish link", func() {
+			if err := mongo.Setup(unpublishedFilterOutput); err != nil {
+				log.ErrorC("Unable to setup test data", err, nil)
+				os.Exit(1)
+			}
+
+			Convey("When an authorised request is made to update a filter output downloads", func() {
+				Convey("Then fail to update filter output and return status forbidden (403)", func() {
+
+					filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
+						WithHeader(serviceAuthTokenName, serviceAuthToken).
+						WithBytes([]byte(`{"downloads":{"csv":{"private":"private-s3-csv-link"}}}`)).
+						Expect().Status(http.StatusForbidden).Body().Contains("Forbidden from updating the following fields: [downloads.csv.private]\n")
+
+					filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
+						WithHeader(serviceAuthTokenName, serviceAuthToken).
+						WithBytes([]byte(`{"downloads":{"xls":{"private":"private-s3-xls-link"}}}`)).
+						Expect().Status(http.StatusForbidden).Body().Contains("Forbidden from updating the following fields: [downloads.xls.private]\n")
+				})
+			})
+
+			if err := mongo.Teardown(unpublishedFilterOutput); err != nil {
+				log.ErrorC("Unable to remove test data from mongo db", err, nil)
+				os.Exit(1)
+			}
+		})
+
+		Convey("And the document is published", func() {
+			if err := mongo.Setup(publishedFilterOutput); err != nil {
+				log.ErrorC("Unable to setup test data", err, nil)
+				os.Exit(1)
+			}
+
+			Convey("When an authorised request is made to update a filter output downloads", func() {
+				Convey("Then fail to update filter output and return status forbidden (403)", func() {
+
+					filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
+						WithHeader(serviceAuthTokenName, serviceAuthToken).
+						WithBytes([]byte(`{"downloads":{"csv":{"private":"private-s3-csv-link"}}}`)).
+						Expect().Status(http.StatusForbidden).Body().Contains("Forbidden from updating the following fields: [downloads.csv]\n")
+
+					filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
+						WithHeader(serviceAuthTokenName, serviceAuthToken).
+						WithBytes([]byte(`{"downloads":{"xls":{"private":"private-s3-xls-link"}}}`)).
+						Expect().Status(http.StatusForbidden).Body().Contains("Forbidden from updating the following fields: [downloads.xls]\n")
+				})
+			})
+
+			if err := mongo.Teardown(publishedFilterOutput); err != nil {
+				log.ErrorC("Unable to remove test data from mongo db", err, nil)
+				os.Exit(1)
+			}
+		})
+	})
 }

--- a/testDataSetup/mongo/mongo.go
+++ b/testDataSetup/mongo/mongo.go
@@ -468,15 +468,16 @@ type Dimension struct {
 
 // Downloads represents a list of file types possible to download
 type Downloads struct {
-	CSV  *DownloadItem `bson:"csv,omitempty"  json:"csv,omitempty"`
-	JSON *DownloadItem `bson:"json,omitempty" json:"json,omitempty"`
-	XLS  *DownloadItem `bson:"xls,omitempty"  json:"xls,omitempty"`
+	CSV *DownloadItem `bson:"csv,omitempty"  json:"csv,omitempty"`
+	XLS *DownloadItem `bson:"xls,omitempty"  json:"xls,omitempty"`
 }
 
 // DownloadItem represents an object containing information for the download item
 type DownloadItem struct {
-	Size string `bson:"size" json:"size"`
-	URL  string `bson:"url"  json:"url"`
+	HRef    string `bson:"href,omitempty"    json:"href,omitempty"`
+	Private string `bson:"private,omitempty" json:"private,omitempty"`
+	Public  string `bson:"public,omitempty"  json:"public,omitempty"`
+	Size    string `bson:"size,omitempty"    json:"size,omitempty"`
 }
 
 // Events represents a list of array objects containing event information against the filter blueprint or output

--- a/testDataSetup/mongo/mongo.go
+++ b/testDataSetup/mongo/mongo.go
@@ -440,6 +440,13 @@ func CountDimensionOptions(database, collection, key, value string) (int, error)
 	return s.DB(database).C(collection).Find(bson.M{key: value}).Count()
 }
 
+// Possible values for flagging whether a filter resource (output or blueprint)
+// is a filter against a published or unpublished version
+var (
+	Published   = true
+	Unpublished = false
+)
+
 // Filter represents a structure for a filter blueprint or output
 type Filter struct {
 	InstanceID string      `bson:"instance_id"          json:"instance_id"`
@@ -449,6 +456,7 @@ type Filter struct {
 	FilterID   string      `bson:"filter_id"            json:"filter_id,omitempty"`
 	State      string      `bson:"state,omitempty"      json:"state,omitempty"`
 	Links      LinkMap     `bson:"links"                json:"links,omitempty"`
+	Published  *bool       `bson:"published,omitempty"  json:"published,omitempty"`
 }
 
 // LinkMap contains a named LinkObject for each link to other resources


### PR DESCRIPTION
### What

Update filter API tests to include new download structure

Also extended tests to include new validation rules based on whether
the public or private download link is available and whether the
instance is published.

### How to review

Check changes make logical sense and filterAPI tests pass.

Run filterAPI tests by doing the following:
1) Run `dp-auth-api-stub` on cmd-develop
2) Run `dp-dataset-api` on `cmd-develop`
3) Run `dp-filter-api` on `feature/private-public-links`

The e2e tests will fail as it is dependent on existing work

### Who can review

Describe who worked on the changes, so that other people can review.
