### PR TITLE
Feature/pre publish filter

### DIFF
--- a/endToEndTests/Makefile
+++ b/endToEndTests/Makefile
@@ -8,7 +8,7 @@ TOKEN_INFO:="$(shell vault token create -address=$(VAULT_ADDR) -policy=write-psk
 APP_TOKEN:="$(shell echo $(TOKEN_INFO) | awk '{print $$6}')"
 
 test:
-	ENCRYPTION_DISABLED=false HUMAN_LOG=1 VAULT_TOKEN=$(APP_TOKEN) VAULT_ADDR=$(VAULT_ADDR) go test ./... -v
+	ENCRYPTION_DISABLED=false HUMAN_LOG=1 VAULT_TOKEN=$(APP_TOKEN) VAULT_ADDR=$(VAULT_ADDR) go test -v
 
 vault:
 	@echo "$(VAULT_POLICY)"

--- a/endToEndTests/end_to_end_api_test.go
+++ b/endToEndTests/end_to_end_api_test.go
@@ -12,13 +12,14 @@ import (
 
 	"gopkg.in/mgo.v2"
 
-	"github.com/ONSdigital/dp-api-tests/testDataSetup/elasticsearch"
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/mongo"
-	"github.com/ONSdigital/dp-api-tests/testDataSetup/neo4j"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	. "github.com/smartystreets/goconvey/convey"
 	"net/url"
+	"strings"
+	"github.com/ONSdigital/dp-api-tests/testDataSetup/elasticsearch"
+	"github.com/ONSdigital/dp-api-tests/testDataSetup/neo4j"
 )
 
 var timeout = time.Duration(15 * time.Second)
@@ -55,595 +56,672 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 		// import API expects a s3 url as the location of the file
 		location := "s3://" + bucketName + "/" + filename
 
-		Convey("When a job is imported and the version of the dataset is published", func() {
+		log.Info("Create job with state created", nil)
+		postJobResponse := importAPI.POST("/jobs").WithBytes([]byte(createValidJobJSON(recipe, location))).
+			WithHeaders(headers).Expect().Status(http.StatusCreated).JSON().Object()
 
-			log.Info("Create job with state created", nil)
-			postJobResponse := importAPI.POST("/jobs").WithBytes([]byte(createValidJobJSON(recipe, location))).
-				WithHeaders(headers).Expect().Status(http.StatusCreated).JSON().Object()
+		postJobResponse.Value("id").NotNull()
+		jobID := postJobResponse.Value("id").String().Raw()
 
-			postJobResponse.Value("id").NotNull()
-			jobID := postJobResponse.Value("id").String().Raw()
+		postJobResponse.Value("files").Array().Element(0).Object().Value("alias_name").Equal("CPIH")
+		postJobResponse.Value("files").Array().Element(0).Object().Value("url").Equal("s3://ons-dp-cmd-test/v4TestFile.csv")
 
-			postJobResponse.Value("files").Array().Element(0).Object().Value("alias_name").Equal("CPIH")
-			postJobResponse.Value("files").Array().Element(0).Object().Value("url").Equal("s3://ons-dp-cmd-test/v4TestFile.csv")
+		postJobResponse.Value("last_updated").NotNull()
+		postJobResponse.Value("links").Object().Value("instances").Array().Element(0).Object().Value("id").NotNull()
+		postJobResponse.Value("links").Object().Value("self").Object().Value("href").String().Match(cfg.ImportAPIURL + "/jobs/" + jobID + "$")
+		postJobResponse.Value("recipe").Equal(recipe)
+		postJobResponse.Value("state").Equal("created")
 
-			postJobResponse.Value("last_updated").NotNull()
-			postJobResponse.Value("links").Object().Value("instances").Array().Element(0).Object().Value("id").NotNull()
-			postJobResponse.Value("links").Object().Value("self").Object().Value("href").String().Match(cfg.ImportAPIURL + "/jobs/" + jobID + "$")
-			postJobResponse.Value("recipe").Equal(recipe)
-			postJobResponse.Value("state").Equal("created")
+		instanceID := postJobResponse.Value("links").Object().Value("instances").Array().Element(0).Object().Value("id").String().Raw()
 
-			instanceID := postJobResponse.Value("links").Object().Value("instances").Array().Element(0).Object().Value("id").String().Raw()
+		// Check for instance creation
+		instanceResource, err := mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve instance resource", err, log.Data{"instance_id": instanceID})
+			t.FailNow()
+		}
 
-			// Check for instance creation
-			instanceResource, err := mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
-			if err != nil {
-				log.ErrorC("Unable to retrieve instance resource", err, log.Data{"instance_id": instanceID})
-				t.FailNow()
-			}
+		So(len(instanceResource.Dimensions), ShouldEqual, 3)
+		So(instanceResource.Links.Job.ID, ShouldEqual, jobID)
+		So(instanceResource.Links.Job.HRef, ShouldEqual, cfg.ImportAPIURL+"/jobs/"+jobID)
+		So(instanceResource.Links.Dataset.ID, ShouldEqual, datasetName)
+		So(instanceResource.Links.Dataset.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName)
+		So(instanceResource.Links.Self.HRef, ShouldEqual, cfg.DatasetAPIURL+"/instances/"+instanceID)
+		So(instanceResource.State, ShouldEqual, "created")
 
-			So(len(instanceResource.Dimensions), ShouldEqual, 3)
-			So(instanceResource.Links.Job.ID, ShouldEqual, jobID)
-			So(instanceResource.Links.Job.HRef, ShouldEqual, cfg.ImportAPIURL+"/jobs/"+jobID)
-			So(instanceResource.Links.Dataset.ID, ShouldEqual, datasetName)
-			So(instanceResource.Links.Dataset.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName)
-			So(instanceResource.Links.Self.HRef, ShouldEqual, cfg.DatasetAPIURL+"/instances/"+instanceID)
-			So(instanceResource.State, ShouldEqual, "created")
+		log.Info("Create dataset with dataset id from previous response", nil)
+		postDatasetResponse := datasetAPI.POST("/datasets/{id}", datasetName).WithHeaders(headers).WithBytes([]byte(validPOSTCreateDatasetJSON)).
+			Expect().Status(http.StatusCreated).JSON().Object()
 
-			log.Info("Create dataset with dataset id from previous response", nil)
-			postDatasetResponse := datasetAPI.POST("/datasets/{id}", datasetName).WithHeaders(headers).WithBytes([]byte(validPOSTCreateDatasetJSON)).
-				Expect().Status(http.StatusCreated).JSON().Object()
+		postDatasetResponse.Value("next").Object().Value("links").Object().Value("self").Object().Value("href").String().Match(cfg.DatasetAPIURL + "/datasets/" + datasetName + "$")
+		postDatasetResponse.Value("next").Object().Value("state").Equal("created")
 
-			postDatasetResponse.Value("next").Object().Value("links").Object().Value("self").Object().Value("href").String().Match(cfg.DatasetAPIURL + "/datasets/" + datasetName + "$")
-			postDatasetResponse.Value("next").Object().Value("state").Equal("created")
+		log.Info("Update job state to submitted", nil)
+		importAPI.PUT("/jobs/{id}", jobID).WithHeaders(headers).WithBytes([]byte(`{"state":"submitted"}`)).
+			Expect().Status(http.StatusOK)
 
-			log.Info("Update job state to submitted", nil)
-			importAPI.PUT("/jobs/{id}", jobID).WithHeaders(headers).WithBytes([]byte(`{"state":"submitted"}`)).
-				Expect().Status(http.StatusOK)
+		// Check import job state is completed or submitted
+		jobResource, err := mongo.GetJob(cfg.MongoImportsDB, "imports", "id", jobID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve job resource", err, log.Data{"job_id": jobID})
+			t.FailNow()
+		}
 
-			// Check import job state is completed or submitted
-			jobResource, err := mongo.GetJob(cfg.MongoImportsDB, "imports", "id", jobID)
-			if err != nil {
-				log.ErrorC("Unable to retrieve job resource", err, log.Data{"job_id": jobID})
-				t.FailNow()
-			}
+		So(jobResource.State, ShouldNotEqual, "created")
 
-			So(jobResource.State, ShouldNotEqual, "created")
+		var stateHasChanged bool
+		if jobResource.State == "completed" || jobResource.State == "submitted" {
+			stateHasChanged = true
+		}
 
-			var stateHasChanged bool
-			if jobResource.State == "completed" || jobResource.State == "submitted" {
-				stateHasChanged = true
-			}
+		So(stateHasChanged, ShouldEqual, true)
 
-			So(stateHasChanged, ShouldEqual, true)
+		// Check instance has updated with headers, state is completed, total_observations and total_inserted_observations
+		totalObservations := int64(1510)
 
-			// Check instance has updated with headers, state is completed, total_observations and total_inserted_observations
-			totalObservations := int64(1510)
+		tryAgain := true
 
-			tryAgain := true
+		exitObservationsCompleteLoop := make(chan bool)
 
-			exitObservationsCompleteLoop := make(chan bool)
+		go func() {
+			time.Sleep(timeout)
+			close(exitObservationsCompleteLoop)
+		}()
 
-			go func() {
-				time.Sleep(timeout)
-				close(exitObservationsCompleteLoop)
-			}()
-
-		observationsCompleteLoop:
-			for tryAgain {
-				select {
-				case <-exitObservationsCompleteLoop:
-					break observationsCompleteLoop
-				default:
-					instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
-					if err != nil {
-						log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
-						t.FailNow()
-					}
-					if instanceResource.ImportTasks.ImportObservations.State == "completed" {
-						tryAgain = false
-					} else {
-						So(instanceResource.State, ShouldEqual, "submitted")
-						So(instanceResource.ImportTasks.ImportObservations.State, ShouldEqual, "created")
-						time.Sleep(time.Millisecond * 100) // Relax the continuous battering of mongo database
-					}
+	observationsCompleteLoop:
+		for tryAgain {
+			select {
+			case <-exitObservationsCompleteLoop:
+				break observationsCompleteLoop
+			default:
+				instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
+					t.FailNow()
+				}
+				if instanceResource.ImportTasks.ImportObservations.State == "completed" {
+					tryAgain = false
+				} else {
+					So(instanceResource.State, ShouldEqual, "submitted")
+					So(instanceResource.ImportTasks.ImportObservations.State, ShouldEqual, "created")
+					time.Sleep(time.Millisecond * 100) // Relax the continuous battering of mongo database
 				}
 			}
+		}
 
-			if tryAgain != false {
-				err = errors.New("timed out")
-				log.ErrorC("Timed out - failed to get instance document to a state of completed", err, log.Data{"instance_id": instanceID, "state": instanceResource.State, "timeout": timeout})
-				t.FailNow()
-			}
+		if tryAgain != false {
+			err = errors.New("timed out")
+			log.ErrorC("Timed out - failed to get instance document to a state of completed", err, log.Data{"instance_id": instanceID, "state": instanceResource.State, "timeout": timeout})
+			t.FailNow()
+		}
 
-			So(instanceResource.Headers, ShouldResemble, &[]string{"V4_0", "time", "time", "uk-only", "geography", "cpih1dim1aggid", "aggregate"})
-			So(instanceResource.State, ShouldEqual, "submitted")
-			So(instanceResource.ImportTasks.ImportObservations.State, ShouldEqual, "completed")
-			So(instanceResource.ImportTasks.ImportObservations.InsertedObservations, ShouldResemble, totalObservations)
-			So(instanceResource.TotalObservations, ShouldResemble, totalObservations)
+		So(instanceResource.Headers, ShouldResemble, &[]string{"V4_0", "time", "time", "uk-only", "geography", "cpih1dim1aggid", "aggregate"})
+		So(instanceResource.State, ShouldEqual, "submitted")
+		So(instanceResource.ImportTasks.ImportObservations.State, ShouldEqual, "completed")
+		So(instanceResource.ImportTasks.ImportObservations.InsertedObservations, ShouldResemble, totalObservations)
+		So(instanceResource.TotalObservations, ShouldResemble, totalObservations)
 
-			// Check dimension options
-			count, err := mongo.CountDimensionOptions(cfg.MongoDB, "dimension.options", "instance_id", instanceID)
-			if err != nil {
-				log.ErrorC("Unable to retrieve dimension option resources", err, log.Data{"instance_id": instanceID})
-				t.FailNow()
-			}
+		// Check dimension options
+		count, err := mongo.CountDimensionOptions(cfg.MongoDB, "dimension.options", "instance_id", instanceID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve dimension option resources", err, log.Data{"instance_id": instanceID})
+			t.FailNow()
+		}
 
-			So(count, ShouldEqual, 156)
+		So(count, ShouldEqual, 156)
 
-			// Check hierarchies have been built
-			tryAgain = true
+		// Check hierarchies have been built
+		tryAgain = true
 
-			exitHierarchiesCompleteLoop := make(chan bool)
+		exitHierarchiesCompleteLoop := make(chan bool)
 
-			go func() {
-				time.Sleep(timeout)
-				close(exitHierarchiesCompleteLoop)
-			}()
+		go func() {
+			time.Sleep(timeout)
+			close(exitHierarchiesCompleteLoop)
+		}()
 
-		hierarchiesCompleteLoop:
-			for tryAgain {
-				select {
-				case <-exitHierarchiesCompleteLoop:
-					break hierarchiesCompleteLoop
-				default:
-					instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
-					if err != nil {
-						log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
-						t.FailNow()
-					}
+	hierarchiesCompleteLoop:
+		for tryAgain {
+			select {
+			case <-exitHierarchiesCompleteLoop:
+				break hierarchiesCompleteLoop
+			default:
+				instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
+					t.FailNow()
+				}
 
-					if instanceResource.ImportTasks.BuildHierarchyTasks == nil ||
-						len(instanceResource.ImportTasks.BuildHierarchyTasks) < 1 {
+				if instanceResource.ImportTasks.BuildHierarchyTasks == nil ||
+					len(instanceResource.ImportTasks.BuildHierarchyTasks) < 1 {
 
-						log.ErrorC("no build hierarchy tasks found", err, log.Data{"instance_id": instanceID})
-						t.FailNow()
-					}
+					log.ErrorC("no build hierarchy tasks found", err, log.Data{"instance_id": instanceID})
+					t.FailNow()
+				}
 
-					if instanceResource.ImportTasks.BuildHierarchyTasks[0].State == "completed" {
-						tryAgain = false
-					} else {
-						So(instanceResource.State, ShouldEqual, "submitted")
-						So(instanceResource.ImportTasks.BuildHierarchyTasks[0].State, ShouldEqual, "created")
-						time.Sleep(time.Millisecond * 100)
-					}
+				if instanceResource.ImportTasks.BuildHierarchyTasks[0].State == "completed" {
+					tryAgain = false
+				} else {
+					So(instanceResource.State, ShouldEqual, "submitted")
+					So(instanceResource.ImportTasks.BuildHierarchyTasks[0].State, ShouldEqual, "created")
+					time.Sleep(time.Millisecond * 100)
 				}
 			}
+		}
 
-			if tryAgain != false {
-				err = errors.New("timed out")
-				log.ErrorC("Timed out - failed to get instance document to have hierarchy tasks with states of completed", err, log.Data{"instance_id": instanceID, "hierarchy_tasks": instanceResource.ImportTasks.BuildHierarchyTasks, "timeout": timeout})
-				t.FailNow()
-			}
+		if tryAgain != false {
+			err = errors.New("timed out")
+			log.ErrorC("Timed out - failed to get instance document to have hierarchy tasks with states of completed", err, log.Data{"instance_id": instanceID, "hierarchy_tasks": instanceResource.ImportTasks.BuildHierarchyTasks, "timeout": timeout})
+			t.FailNow()
+		}
 
-			// Check hierarchies exist by calling the hierarchy api
-			getHierarchyParentDimensionResponse := hierarchyAPI.GET("/hierarchies/{instance_id}/{dimension}", instanceID, "aggregate").WithHeaders(headers).
-				Expect().Status(http.StatusOK).JSON().Object()
+		// Check hierarchies exist by calling the hierarchy api
+		getHierarchyParentDimensionResponse := hierarchyAPI.GET("/hierarchies/{instance_id}/{dimension}", instanceID, "aggregate").WithHeaders(headers).
+			Expect().Status(http.StatusOK).JSON().Object()
 
-			getHierarchyParentDimensionResponse.Value("has_data").Equal(true)
-			getHierarchyParentDimensionResponse.Value("label").Equal("Overall Index")
-			getHierarchyParentDimensionResponse.Value("no_of_children").Equal(12)
-			getHierarchyParentDimensionResponse.Value("links").Object().Value("code").Object().Value("href").Equal("http://localhost:22400/code-list/cpih1dim1aggid/code/cpih1dim1A0")
-			getHierarchyParentDimensionResponse.Value("links").Object().Value("code").Object().Value("id").Equal("cpih1dim1A0")
-			getHierarchyParentDimensionResponse.Value("links").Object().Value("self").Object().Value("href").Equal("http://localhost:22600/hierarchies/" + instanceID + "/aggregate")
-			getHierarchyParentDimensionResponse.Value("links").Object().Value("self").Object().Value("id").Equal("cpih1dim1A0")
+		getHierarchyParentDimensionResponse.Value("has_data").Equal(true)
+		getHierarchyParentDimensionResponse.Value("label").Equal("Overall Index")
+		getHierarchyParentDimensionResponse.Value("no_of_children").Equal(12)
+		getHierarchyParentDimensionResponse.Value("links").Object().Value("code").Object().Value("href").Equal("http://localhost:22400/code-list/cpih1dim1aggid/code/cpih1dim1A0")
+		getHierarchyParentDimensionResponse.Value("links").Object().Value("code").Object().Value("id").Equal("cpih1dim1A0")
+		getHierarchyParentDimensionResponse.Value("links").Object().Value("self").Object().Value("href").Equal("http://localhost:22600/hierarchies/" + instanceID + "/aggregate")
+		getHierarchyParentDimensionResponse.Value("links").Object().Value("self").Object().Value("id").Equal("cpih1dim1A0")
 
-			numberOfChildren := getHierarchyParentDimensionResponse.Value("no_of_children").Raw()
-			getHierarchyParentDimensionResponse.Value("children").Array().Length().Equal(numberOfChildren)
+		numberOfChildren := getHierarchyParentDimensionResponse.Value("no_of_children").Raw()
+		getHierarchyParentDimensionResponse.Value("children").Array().Length().Equal(numberOfChildren)
 
-			// Reset tryAgain for next loop
-			tryAgain = true
+		// Reset tryAgain for next loop
+		tryAgain = true
 
-			exitElasticSearchCompleteLoop := make(chan bool)
+		exitElasticSearchCompleteLoop := make(chan bool)
 
-			go func() {
-				time.Sleep(timeout)
-				close(exitElasticSearchCompleteLoop)
-			}()
+		go func() {
+			time.Sleep(timeout)
+			close(exitElasticSearchCompleteLoop)
+		}()
 
-			// Check elastic search tasks have completed against instance
-		elasticSearchCompleteLoop:
-			for tryAgain {
-				select {
-				case <-exitElasticSearchCompleteLoop:
-					break elasticSearchCompleteLoop
-				default:
-					instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
-					if err != nil {
-						log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
-						t.FailNow()
-					}
+		// Check elastic search tasks have completed against instance
+	elasticSearchCompleteLoop:
+		for tryAgain {
+			select {
+			case <-exitElasticSearchCompleteLoop:
+				break elasticSearchCompleteLoop
+			default:
+				instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
+					t.FailNow()
+				}
 
-					if instanceResource.ImportTasks.SearchTasks == nil ||
-						len(instanceResource.ImportTasks.SearchTasks) < 1 {
+				if instanceResource.ImportTasks.SearchTasks == nil ||
+					len(instanceResource.ImportTasks.SearchTasks) < 1 {
 
-						log.ErrorC("no build hierarchy tasks found", err, log.Data{"instance_id": instanceID})
-						t.FailNow()
-					}
+					log.ErrorC("no build hierarchy tasks found", err, log.Data{"instance_id": instanceID})
+					t.FailNow()
+				}
 
-					if instanceResource.ImportTasks.SearchTasks[0].State == "completed" {
-						tryAgain = false
-					} else {
-						So(instanceResource.State, ShouldEqual, "submitted")
-						So(instanceResource.ImportTasks.SearchTasks[0].State, ShouldEqual, "created")
-						time.Sleep(time.Millisecond * 100)
-					}
+				if instanceResource.ImportTasks.SearchTasks[0].State == "completed" {
+					tryAgain = false
+				} else {
+					So(instanceResource.State, ShouldEqual, "submitted")
+					So(instanceResource.ImportTasks.SearchTasks[0].State, ShouldEqual, "created")
+					time.Sleep(time.Millisecond * 100)
 				}
 			}
+		}
 
-			if tryAgain != false {
-				err = errors.New("timed out")
-				log.ErrorC("Timed out - failed to get instance document to have search tasks with states of completed", err, log.Data{"instance_id": instanceID, "search_tasks": instanceResource.ImportTasks.SearchTasks, "timeout": timeout})
-				t.FailNow()
-			}
+		if tryAgain != false {
+			err = errors.New("timed out")
+			log.ErrorC("Timed out - failed to get instance document to have search tasks with states of completed", err, log.Data{"instance_id": instanceID, "search_tasks": instanceResource.ImportTasks.SearchTasks, "timeout": timeout})
+			t.FailNow()
+		}
 
-			// todo, add retry loop to check when the instance is set to complete.
-			time.Sleep(time.Second * 5)
+		// todo, add retry loop to check when the instance is set to complete.
+		time.Sleep(time.Second * 5)
 
-			// get the instance again now the tracker has had change to set the instance status to complete
-			instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
-			if err != nil {
-				log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
-				t.FailNow()
-			}
+		// get the instance again now the tracker has had change to set the instance status to complete
+		instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
+			t.FailNow()
+		}
 
-			// Check instance state is completed
-			So(instanceResource.State, ShouldEqual, "completed")
-			So(instanceResource.ImportTasks.SearchTasks[0].DimensionName, ShouldEqual, "aggregate")
+		// Check instance state is completed
+		So(instanceResource.State, ShouldEqual, "completed")
+		So(instanceResource.ImportTasks.SearchTasks[0].DimensionName, ShouldEqual, "aggregate")
 
-			log.Info("Update instance with meta data and change state to `edition-confirmed`", nil)
-			datasetAPI.PUT("/instances/{instance_id}", instanceID).WithHeaders(headers).
-				WithBytes([]byte(validPUTInstanceMetadataJSON)).Expect().Status(http.StatusOK)
+		log.Info("Update instance with meta data and change state to `edition-confirmed`", nil)
+		datasetAPI.PUT("/instances/{instance_id}", instanceID).WithHeaders(headers).
+			WithBytes([]byte(validPUTInstanceMetadataJSON)).Expect().Status(http.StatusOK)
 
-			// Check instance has updated
-			instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
-			if err != nil {
-				log.ErrorC("Unable to retrieve instance resource", err, log.Data{"instance_id": instanceID})
-				t.FailNow()
-			}
+		// Check instance has updated
+		instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve instance resource", err, log.Data{"instance_id": instanceID})
+			t.FailNow()
+		}
 
-			So(instanceResource.Alerts, ShouldNotBeNil)
-			So(instanceResource.Edition, ShouldEqual, "2017")
-			So(instanceResource.LatestChanges, ShouldNotBeNil)
-			So(instanceResource.Links.Dimensions.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1/dimensions")
-			So(instanceResource.Links.Edition.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017")
-			So(instanceResource.Links.Edition.ID, ShouldEqual, "2017")
-			So(instanceResource.Links.Spatial.HRef, ShouldEqual, "http://ons.gov.uk/geography-list")
-			So(instanceResource.Links.Version.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
-			So(instanceResource.Links.Version.ID, ShouldEqual, "1")
-			So(instanceResource.ReleaseDate, ShouldEqual, "2017-11-11")
-			So(instanceResource.State, ShouldEqual, "edition-confirmed")
-			So(instanceResource.Temporal, ShouldNotBeNil)
-			So(instanceResource.Version, ShouldEqual, 1)
+		So(instanceResource.Alerts, ShouldNotBeNil)
+		So(instanceResource.Edition, ShouldEqual, "2017")
+		So(instanceResource.LatestChanges, ShouldNotBeNil)
+		So(instanceResource.Links.Dimensions.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1/dimensions")
+		So(instanceResource.Links.Edition.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017")
+		So(instanceResource.Links.Edition.ID, ShouldEqual, "2017")
+		So(instanceResource.Links.Spatial.HRef, ShouldEqual, "http://ons.gov.uk/geography-list")
+		So(instanceResource.Links.Version.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
+		So(instanceResource.Links.Version.ID, ShouldEqual, "1")
+		So(instanceResource.ReleaseDate, ShouldEqual, "2017-11-11")
+		So(instanceResource.State, ShouldEqual, "edition-confirmed")
+		So(instanceResource.Temporal, ShouldNotBeNil)
+		So(instanceResource.Version, ShouldEqual, 1)
 
-			// Check Edition has been created
-			editionResource, err := mongo.GetEdition(cfg.MongoDB, "editions", "next.links.self.href", instanceResource.Links.Edition.HRef)
-			if err != nil {
-				log.ErrorC("Unable to retrieve edition resource", err, log.Data{"links.self.href": instanceResource.Links.Edition.HRef})
-				t.FailNow()
-			}
+		// Check Edition has been created
+		editionResource, err := mongo.GetEdition(cfg.MongoDB, "editions", "next.links.self.href", instanceResource.Links.Edition.HRef)
+		if err != nil {
+			log.ErrorC("Unable to retrieve edition resource", err, log.Data{"links.self.href": instanceResource.Links.Edition.HRef})
+			t.FailNow()
+		}
 
-			So(editionResource.Next.Edition, ShouldEqual, "2017")
-			So(editionResource.Next.Links.Dataset.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName)
-			So(editionResource.Next.Links.Dataset.ID, ShouldEqual, datasetName)
-			So(editionResource.Next.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
-			So(editionResource.Next.Links.LatestVersion.ID, ShouldEqual, "1")
-			So(editionResource.Next.Links.Self.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017")
-			So(editionResource.Next.Links.Versions.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions")
-			So(editionResource.Next.State, ShouldEqual, "edition-confirmed")
+		So(editionResource.Next.Edition, ShouldEqual, "2017")
+		So(editionResource.Next.Links.Dataset.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName)
+		So(editionResource.Next.Links.Dataset.ID, ShouldEqual, datasetName)
+		So(editionResource.Next.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
+		So(editionResource.Next.Links.LatestVersion.ID, ShouldEqual, "1")
+		So(editionResource.Next.Links.Self.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017")
+		So(editionResource.Next.Links.Versions.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions")
+		So(editionResource.Next.State, ShouldEqual, "edition-confirmed")
 
-			log.Info("Update version with collection_id and change state to associated", nil)
-			datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetName, "2017", "1").WithHeaders(headers).
-				WithBytes([]byte(validPUTUpdateVersionToAssociatedJSON)).Expect().Status(http.StatusOK)
+		log.Info("Update version with collection_id and change state to associated", nil)
+		datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetName, "2017", "1").WithHeaders(headers).
+			WithBytes([]byte(validPUTUpdateVersionToAssociatedJSON)).Expect().Status(http.StatusOK)
 
-			versionResource, err := mongo.GetVersion(cfg.MongoDB, "instances", "id", instanceID)
-			if err != nil {
-				log.ErrorC("Unable to retrieve version resource", err, log.Data{"instance_id": instanceID})
-				t.FailNow()
-			}
+		versionResource, err := mongo.GetVersion(cfg.MongoDB, "instances", "id", instanceID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve version resource", err, log.Data{"instance_id": instanceID})
+			t.FailNow()
+		}
 
-			So(versionResource.CollectionID, ShouldEqual, "308064B3-A808-449B-9041-EA3A2F72CFAC")
-			So(versionResource.State, ShouldEqual, "associated")
+		So(versionResource.CollectionID, ShouldEqual, "308064B3-A808-449B-9041-EA3A2F72CFAC")
+		So(versionResource.State, ShouldEqual, "associated")
 
-			// Check dataset has updated
-			datasetResource, err := mongo.GetDataset(cfg.MongoDB, "datasets", "_id", datasetName)
-			if err != nil {
-				log.ErrorC("Unable to retrieve dataset resource", err, log.Data{"dataset_id": datasetName})
-				t.FailNow()
-			}
+		// Check dataset has updated
+		datasetResource, err := mongo.GetDataset(cfg.MongoDB, "datasets", "_id", datasetName)
+		if err != nil {
+			log.ErrorC("Unable to retrieve dataset resource", err, log.Data{"dataset_id": datasetName})
+			t.FailNow()
+		}
 
-			So(datasetResource.Current, ShouldBeNil)
-			So(datasetResource.Next.CollectionID, ShouldEqual, "308064B3-A808-449B-9041-EA3A2F72CFAC")
-			So(datasetResource.Next.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
-			So(datasetResource.Next.Links.LatestVersion.ID, ShouldEqual, "1")
-			So(datasetResource.Next.State, ShouldEqual, "associated")
+		So(datasetResource.Current, ShouldBeNil)
+		So(datasetResource.Next.CollectionID, ShouldEqual, "308064B3-A808-449B-9041-EA3A2F72CFAC")
+		So(datasetResource.Next.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
+		So(datasetResource.Next.Links.LatestVersion.ID, ShouldEqual, "1")
+		So(datasetResource.Next.State, ShouldEqual, "associated")
 
-			exitHasDownloadsLoop := make(chan bool)
+		exitHasDownloadsLoop := make(chan bool)
 
-			go func() {
-				time.Sleep(timeout)
-				close(exitHasDownloadsLoop)
-			}()
+		go func() {
+			time.Sleep(timeout)
+			close(exitHasDownloadsLoop)
+		}()
 
-			// Waiting for version to have downloads before updating state to published
-			hasDownloads := false
-			var XLSSize int
-		hasDownloadsLoop:
-			for !hasDownloads {
-				select {
-				case <-exitHasDownloadsLoop:
-					break hasDownloadsLoop
-				default:
+		// Waiting for version to have downloads before updating state to published
+		hasDownloads := false
+		var XLSSize int
+	hasDownloadsLoop:
+		for !hasDownloads {
+			select {
+			case <-exitHasDownloadsLoop:
+				break hasDownloadsLoop
+			default:
 
-					instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
-					if err != nil {
-						log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
-						t.FailNow()
-					}
+				instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
+					t.FailNow()
+				}
 
-					if instanceResource.Downloads != nil {
-						if instanceResource.Downloads.XLS != nil {
-							if instanceResource.Downloads.XLS.Private != "" {
-								XLSSize, err = strconv.Atoi(instanceResource.Downloads.XLS.Size)
-								if err != nil {
-									log.ErrorC("cannot convert xls size of type string to integer", err, log.Data{"xls_size": instanceResource.Downloads.XLS.Size})
-									t.FailNow()
-								}
-								So(XLSSize, ShouldBeBetweenOrEqual, 19000, 20000)
-								So(instanceResource.Downloads.XLS.Private, ShouldNotBeEmpty)
-								CSVSize, err := strconv.Atoi(instanceResource.Downloads.CSV.Size)
-								if err != nil {
-									log.ErrorC("cannot convert csv size of type string to integer", err, log.Data{"csv_size": instanceResource.Downloads.CSV.Size})
-									t.FailNow()
-								}
-								So(CSVSize, ShouldBeBetweenOrEqual, 137000, 139000)
-								So(instanceResource.Downloads.CSV.URL, ShouldNotBeEmpty)
-								hasDownloads = true
+				if instanceResource.Downloads != nil {
+					if instanceResource.Downloads.XLS != nil {
+						if instanceResource.Downloads.XLS.Private != "" {
+							XLSSize, err = strconv.Atoi(instanceResource.Downloads.XLS.Size)
+							if err != nil {
+								log.ErrorC("cannot convert xls size of type string to integer", err, log.Data{"xls_size": instanceResource.Downloads.XLS.Size})
+								t.FailNow()
 							}
-						}
-					} else {
-						So(instanceResource.State, ShouldEqual, "associated")
-					}
-
-					time.Sleep(time.Millisecond * 200)
-				}
-			}
-
-			if hasDownloads == false {
-				err := errors.New("timed out")
-				log.ErrorC("Timed out - failed to get instance document with available downloads", err, log.Data{"instance_id": instanceID, "downloads": instanceResource.Downloads, "timeout": timeout})
-				t.FailNow()
-			}
-
-			log.Info("Then an authenticated user should be able to filter a dataset", nil)
-
-			filterBlueprintID, filterOutputID := testFiltering(t, filterAPI, instanceID, false)
-
-			filterBlueprint := &mongo.Doc{
-				Database:   cfg.MongoFiltersDB,
-				Collection: "filters",
-				Key:        "filter_id",
-				Value:      filterBlueprintID,
-			}
-
-			filterOutput := &mongo.Doc{
-				Database:   cfg.MongoFiltersDB,
-				Collection: "filterOutputs",
-				Key:        "filter_id",
-				Value:      filterOutputID,
-			}
-
-			// remove filter output
-			if err = mongo.Teardown(filterBlueprint, filterOutput); err != nil {
-				if err != mgo.ErrNotFound {
-					log.ErrorC("failed to remove filter output resource", err, log.Data{"filter_output_id": filterOutputID})
-					hasRemovedAllResources = false
-				}
-			}
-
-			log.Info("STEP 6 - Update version to a state of published", nil)
-			datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetName, "2017", "1").WithHeaders(headers).
-				WithBytes([]byte(`{"state":"published"}`)).Expect().Status(http.StatusOK)
-
-			versionResource, err = mongo.GetVersion(cfg.MongoDB, "instances", "id", instanceID)
-			if err != nil {
-				log.ErrorC("Unable to retrieve version resource", err, log.Data{"instance_id": instanceID})
-				t.FailNow()
-			}
-
-			So(versionResource.State, ShouldEqual, "published")
-
-			log.Info("Check edition has updated", nil)
-			editionResource, err = mongo.GetEdition(cfg.MongoDB, "editions", "current.links.self.href", instanceResource.Links.Edition.HRef)
-			if err != nil {
-				log.ErrorC("Unable to retrieve dataset resource", err, log.Data{"dataset_id": datasetName})
-				t.FailNow()
-			}
-
-			So(editionResource.Next.State, ShouldEqual, "published")
-			So(editionResource.Current, ShouldNotBeNil)
-			So(editionResource.Current.State, ShouldEqual, "published")
-
-			log.Info("Check dataset has updated", nil)
-			datasetResource, err = mongo.GetDataset(cfg.MongoDB, "datasets", "_id", datasetName)
-			if err != nil {
-				log.ErrorC("Unable to retrieve dataset resource", err, log.Data{"dataset_id": datasetName})
-				t.FailNow()
-			}
-
-			So(datasetResource.Current, ShouldNotBeNil)
-			So(datasetResource.Current.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
-			So(datasetResource.Current.State, ShouldEqual, "published")
-
-			log.Info("Check data exists in elaticsearch by calling search API to find dimension option", nil)
-			getSearchResponse := searchAPI.GET("/search/datasets/{id}/editions/{edition}/versions/{version}/dimensions/{dimension}", datasetName, versionResource.Edition, strconv.Itoa(versionResource.Version), "aggregate").
-				WithQuery("q", "Overall Index").Expect().Status(http.StatusOK).JSON().Object()
-
-			getSearchResponse.Value("count").Equal(1)
-			getSearchResponse.Value("items").Array().Length().Equal(1)
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("code").Equal("cpih1dim1A0")
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("dimension_option_url").Equal("http://localhost:22400/code-list/cpih1dim1aggid/code/cpih1dim1A0")
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("has_data").Equal(true)
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("label").Equal("Overall Index")
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().NotContainsKey("code")
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Length().Equal(2)
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Element(0).Object().Value("start").Equal(1)
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Element(0).Object().Value("end").Equal(7)
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Element(1).Object().Value("start").Equal(9)
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Element(1).Object().Value("end").Equal(13)
-			getSearchResponse.Value("items").Array().Element(0).Object().Value("number_of_children").Equal(12)
-			getSearchResponse.Value("limit").Equal(20)
-			getSearchResponse.Value("offset").Equal(0)
-
-			Convey("Then an api customer should be able to get a csv and xls download link", func() {
-
-				log.Info("Get downloads link from version document", nil)
-				csvURL := versionResource.Downloads.CSV.URL
-
-				response, err := http.Get(csvURL)
-				if err != nil {
-					log.Error(err, nil)
-				}
-				defer response.Body.Close()
-
-				csvReader := csv.NewReader(response.Body)
-
-				headerRow, err := csvReader.Read()
-				if err != nil {
-					log.ErrorC("unable to read header row", err, log.Data{"csv_url": csvURL})
-				}
-
-				So(len(headerRow), ShouldEqual, 7)
-
-				log.Info("check the number of rows and anything else (e.g. meta data)", nil)
-				numberOfCSVRows := 0
-				for {
-					_, err = csvReader.Read()
-					if err != nil {
-						if err == io.EOF {
-							break
-						}
-						log.ErrorC("unable to read row", err, log.Data{"csv_url": csvURL})
-						t.FailNow()
-					}
-					numberOfCSVRows++
-				}
-				So(numberOfCSVRows, ShouldEqual, 1510)
-
-				xlsURL := versionResource.Downloads.XLS.URL
-
-				xlsResponse, err := http.Get(xlsURL)
-				if err != nil {
-					log.Error(err, nil)
-				}
-				xlsFile := xlsResponse.Body
-
-				So(xlsFile, ShouldNotBeEmpty)
-
-				b, _ := ioutil.ReadAll(xlsFile)
-				xlsFileSize := len(b)
-
-				expectedXLSFileSize := XLSSize
-				So(xlsFileSize, ShouldResemble, expectedXLSFileSize)
-
-				log.Info("Then an api customer should be able to filter a dataset and be able to download", nil)
-				Convey("Then an api customer should be able to filter a dataset and be able to download a csv and xlsx download of the data", func() {
-
-					filterBlueprintID, filterOutputID := testFiltering(t, filterAPI, instanceID, true)
-					if err != nil {
-						return
-					}
-
-					filterBlueprint := &mongo.Doc{
-						Database:   cfg.MongoFiltersDB,
-						Collection: "filters",
-						Key:        "filter_id",
-						Value:      filterBlueprintID,
-					}
-
-					filterOutput := &mongo.Doc{
-						Database:   cfg.MongoFiltersDB,
-						Collection: "filterOutputs",
-						Key:        "filter_id",
-						Value:      filterOutputID,
-					}
-
-					// remove filter output
-					if err = mongo.Teardown(filterBlueprint, filterOutput); err != nil {
-						if err != mgo.ErrNotFound {
-							log.ErrorC("failed to remove filter output resource", err, log.Data{"filter_output_id": filterOutputID})
-							hasRemovedAllResources = false
+							So(XLSSize, ShouldBeBetweenOrEqual, 19000, 20000)
+							So(instanceResource.Downloads.XLS.Private, ShouldNotBeEmpty)
+							CSVSize, err := strconv.Atoi(instanceResource.Downloads.CSV.Size)
+							if err != nil {
+								log.ErrorC("cannot convert csv size of type string to integer", err, log.Data{"csv_size": instanceResource.Downloads.CSV.Size})
+								t.FailNow()
+							}
+							So(CSVSize, ShouldBeBetweenOrEqual, 137000, 139000)
+							So(instanceResource.Downloads.CSV.URL, ShouldNotBeEmpty)
+							hasDownloads = true
 						}
 					}
-				})
+				} else {
+					So(instanceResource.State, ShouldEqual, "associated")
+				}
+
+				time.Sleep(time.Millisecond * 200)
+			}
+		}
+
+		if hasDownloads == false {
+			err := errors.New("timed out")
+			log.ErrorC("Timed out - failed to get instance document with available downloads", err, log.Data{"instance_id": instanceID, "downloads": instanceResource.Downloads, "timeout": timeout})
+			t.FailNow()
+		}
+
+		log.Info("attempting to read private full file download from S3", nil)
+		instanceResource, err = mongo.GetInstance(cfg.MongoDB, "instances", "id", instanceID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve instance document", err, log.Data{"instance_id": instanceID})
+			t.FailNow()
+		}
+
+		logData := log.Data{
+			"private_csv_link": instanceResource.Downloads.CSV.Private,
+			"private_xls_link": instanceResource.Downloads.XLS.Private,
+		}
+		log.Debug("Pre publish full downloads have been generated", logData)
+
+		u, err := url.Parse(instanceResource.Downloads.CSV.Private)
+		if err != nil {
+			t.Error("failed to parse filtered XLS URL", err)
+			t.FailNow()
+		}
+		privateCSVFilename := strings.TrimLeft(u.Path, "/")
+
+		// read csv download from s3
+		privateCSVFile, err := getS3File(region, bucket, privateCSVFilename, true)
+		if err != nil {
+			log.ErrorC("unable to find csv download in s3", err, nil)
+			t.Error()
+			t.FailNow()
+		}
+		privateCSVReader := csv.NewReader(privateCSVFile)
+		if err = checkFileRowCount(privateCSVReader, 1511); err != nil {
+			log.ErrorC("unable to check file row count", err, nil)
+			t.FailNow()
+		}
+
+		log.Info("Then an authenticated user should be able to filter a dataset", nil)
+
+		prePublishFilterBlueprintID, prePublishFilterOutputID := testFiltering(t, filterAPI, instanceID, false)
+
+		log.Info("pre publish filter test passed", log.Data{
+			"filter_blueprint": prePublishFilterBlueprintID,
+			"filter_output":    prePublishFilterOutputID,
+		})
+
+		prePublishFilterBlueprint := &mongo.Doc{
+			Database:   cfg.MongoFiltersDB,
+			Collection: "filters",
+			Key:        "filter_id",
+			Value:      prePublishFilterBlueprintID,
+		}
+
+		prePublishFilterOutput := &mongo.Doc{
+			Database:   cfg.MongoFiltersDB,
+			Collection: "filterOutputs",
+			Key:        "filter_id",
+			Value:      prePublishFilterOutputID,
+		}
+
+		//remove filter output
+		if err = mongo.Teardown(prePublishFilterBlueprint, prePublishFilterOutput); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("failed to remove filter output resource", err, log.Data{"filter_output_id": prePublishFilterOutputID})
+				hasRemovedAllResources = false
+			}
+		}
+
+		log.Info("STEP 6 - Update version to a state of published", nil)
+		datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetName, "2017", "1").WithHeaders(headers).
+			WithBytes([]byte(`{"state":"published"}`)).Expect().Status(http.StatusOK)
+
+		versionResource, err = mongo.GetVersion(cfg.MongoDB, "instances", "id", instanceID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve version resource", err, log.Data{"instance_id": instanceID})
+			t.FailNow()
+		}
+
+		log.Info("Check edition has updated", nil)
+		editionResource, err = mongo.GetEdition(cfg.MongoDB, "editions", "current.links.self.href", instanceResource.Links.Edition.HRef)
+		if err != nil {
+			log.ErrorC("Unable to retrieve dataset resource", err, log.Data{"dataset_id": datasetName})
+			t.FailNow()
+		}
+
+		So(editionResource.Next.State, ShouldEqual, "published")
+		So(editionResource.Current, ShouldNotBeNil)
+		So(editionResource.Current.State, ShouldEqual, "published")
+
+		log.Info("Check dataset has updated", nil)
+		datasetResource, err = mongo.GetDataset(cfg.MongoDB, "datasets", "_id", datasetName)
+		if err != nil {
+			log.ErrorC("Unable to retrieve dataset resource", err, log.Data{"dataset_id": datasetName})
+			t.FailNow()
+		}
+
+		So(datasetResource.Current, ShouldNotBeNil)
+		So(datasetResource.Current.Links.LatestVersion.HRef, ShouldEqual, cfg.DatasetAPIURL+"/datasets/"+datasetName+"/editions/2017/versions/1")
+		So(datasetResource.Current.State, ShouldEqual, "published")
+
+		log.Info("Check data exists in elaticsearch by calling search API to find dimension option", nil)
+		getSearchResponse := searchAPI.GET("/search/datasets/{id}/editions/{edition}/versions/{version}/dimensions/{dimension}", datasetName, versionResource.Edition, strconv.Itoa(versionResource.Version), "aggregate").
+			WithQuery("q", "Overall Index").Expect().Status(http.StatusOK).JSON().Object()
+
+		getSearchResponse.Value("count").Equal(1)
+		getSearchResponse.Value("items").Array().Length().Equal(1)
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("code").Equal("cpih1dim1A0")
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("dimension_option_url").Equal("http://localhost:22400/code-list/cpih1dim1aggid/code/cpih1dim1A0")
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("has_data").Equal(true)
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("label").Equal("Overall Index")
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().NotContainsKey("code")
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Length().Equal(2)
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Element(0).Object().Value("start").Equal(1)
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Element(0).Object().Value("end").Equal(7)
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Element(1).Object().Value("start").Equal(9)
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("matches").Object().Value("label").Array().Element(1).Object().Value("end").Equal(13)
+		getSearchResponse.Value("items").Array().Element(0).Object().Value("number_of_children").Equal(12)
+		getSearchResponse.Value("limit").Equal(20)
+		getSearchResponse.Value("offset").Equal(0)
+
+		versionResourcePostPublish, err := mongo.GetVersion(cfg.MongoDB, "instances", "id", instanceID)
+		if err != nil {
+			log.ErrorC("Unable to retrieve version resource", err, log.Data{"instance_id": instanceID})
+			t.FailNow()
+		}
+		logData ["after_loop_public_csv_link"] = versionResourcePostPublish.Downloads.CSV.Public
+		logData ["after_loop_public_xls_link"] = versionResourcePostPublish.Downloads.CSV.Public
+		log.Debug("Pre publish full downloads have been generated", logData)
+
+		log.Info("Get downloads link from version document", nil)
+		csvURL := versionResource.Downloads.CSV.URL
+
+		log.Debug("getting downloads from the version",
+			log.Data{
+				"csv_link": versionResource.Downloads.CSV.URL,
+				"xls_link": versionResource.Downloads.XLS.URL,
 			})
 
-			var docs []*mongo.Doc
+		response, err := http.Get(csvURL)
+		if err != nil {
+			log.Error(err, nil)
+		}
+		log.Info("get csv response", log.Data{
+			"response_status": response.StatusCode,
+		})
+		defer response.Body.Close()
 
-			dataset := &mongo.Doc{
-				Database:   cfg.MongoDB,
-				Collection: "datasets",
-				Key:        "_id",
-				Value:      datasetName,
-			}
+		csvReader := csv.NewReader(response.Body)
 
-			importJob := &mongo.Doc{
-				Database:   cfg.MongoImportsDB,
-				Collection: "imports",
-				Key:        "id",
-				Value:      jobID,
-			}
+		headerRow, err := csvReader.Read()
+		if err != nil {
+			log.ErrorC("unable to read header row", err, log.Data{"csv_url": csvURL})
+		}
 
-			instance := &mongo.Doc{
-				Database:   cfg.MongoDB,
-				Collection: "instances",
-				Key:        "id",
-				Value:      instanceID,
-			}
+		So(len(headerRow), ShouldEqual, 7)
 
-			edition := &mongo.Doc{
-				Database:   cfg.MongoDB,
-				Collection: "editions",
-				Key:        "links.self.href",
-				Value:      instanceResource.Links.Edition.HRef,
-			}
-
-			docs = append(docs, dataset, importJob, instance, edition)
-
-			// remove all mongo documents created in the test
-			if err = mongo.Teardown(docs...); err != nil {
-				if err != mgo.ErrNotFound {
-					log.ErrorC("failed to remove edition resource", err, log.Data{"links.self.href": instanceResource.Links.Edition.HRef})
-					hasRemovedAllResources = false
-				}
-			}
-
-			// remove all dimension options from mongo collection
-			if err = mongo.TeardownAll(cfg.MongoDB, "dimension.options"); err != nil {
-				if err != mgo.ErrNotFound {
-					log.ErrorC("failed to remove edition resource", err, log.Data{"links.self.href": instanceResource.Links.Edition.HRef})
-					hasRemovedAllResources = false
-				}
-			}
-
-			// remove elasticsearch index for instance and dimension (call elasticsearch directly)
-			if _, err = elasticsearch.DeleteIndex(cfg.ElasticSearchAPIURL + "/" + instanceID + "_aggregate"); err != nil {
-				log.ErrorC("Failed to delete index from elasticsearch", err, nil)
-				hasRemovedAllResources = false
-			}
-
-			// remove instance from neo4j
-			datastore, err := neo4j.NewDatastore(cfg.Neo4jAddr, instanceID, "")
+		log.Info("check the number of rows and anything else (e.g. meta data)", nil)
+		numberOfCSVRows := 0
+		for {
+			_, err = csvReader.Read()
 			if err != nil {
-				log.ErrorC("Failed to connecton to neo4j database", err, nil)
+				if err == io.EOF {
+					break
+				}
+				log.ErrorC("unable to read row", err, log.Data{"csv_url": csvURL})
 				t.FailNow()
 			}
+			numberOfCSVRows++
+		}
+		So(numberOfCSVRows, ShouldEqual, 1510)
 
-			if err = datastore.TeardownInstance(); err != nil {
-				log.ErrorC("Failed to delete all instances in neo4j database", err, nil)
+		xlsURL := versionResource.Downloads.XLS.URL
+
+		xlsResponse, err := http.Get(xlsURL)
+		if err != nil {
+			log.Error(err, nil)
+		}
+		xlsFile := xlsResponse.Body
+
+		So(xlsFile, ShouldNotBeEmpty)
+
+		b, _ := ioutil.ReadAll(xlsFile)
+		xlsFileSize := len(b)
+
+		expectedXLSFileSize := XLSSize
+		So(xlsFileSize, ShouldResemble, expectedXLSFileSize)
+
+		exitHasPublicDownloadsLoop := make(chan bool)
+
+		go func() {
+			time.Sleep(timeout)
+			close(exitHasPublicDownloadsLoop)
+		}()
+
+		// Waiting for version to have downloads before updating state to published
+	hasPublicDownloadsLoop:
+		for {
+			select {
+			case <-exitHasPublicDownloadsLoop:
+				err := errors.New("timed out")
+				log.ErrorC("timeout waiting for public full download links to be generated", err, nil)
+				t.FailNow()
+			default:
+
+				versionResourcePostPublish, err := mongo.GetVersion(cfg.MongoDB, "instances", "id", instanceID)
+				if err != nil {
+					log.ErrorC("Unable to retrieve version resource", err, log.Data{"instance_id": instanceID})
+					t.FailNow()
+				}
+
+				if versionResourcePostPublish.Downloads.XLS.Public != "" {
+					break hasPublicDownloadsLoop
+				}
+			}
+		}
+
+		log.Info("Then an api customer should be able to filter a dataset and be able to download", nil)
+
+		filterBlueprintID, filterOutputID := testFiltering(t, filterAPI, instanceID, true)
+		if err != nil {
+			return
+		}
+
+		filterBlueprint := &mongo.Doc{
+			Database:   cfg.MongoFiltersDB,
+			Collection: "filters",
+			Key:        "filter_id",
+			Value:      filterBlueprintID,
+		}
+
+		filterOutput := &mongo.Doc{
+			Database:   cfg.MongoFiltersDB,
+			Collection: "filterOutputs",
+			Key:        "filter_id",
+			Value:      filterOutputID,
+		}
+
+		// remove filter output
+		if err = mongo.Teardown(filterBlueprint, filterOutput); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("failed to remove filter output resource", err, log.Data{"filter_output_id": filterOutputID})
 				hasRemovedAllResources = false
 			}
-		})
+		}
+
+		var docs []*mongo.Doc
+
+		dataset := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: "datasets",
+			Key:        "_id",
+			Value:      datasetName,
+		}
+
+		importJob := &mongo.Doc{
+			Database:   cfg.MongoImportsDB,
+			Collection: "imports",
+			Key:        "id",
+			Value:      jobID,
+		}
+
+		instance := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: "instances",
+			Key:        "id",
+			Value:      instanceID,
+		}
+
+		edition := &mongo.Doc{
+			Database:   cfg.MongoDB,
+			Collection: "editions",
+			Key:        "links.self.href",
+			Value:      instanceResource.Links.Edition.HRef,
+		}
+
+		docs = append(docs, dataset, importJob, instance, edition)
+
+		log.Debug("tearing down", nil)
+
+		// remove all mongo documents created in the test
+		if err = mongo.Teardown(docs...); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("failed to remove edition resource", err, log.Data{"links.self.href": instanceResource.Links.Edition.HRef})
+				hasRemovedAllResources = false
+			}
+		}
+
+		// remove all dimension options from mongo collection
+		if err = mongo.TeardownAll(cfg.MongoDB, "dimension.options"); err != nil {
+			if err != mgo.ErrNotFound {
+				log.ErrorC("failed to remove edition resource", err, log.Data{"links.self.href": instanceResource.Links.Edition.HRef})
+				hasRemovedAllResources = false
+			}
+		}
+
+		// remove elasticsearch index for instance and dimension (call elasticsearch directly)
+		if _, err = elasticsearch.DeleteIndex(cfg.ElasticSearchAPIURL + "/" + instanceID + "_aggregate"); err != nil {
+			log.ErrorC("Failed to delete index from elasticsearch", err, nil)
+			hasRemovedAllResources = false
+		}
+
+		// remove instance from neo4j
+		datastore, err := neo4j.NewDatastore(cfg.Neo4jAddr, instanceID, "")
+		if err != nil {
+			log.ErrorC("Failed to connecton to neo4j database", err, nil)
+			t.FailNow()
+		}
+
+		if err = datastore.TeardownInstance(); err != nil {
+			log.ErrorC("Failed to delete all instances in neo4j database", err, nil)
+			hasRemovedAllResources = false
+		}
 
 		// remove test file from s3
 		if err := deleteS3File("eu-west-1", "ons-dp-cmd-test", "v4TestFile.csv"); err != nil {
@@ -725,6 +803,13 @@ func testFiltering(t *testing.T, filterAPI *httpexpect.Expect, instanceID string
 	So(filterOutputResource.Downloads.CSV, ShouldNotBeNil)
 	So(filterOutputResource.Downloads.XLS, ShouldNotBeNil)
 
+	log.Debug("filter is complete, checking csv download",
+		log.Data{
+			"public_link":  filterOutputResource.Downloads.CSV.Public,
+			"private_link": filterOutputResource.Downloads.CSV.Private,
+			"href":         filterOutputResource.Downloads.CSV.HRef,
+		})
+
 	filteredCSVURL := filterOutputResource.Downloads.CSV.Public
 	if !isPublished {
 		filteredCSVURL = filterOutputResource.Downloads.CSV.Private
@@ -735,7 +820,7 @@ func testFiltering(t *testing.T, filterAPI *httpexpect.Expect, instanceID string
 		t.Error("failed to parse filtered XLS URL", err)
 		t.FailNow()
 	}
-	filteredCSVFilename := u.Path
+	filteredCSVFilename := strings.TrimLeft(u.Path, "/")
 
 	// read csv download from s3
 	filteredCSVFile, err := getS3File(region, bucket, filteredCSVFilename, !isPublished)
@@ -750,6 +835,13 @@ func testFiltering(t *testing.T, filterAPI *httpexpect.Expect, instanceID string
 		t.FailNow()
 	}
 
+	log.Debug("checking xlsx download",
+		log.Data{
+			"public_link":  filterOutputResource.Downloads.XLS.Public,
+			"private_link": filterOutputResource.Downloads.XLS.Private,
+			"href":         filterOutputResource.Downloads.XLS.HRef,
+		})
+
 	filteredXLSURL := filterOutputResource.Downloads.XLS.Public
 	if !isPublished {
 		filteredXLSURL = filterOutputResource.Downloads.XLS.Private
@@ -760,7 +852,7 @@ func testFiltering(t *testing.T, filterAPI *httpexpect.Expect, instanceID string
 		t.Error("failed to parse filtered XLS URL", err)
 		t.FailNow()
 	}
-	filteredXLSFilename := u.Path
+	filteredXLSFilename := strings.TrimLeft(u.Path, "/")
 
 	// read xls download from s3
 	filteredXLSFile, err := getS3File(region, bucket, filteredXLSFilename, !isPublished)

--- a/endToEndTests/end_to_end_api_test.go
+++ b/endToEndTests/end_to_end_api_test.go
@@ -16,10 +16,9 @@ import (
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/gavv/httpexpect"
 	. "github.com/smartystreets/goconvey/convey"
-	"net/url"
-	"strings"
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/elasticsearch"
 	"github.com/ONSdigital/dp-api-tests/testDataSetup/neo4j"
+	"path/filepath"
 )
 
 var timeout = time.Duration(15 * time.Second)
@@ -427,12 +426,7 @@ func TestSuccessfulEndToEndProcess(t *testing.T) {
 		}
 		log.Debug("Pre publish full downloads have been generated", logData)
 
-		u, err := url.Parse(instanceResource.Downloads.CSV.Private)
-		if err != nil {
-			t.Error("failed to parse filtered XLS URL", err)
-			t.FailNow()
-		}
-		privateCSVFilename := strings.TrimLeft(u.Path, "/")
+		privateCSVFilename := filepath.Base(instanceResource.Downloads.CSV.Private)
 
 		// read csv download from s3
 		privateCSVFile, err := getS3File(region, bucket, privateCSVFilename, true)
@@ -815,12 +809,7 @@ func testFiltering(t *testing.T, filterAPI *httpexpect.Expect, instanceID string
 		filteredCSVURL = filterOutputResource.Downloads.CSV.Private
 	}
 
-	u, err := url.Parse(filteredCSVURL)
-	if err != nil {
-		t.Error("failed to parse filtered XLS URL", err)
-		t.FailNow()
-	}
-	filteredCSVFilename := strings.TrimLeft(u.Path, "/")
+	filteredCSVFilename := filepath.Base(filteredCSVURL)
 
 	// read csv download from s3
 	filteredCSVFile, err := getS3File(region, bucket, filteredCSVFilename, !isPublished)
@@ -846,13 +835,7 @@ func testFiltering(t *testing.T, filterAPI *httpexpect.Expect, instanceID string
 	if !isPublished {
 		filteredXLSURL = filterOutputResource.Downloads.XLS.Private
 	}
-
-	u, err = url.Parse(filteredXLSURL)
-	if err != nil {
-		t.Error("failed to parse filtered XLS URL", err)
-		t.FailNow()
-	}
-	filteredXLSFilename := strings.TrimLeft(u.Path, "/")
+	filteredXLSFilename := filepath.Base(filteredXLSURL)
 
 	// read xls download from s3
 	filteredXLSFile, err := getS3File(region, bucket, filteredXLSFilename, !isPublished)

--- a/endToEndTests/initialise.go
+++ b/endToEndTests/initialise.go
@@ -26,7 +26,7 @@ const (
 	florenceTokenHeader      = "X-Florence-Token"
 	florenceToken            = "85c718c3-9ba4-4f31-99bb-3e4eaabb2cc1"
 	authorizationTokenHeader = "Authorization"
-	authorizationToken       = "939616dc-7599-4ded-9a86-a9c66fbf98e0"
+	authorizationToken       = "Bearer FD0108EA-825D-411C-9B1D-41EF7727F465"
 	bucket                   = "csv-exported"
 
 	invalidToken = "FD0108EA-825D-411C-9B1D-41EF7727F465A"

--- a/endToEndTests/initialise.go
+++ b/endToEndTests/initialise.go
@@ -15,8 +15,6 @@ import (
 var cfg *config.Config
 
 const (
-	importTracker = "dp-import-tracker"
-
 	region     = "eu-west-1"
 	bucketName = "ons-dp-cmd-test"
 
@@ -28,8 +26,6 @@ const (
 	authorizationTokenHeader = "Authorization"
 	authorizationToken       = "Bearer FD0108EA-825D-411C-9B1D-41EF7727F465"
 	bucket                   = "csv-exported"
-
-	invalidToken = "FD0108EA-825D-411C-9B1D-41EF7727F465A"
 )
 
 var (

--- a/endToEndTests/policy.hcl
+++ b/endToEndTests/policy.hcl
@@ -1,3 +1,3 @@
 path "secret/shared/psk" {
-  capabilities = ["read", "create", "update"]
+  capabilities = ["read", "create", "update", "list"]
 }

--- a/endToEndTests/policy.hcl
+++ b/endToEndTests/policy.hcl
@@ -1,3 +1,3 @@
-path "secret/shared/psk" {
-  capabilities = ["read", "create", "update", "list"]
+path "secret/shared/psk/*" {
+  capabilities = ["read", "create", "update"]
 }

--- a/endToEndTests/setup.go
+++ b/endToEndTests/setup.go
@@ -93,7 +93,10 @@ func sendV4FileToAWS(region, bucket, filename string, encrypt bool) error {
 		psk := createPSK()
 		pskStr := hex.EncodeToString(psk)
 
-		err := vaultClient.WriteKey(cfg.VaultPath, filename, pskStr)
+		vaultPath := cfg.VaultPath + "/" + filename
+		vaultKey := "key"
+
+		err := vaultClient.WriteKey(vaultPath, vaultKey, pskStr)
 		if err != nil {
 			log.ErrorC("failed to write to vault", err, nil)
 			return err
@@ -153,7 +156,10 @@ func getS3File(region, bucket, filename string, decrypt bool) (io.ReadCloser, er
 			log.Data{"vault_path": cfg.VaultPath,
 				"filename": filename})
 
-		pskStr, err := vaultClient.ReadKey(cfg.VaultPath, filename)
+		vaultPath := cfg.VaultPath + "/" + filename
+		vaultKey := "key"
+
+		pskStr, err := vaultClient.ReadKey(vaultPath, vaultKey)
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +171,8 @@ func getS3File(region, bucket, filename string, decrypt bool) (io.ReadCloser, er
 		log.Debug("reading file with psk",
 			log.Data{"vault_path": cfg.VaultPath,
 				"filename": filename,
-				"psk": psk})
+				"psk": psk,
+			})
 
 		output, err = client.GetObjectWithPSK(input, psk)
 		if err != nil {

--- a/endToEndTests/setup.go
+++ b/endToEndTests/setup.go
@@ -119,6 +119,11 @@ func sendV4FileToAWS(region, bucket, filename string, encrypt bool) error {
 func getS3File(region, bucket, filename string, decrypt bool) (io.ReadCloser, error) {
 	config := aws.NewConfig().WithRegion(region)
 
+	log.Debug("attempting to get file from s3",
+		log.Data{"bucket": bucket,
+			"filename": filename,
+			"decrypt": decrypt})
+
 	store := &Store{
 		config: config,
 		bucket: bucket,
@@ -143,6 +148,11 @@ func getS3File(region, bucket, filename string, decrypt bool) (io.ReadCloser, er
 
 	var output *s3.GetObjectOutput
 	if decrypt {
+
+		log.Debug("reading key from vault",
+			log.Data{"vault_path": cfg.VaultPath,
+				"filename": filename})
+
 		pskStr, err := vaultClient.ReadKey(cfg.VaultPath, filename)
 		if err != nil {
 			return nil, err
@@ -151,6 +161,11 @@ func getS3File(region, bucket, filename string, decrypt bool) (io.ReadCloser, er
 		if err != nil {
 			return nil, err
 		}
+
+		log.Debug("reading file with psk",
+			log.Data{"vault_path": cfg.VaultPath,
+				"filename": filename,
+				"psk": psk})
 
 		output, err = client.GetObjectWithPSK(input, psk)
 		if err != nil {

--- a/vendor/github.com/aws/aws-sdk-go/aws/config.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/config.go
@@ -151,6 +151,15 @@ type Config struct {
 	// with accelerate.
 	S3UseAccelerate *bool
 
+	// S3DisableContentMD5Validation config option is temporarily disabled,
+	// For S3 GetObject API calls, #1837.
+	//
+	// Set this to `true` to disable the S3 service client from automatically
+	// adding the ContentMD5 to S3 Object Put and Upload API calls. This option
+	// will also disable the SDK from performing object ContentMD5 validation
+	// on GetObject API calls.
+	S3DisableContentMD5Validation *bool
+
 	// Set this to `true` to disable the EC2Metadata client from overriding the
 	// default http.Client's Timeout. This is helpful if you do not want the
 	// EC2Metadata client to create a new http.Client. This options is only
@@ -168,7 +177,7 @@ type Config struct {
 	//
 	EC2MetadataDisableTimeoutOverride *bool
 
-	// Instructs the endpiont to be generated for a service client to
+	// Instructs the endpoint to be generated for a service client to
 	// be the dual stack endpoint. The dual stack endpoint will support
 	// both IPv4 and IPv6 addressing.
 	//
@@ -336,6 +345,15 @@ func (c *Config) WithS3Disable100Continue(disable bool) *Config {
 func (c *Config) WithS3UseAccelerate(enable bool) *Config {
 	c.S3UseAccelerate = &enable
 	return c
+
+}
+
+// WithS3DisableContentMD5Validation sets a config
+// S3DisableContentMD5Validation value returning a Config pointer for chaining.
+func (c *Config) WithS3DisableContentMD5Validation(enable bool) *Config {
+	c.S3DisableContentMD5Validation = &enable
+	return c
+
 }
 
 // WithUseDualStack sets a config UseDualStack value returning a Config
@@ -433,6 +451,10 @@ func mergeInConfig(dst *Config, other *Config) {
 
 	if other.S3UseAccelerate != nil {
 		dst.S3UseAccelerate = other.S3UseAccelerate
+	}
+
+	if other.S3DisableContentMD5Validation != nil {
+		dst.S3DisableContentMD5Validation = other.S3DisableContentMD5Validation
 	}
 
 	if other.UseDualStack != nil {

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.12.37"
+const SDKVersion = "1.13.32"

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.6.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.6.go
@@ -1,0 +1,10 @@
+// +build !go1.7
+
+package sdkio
+
+// Copy of Go 1.7 io package's Seeker constants.
+const (
+	SeekStart   = 0 // seek relative to the origin of the file
+	SeekCurrent = 1 // seek relative to the current offset
+	SeekEnd     = 2 // seek relative to the end
+)

--- a/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.7.go
+++ b/vendor/github.com/aws/aws-sdk-go/internal/sdkio/io_go1.7.go
@@ -1,0 +1,12 @@
+// +build go1.7
+
+package sdkio
+
+import "io"
+
+// Alias for Go 1.7 io package Seeker constants
+const (
+	SeekStart   = io.SeekStart   // seek relative to the origin of the file
+	SeekCurrent = io.SeekCurrent // seek relative to the current offset
+	SeekEnd     = io.SeekEnd     // seek relative to the end
+)

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/batch.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/batch.go
@@ -1,0 +1,524 @@
+package s3manager
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+const (
+	// DefaultBatchSize is the batch size we initialize when constructing a batch delete client.
+	// This value is used when calling DeleteObjects. This represents how many objects to delete
+	// per DeleteObjects call.
+	DefaultBatchSize = 100
+)
+
+// BatchError will contain the key and bucket of the object that failed to
+// either upload or download.
+type BatchError struct {
+	Errors  Errors
+	code    string
+	message string
+}
+
+// Errors is a typed alias for a slice of errors to satisfy the error
+// interface.
+type Errors []Error
+
+func (errs Errors) Error() string {
+	buf := bytes.NewBuffer(nil)
+	for i, err := range errs {
+		buf.WriteString(err.Error())
+		if i+1 < len(errs) {
+			buf.WriteString("\n")
+		}
+	}
+	return buf.String()
+}
+
+// Error will contain the original error, bucket, and key of the operation that failed
+// during batch operations.
+type Error struct {
+	OrigErr error
+	Bucket  *string
+	Key     *string
+}
+
+func newError(err error, bucket, key *string) Error {
+	return Error{
+		err,
+		bucket,
+		key,
+	}
+}
+
+func (err *Error) Error() string {
+	origErr := ""
+	if err.OrigErr != nil {
+		origErr = ":\n" + err.OrigErr.Error()
+	}
+	return fmt.Sprintf("failed to perform batch operation on %q to %q%s",
+		aws.StringValue(err.Key),
+		aws.StringValue(err.Bucket),
+		origErr,
+	)
+}
+
+// NewBatchError will return a BatchError that satisfies the awserr.Error interface.
+func NewBatchError(code, message string, err []Error) awserr.Error {
+	return &BatchError{
+		Errors:  err,
+		code:    code,
+		message: message,
+	}
+}
+
+// Code will return the code associated with the batch error.
+func (err *BatchError) Code() string {
+	return err.code
+}
+
+// Message will return the message associated with the batch error.
+func (err *BatchError) Message() string {
+	return err.message
+}
+
+func (err *BatchError) Error() string {
+	return awserr.SprintError(err.Code(), err.Message(), "", err.Errors)
+}
+
+// OrigErr will return the original error. Which, in this case, will always be nil
+// for batched operations.
+func (err *BatchError) OrigErr() error {
+	return err.Errors
+}
+
+// BatchDeleteIterator is an interface that uses the scanner pattern to
+// iterate through what needs to be deleted.
+type BatchDeleteIterator interface {
+	Next() bool
+	Err() error
+	DeleteObject() BatchDeleteObject
+}
+
+// DeleteListIterator is an alternative iterator for the BatchDelete client. This will
+// iterate through a list of objects and delete the objects.
+//
+// Example:
+//	iter := &s3manager.DeleteListIterator{
+//		Client: svc,
+//		Input: &s3.ListObjectsInput{
+//			Bucket:  aws.String("bucket"),
+//			MaxKeys: aws.Int64(5),
+//		},
+//		Paginator: request.Pagination{
+//			NewRequest: func() (*request.Request, error) {
+//				var inCpy *ListObjectsInput
+//				if input != nil {
+//					tmp := *input
+//					inCpy = &tmp
+//				}
+//				req, _ := c.ListObjectsRequest(inCpy)
+//				return req, nil
+//			},
+//		},
+//	}
+//
+//	batcher := s3manager.NewBatchDeleteWithClient(svc)
+//	if err := batcher.Delete(aws.BackgroundContext(), iter); err != nil {
+//		return err
+//	}
+type DeleteListIterator struct {
+	Bucket    *string
+	Paginator request.Pagination
+	objects   []*s3.Object
+}
+
+// NewDeleteListIterator will return a new DeleteListIterator.
+func NewDeleteListIterator(svc s3iface.S3API, input *s3.ListObjectsInput, opts ...func(*DeleteListIterator)) BatchDeleteIterator {
+	iter := &DeleteListIterator{
+		Bucket: input.Bucket,
+		Paginator: request.Pagination{
+			NewRequest: func() (*request.Request, error) {
+				var inCpy *s3.ListObjectsInput
+				if input != nil {
+					tmp := *input
+					inCpy = &tmp
+				}
+				req, _ := svc.ListObjectsRequest(inCpy)
+				return req, nil
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(iter)
+	}
+	return iter
+}
+
+// Next will use the S3API client to iterate through a list of objects.
+func (iter *DeleteListIterator) Next() bool {
+	if len(iter.objects) > 0 {
+		iter.objects = iter.objects[1:]
+	}
+
+	if len(iter.objects) == 0 && iter.Paginator.Next() {
+		iter.objects = iter.Paginator.Page().(*s3.ListObjectsOutput).Contents
+	}
+
+	return len(iter.objects) > 0
+}
+
+// Err will return the last known error from Next.
+func (iter *DeleteListIterator) Err() error {
+	return iter.Paginator.Err()
+}
+
+// DeleteObject will return the current object to be deleted.
+func (iter *DeleteListIterator) DeleteObject() BatchDeleteObject {
+	return BatchDeleteObject{
+		Object: &s3.DeleteObjectInput{
+			Bucket: iter.Bucket,
+			Key:    iter.objects[0].Key,
+		},
+	}
+}
+
+// BatchDelete will use the s3 package's service client to perform a batch
+// delete.
+type BatchDelete struct {
+	Client    s3iface.S3API
+	BatchSize int
+}
+
+// NewBatchDeleteWithClient will return a new delete client that can delete a batched amount of
+// objects.
+//
+// Example:
+//	batcher := s3manager.NewBatchDeleteWithClient(client, size)
+//
+//	objects := []BatchDeleteObject{
+//		{
+//			Object:	&s3.DeleteObjectInput {
+//				Key: aws.String("key"),
+//				Bucket: aws.String("bucket"),
+//			},
+//		},
+//	}
+//
+//	if err := batcher.Delete(aws.BackgroundContext(), &s3manager.DeleteObjectsIterator{
+//		Objects: objects,
+//	}); err != nil {
+//		return err
+//	}
+func NewBatchDeleteWithClient(client s3iface.S3API, options ...func(*BatchDelete)) *BatchDelete {
+	svc := &BatchDelete{
+		Client:    client,
+		BatchSize: DefaultBatchSize,
+	}
+
+	for _, opt := range options {
+		opt(svc)
+	}
+
+	return svc
+}
+
+// NewBatchDelete will return a new delete client that can delete a batched amount of
+// objects.
+//
+// Example:
+//	batcher := s3manager.NewBatchDelete(sess, size)
+//
+//	objects := []BatchDeleteObject{
+//		{
+//			Object:	&s3.DeleteObjectInput {
+//				Key: aws.String("key"),
+//				Bucket: aws.String("bucket"),
+//			},
+//		},
+//	}
+//
+//	if err := batcher.Delete(aws.BackgroundContext(), &s3manager.DeleteObjectsIterator{
+//		Objects: objects,
+//	}); err != nil {
+//		return err
+//	}
+func NewBatchDelete(c client.ConfigProvider, options ...func(*BatchDelete)) *BatchDelete {
+	client := s3.New(c)
+	return NewBatchDeleteWithClient(client, options...)
+}
+
+// BatchDeleteObject is a wrapper object for calling the batch delete operation.
+type BatchDeleteObject struct {
+	Object *s3.DeleteObjectInput
+	// After will run after each iteration during the batch process. This function will
+	// be executed whether or not the request was successful.
+	After func() error
+}
+
+// DeleteObjectsIterator is an interface that uses the scanner pattern to iterate
+// through a series of objects to be deleted.
+type DeleteObjectsIterator struct {
+	Objects []BatchDeleteObject
+	index   int
+	inc     bool
+}
+
+// Next will increment the default iterator's index and and ensure that there
+// is another object to iterator to.
+func (iter *DeleteObjectsIterator) Next() bool {
+	if iter.inc {
+		iter.index++
+	} else {
+		iter.inc = true
+	}
+	return iter.index < len(iter.Objects)
+}
+
+// Err will return an error. Since this is just used to satisfy the BatchDeleteIterator interface
+// this will only return nil.
+func (iter *DeleteObjectsIterator) Err() error {
+	return nil
+}
+
+// DeleteObject will return the BatchDeleteObject at the current batched index.
+func (iter *DeleteObjectsIterator) DeleteObject() BatchDeleteObject {
+	object := iter.Objects[iter.index]
+	return object
+}
+
+// Delete will use the iterator to queue up objects that need to be deleted.
+// Once the batch size is met, this will call the deleteBatch function.
+func (d *BatchDelete) Delete(ctx aws.Context, iter BatchDeleteIterator) error {
+	var errs []Error
+	objects := []BatchDeleteObject{}
+	var input *s3.DeleteObjectsInput
+
+	for iter.Next() {
+		o := iter.DeleteObject()
+
+		if input == nil {
+			input = initDeleteObjectsInput(o.Object)
+		}
+
+		parity := hasParity(input, o)
+		if parity {
+			input.Delete.Objects = append(input.Delete.Objects, &s3.ObjectIdentifier{
+				Key:       o.Object.Key,
+				VersionId: o.Object.VersionId,
+			})
+			objects = append(objects, o)
+		}
+
+		if len(input.Delete.Objects) == d.BatchSize || !parity {
+			if err := deleteBatch(ctx, d, input, objects); err != nil {
+				errs = append(errs, err...)
+			}
+
+			objects = objects[:0]
+			input = nil
+
+			if !parity {
+				objects = append(objects, o)
+				input = initDeleteObjectsInput(o.Object)
+				input.Delete.Objects = append(input.Delete.Objects, &s3.ObjectIdentifier{
+					Key:       o.Object.Key,
+					VersionId: o.Object.VersionId,
+				})
+			}
+		}
+	}
+
+	if input != nil && len(input.Delete.Objects) > 0 {
+		if err := deleteBatch(ctx, d, input, objects); err != nil {
+			errs = append(errs, err...)
+		}
+	}
+
+	if len(errs) > 0 {
+		return NewBatchError("BatchedDeleteIncomplete", "some objects have failed to be deleted.", errs)
+	}
+	return nil
+}
+
+func initDeleteObjectsInput(o *s3.DeleteObjectInput) *s3.DeleteObjectsInput {
+	return &s3.DeleteObjectsInput{
+		Bucket:       o.Bucket,
+		MFA:          o.MFA,
+		RequestPayer: o.RequestPayer,
+		Delete:       &s3.Delete{},
+	}
+}
+
+const (
+	// ErrDeleteBatchFailCode represents an error code which will be returned
+	// only when DeleteObjects.Errors has an error that does not contain a code.
+	ErrDeleteBatchFailCode       = "DeleteBatchError"
+	errDefaultDeleteBatchMessage = "failed to delete"
+)
+
+// deleteBatch will delete a batch of items in the objects parameters.
+func deleteBatch(ctx aws.Context, d *BatchDelete, input *s3.DeleteObjectsInput, objects []BatchDeleteObject) []Error {
+	errs := []Error{}
+
+	if result, err := d.Client.DeleteObjectsWithContext(ctx, input); err != nil {
+		for i := 0; i < len(input.Delete.Objects); i++ {
+			errs = append(errs, newError(err, input.Bucket, input.Delete.Objects[i].Key))
+		}
+	} else if len(result.Errors) > 0 {
+		for i := 0; i < len(result.Errors); i++ {
+			code := ErrDeleteBatchFailCode
+			msg := errDefaultDeleteBatchMessage
+			if result.Errors[i].Message != nil {
+				msg = *result.Errors[i].Message
+			}
+			if result.Errors[i].Code != nil {
+				code = *result.Errors[i].Code
+			}
+
+			errs = append(errs, newError(awserr.New(code, msg, err), input.Bucket, result.Errors[i].Key))
+		}
+	}
+	for _, object := range objects {
+		if object.After == nil {
+			continue
+		}
+		if err := object.After(); err != nil {
+			errs = append(errs, newError(err, object.Object.Bucket, object.Object.Key))
+		}
+	}
+
+	return errs
+}
+
+func hasParity(o1 *s3.DeleteObjectsInput, o2 BatchDeleteObject) bool {
+	if o1.Bucket != nil && o2.Object.Bucket != nil {
+		if *o1.Bucket != *o2.Object.Bucket {
+			return false
+		}
+	} else if o1.Bucket != o2.Object.Bucket {
+		return false
+	}
+
+	if o1.MFA != nil && o2.Object.MFA != nil {
+		if *o1.MFA != *o2.Object.MFA {
+			return false
+		}
+	} else if o1.MFA != o2.Object.MFA {
+		return false
+	}
+
+	if o1.RequestPayer != nil && o2.Object.RequestPayer != nil {
+		if *o1.RequestPayer != *o2.Object.RequestPayer {
+			return false
+		}
+	} else if o1.RequestPayer != o2.Object.RequestPayer {
+		return false
+	}
+
+	return true
+}
+
+// BatchDownloadIterator is an interface that uses the scanner pattern to iterate
+// through a series of objects to be downloaded.
+type BatchDownloadIterator interface {
+	Next() bool
+	Err() error
+	DownloadObject() BatchDownloadObject
+}
+
+// BatchDownloadObject contains all necessary information to run a batch operation once.
+type BatchDownloadObject struct {
+	Object *s3.GetObjectInput
+	Writer io.WriterAt
+	// After will run after each iteration during the batch process. This function will
+	// be executed whether or not the request was successful.
+	After func() error
+}
+
+// DownloadObjectsIterator implements the BatchDownloadIterator interface and allows for batched
+// download of objects.
+type DownloadObjectsIterator struct {
+	Objects []BatchDownloadObject
+	index   int
+	inc     bool
+}
+
+// Next will increment the default iterator's index and and ensure that there
+// is another object to iterator to.
+func (batcher *DownloadObjectsIterator) Next() bool {
+	if batcher.inc {
+		batcher.index++
+	} else {
+		batcher.inc = true
+	}
+	return batcher.index < len(batcher.Objects)
+}
+
+// DownloadObject will return the BatchDownloadObject at the current batched index.
+func (batcher *DownloadObjectsIterator) DownloadObject() BatchDownloadObject {
+	object := batcher.Objects[batcher.index]
+	return object
+}
+
+// Err will return an error. Since this is just used to satisfy the BatchDeleteIterator interface
+// this will only return nil.
+func (batcher *DownloadObjectsIterator) Err() error {
+	return nil
+}
+
+// BatchUploadIterator is an interface that uses the scanner pattern to
+// iterate through what needs to be uploaded.
+type BatchUploadIterator interface {
+	Next() bool
+	Err() error
+	UploadObject() BatchUploadObject
+}
+
+// UploadObjectsIterator implements the BatchUploadIterator interface and allows for batched
+// upload of objects.
+type UploadObjectsIterator struct {
+	Objects []BatchUploadObject
+	index   int
+	inc     bool
+}
+
+// Next will increment the default iterator's index and and ensure that there
+// is another object to iterator to.
+func (batcher *UploadObjectsIterator) Next() bool {
+	if batcher.inc {
+		batcher.index++
+	} else {
+		batcher.inc = true
+	}
+	return batcher.index < len(batcher.Objects)
+}
+
+// Err will return an error. Since this is just used to satisfy the BatchUploadIterator interface
+// this will only return nil.
+func (batcher *UploadObjectsIterator) Err() error {
+	return nil
+}
+
+// UploadObject will return the BatchUploadObject at the current batched index.
+func (batcher *UploadObjectsIterator) UploadObject() BatchUploadObject {
+	object := batcher.Objects[batcher.index]
+	return object
+}
+
+// BatchUploadObject contains all necessary information to run a batch operation once.
+type BatchUploadObject struct {
+	Object *UploadInput
+	// After will run after each iteration during the batch process. This function will
+	// be executed whether or not the request was successful.
+	After func() error
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/bucket_region.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/bucket_region.go
@@ -1,0 +1,88 @@
+package s3manager
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+// GetBucketRegion will attempt to get the region for a bucket using the
+// regionHint to determine which AWS partition to perform the query on.
+//
+// The request will not be signed, and will not use your AWS credentials.
+//
+// A "NotFound" error code will be returned if the bucket does not exist in the
+// AWS partition the regionHint belongs to. If the regionHint parameter is an
+// empty string GetBucketRegion will fallback to the ConfigProvider's region
+// config. If the regionHint is empty, and the ConfigProvider does not have a
+// region value, an error will be returned..
+//
+// For example to get the region of a bucket which exists in "eu-central-1"
+// you could provide a region hint of "us-west-2".
+//
+//    sess := session.Must(session.NewSession())
+//
+//    bucket := "my-bucket"
+//    region, err := s3manager.GetBucketRegion(ctx, sess, bucket, "us-west-2")
+//    if err != nil {
+//        if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
+//             fmt.Fprintf(os.Stderr, "unable to find bucket %s's region not found\n", bucket)
+//        }
+//        return err
+//    }
+//    fmt.Printf("Bucket %s is in %s region\n", bucket, region)
+//
+func GetBucketRegion(ctx aws.Context, c client.ConfigProvider, bucket, regionHint string, opts ...request.Option) (string, error) {
+	var cfg aws.Config
+	if len(regionHint) != 0 {
+		cfg.Region = aws.String(regionHint)
+	}
+	svc := s3.New(c, &cfg)
+	return GetBucketRegionWithClient(ctx, svc, bucket, opts...)
+}
+
+const bucketRegionHeader = "X-Amz-Bucket-Region"
+
+// GetBucketRegionWithClient is the same as GetBucketRegion with the exception
+// that it takes a S3 service client instead of a Session. The regionHint is
+// derived from the region the S3 service client was created in.
+//
+// See GetBucketRegion for more information.
+func GetBucketRegionWithClient(ctx aws.Context, svc s3iface.S3API, bucket string, opts ...request.Option) (string, error) {
+	req, _ := svc.HeadBucketRequest(&s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	req.Config.S3ForcePathStyle = aws.Bool(true)
+	req.Config.Credentials = credentials.AnonymousCredentials
+	req.SetContext(ctx)
+
+	// Disable HTTP redirects to prevent an invalid 301 from eating the response
+	// because Go's HTTP client will fail, and drop the response if an 301 is
+	// received without a location header. S3 will return a 301 without the
+	// location header for HeadObject API calls.
+	req.DisableFollowRedirects = true
+
+	var bucketRegion string
+	req.Handlers.Send.PushBack(func(r *request.Request) {
+		bucketRegion = r.HTTPResponse.Header.Get(bucketRegionHeader)
+		if len(bucketRegion) == 0 {
+			return
+		}
+		r.HTTPResponse.StatusCode = 200
+		r.HTTPResponse.Status = "OK"
+		r.Error = nil
+	})
+
+	req.ApplyOptions(opts...)
+
+	if err := req.Send(); err != nil {
+		return "", err
+	}
+
+	bucketRegion = s3.NormalizeBucketLocation(bucketRegion)
+
+	return bucketRegion, nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/doc.go
@@ -1,0 +1,3 @@
+// Package s3manager provides utilities to upload and download objects from
+// S3 concurrently. Helpful for when working with large objects.
+package s3manager

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/download.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/download.go
@@ -1,0 +1,547 @@
+package s3manager
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+// DefaultDownloadPartSize is the default range of bytes to get at a time when
+// using Download().
+const DefaultDownloadPartSize = 1024 * 1024 * 5
+
+// DefaultDownloadConcurrency is the default number of goroutines to spin up
+// when using Download().
+const DefaultDownloadConcurrency = 5
+
+// The Downloader structure that calls Download(). It is safe to call Download()
+// on this structure for multiple objects and across concurrent goroutines.
+// Mutating the Downloader's properties is not safe to be done concurrently.
+type Downloader struct {
+	// The buffer size (in bytes) to use when buffering data into chunks and
+	// sending them as parts to S3. The minimum allowed part size is 5MB, and
+	// if this value is set to zero, the DefaultDownloadPartSize value will be used.
+	//
+	// PartSize is ignored if the Range input parameter is provided.
+	PartSize int64
+
+	// The number of goroutines to spin up in parallel when sending parts.
+	// If this is set to zero, the DefaultDownloadConcurrency value will be used.
+	//
+	// Concurrency is ignored if the Range input parameter is provided.
+	Concurrency int
+
+	// An S3 client to use when performing downloads.
+	S3 s3iface.S3API
+
+	// List of request options that will be passed down to individual API
+	// operation requests made by the downloader.
+	RequestOptions []request.Option
+}
+
+// WithDownloaderRequestOptions appends to the Downloader's API request options.
+func WithDownloaderRequestOptions(opts ...request.Option) func(*Downloader) {
+	return func(d *Downloader) {
+		d.RequestOptions = append(d.RequestOptions, opts...)
+	}
+}
+
+// NewDownloader creates a new Downloader instance to downloads objects from
+// S3 in concurrent chunks. Pass in additional functional options  to customize
+// the downloader behavior. Requires a client.ConfigProvider in order to create
+// a S3 service client. The session.Session satisfies the client.ConfigProvider
+// interface.
+//
+// Example:
+//     // The session the S3 Downloader will use
+//     sess := session.Must(session.NewSession())
+//
+//     // Create a downloader with the session and default options
+//     downloader := s3manager.NewDownloader(sess)
+//
+//     // Create a downloader with the session and custom options
+//     downloader := s3manager.NewDownloader(sess, func(d *s3manager.Downloader) {
+//          d.PartSize = 64 * 1024 * 1024 // 64MB per part
+//     })
+func NewDownloader(c client.ConfigProvider, options ...func(*Downloader)) *Downloader {
+	d := &Downloader{
+		S3:          s3.New(c),
+		PartSize:    DefaultDownloadPartSize,
+		Concurrency: DefaultDownloadConcurrency,
+	}
+	for _, option := range options {
+		option(d)
+	}
+
+	return d
+}
+
+// NewDownloaderWithClient creates a new Downloader instance to downloads
+// objects from S3 in concurrent chunks. Pass in additional functional
+// options to customize the downloader behavior. Requires a S3 service client
+// to make S3 API calls.
+//
+// Example:
+//     // The session the S3 Downloader will use
+//     sess := session.Must(session.NewSession())
+//
+//     // The S3 client the S3 Downloader will use
+//     s3Svc := s3.new(sess)
+//
+//     // Create a downloader with the s3 client and default options
+//     downloader := s3manager.NewDownloaderWithClient(s3Svc)
+//
+//     // Create a downloader with the s3 client and custom options
+//     downloader := s3manager.NewDownloaderWithClient(s3Svc, func(d *s3manager.Downloader) {
+//          d.PartSize = 64 * 1024 * 1024 // 64MB per part
+//     })
+func NewDownloaderWithClient(svc s3iface.S3API, options ...func(*Downloader)) *Downloader {
+	d := &Downloader{
+		S3:          svc,
+		PartSize:    DefaultDownloadPartSize,
+		Concurrency: DefaultDownloadConcurrency,
+	}
+	for _, option := range options {
+		option(d)
+	}
+
+	return d
+}
+
+type maxRetrier interface {
+	MaxRetries() int
+}
+
+// Download downloads an object in S3 and writes the payload into w using
+// concurrent GET requests.
+//
+// Additional functional options can be provided to configure the individual
+// download. These options are copies of the Downloader instance Download is called from.
+// Modifying the options will not impact the original Downloader instance.
+//
+// It is safe to call this method concurrently across goroutines.
+//
+// The w io.WriterAt can be satisfied by an os.File to do multipart concurrent
+// downloads, or in memory []byte wrapper using aws.WriteAtBuffer.
+//
+// If the GetObjectInput's Range value is provided that will cause the downloader
+// to perform a single GetObjectInput request for that object's range. This will
+// caused the part size, and concurrency configurations to be ignored.
+func (d Downloader) Download(w io.WriterAt, input *s3.GetObjectInput, options ...func(*Downloader)) (n int64, err error) {
+	return d.DownloadWithContext(aws.BackgroundContext(), w, input, options...)
+}
+
+// DownloadWithContext downloads an object in S3 and writes the payload into w
+// using concurrent GET requests.
+//
+// DownloadWithContext is the same as Download with the additional support for
+// Context input parameters. The Context must not be nil. A nil Context will
+// cause a panic. Use the Context to add deadlining, timeouts, ect. The
+// DownloadWithContext may create sub-contexts for individual underlying
+// requests.
+//
+// Additional functional options can be provided to configure the individual
+// download. These options are copies of the Downloader instance Download is
+// called from. Modifying the options will not impact the original Downloader
+// instance. Use the WithDownloaderRequestOptions helper function to pass in request
+// options that will be applied to all API operations made with this downloader.
+//
+// The w io.WriterAt can be satisfied by an os.File to do multipart concurrent
+// downloads, or in memory []byte wrapper using aws.WriteAtBuffer.
+//
+// It is safe to call this method concurrently across goroutines.
+//
+// If the GetObjectInput's Range value is provided that will cause the downloader
+// to perform a single GetObjectInput request for that object's range. This will
+// caused the part size, and concurrency configurations to be ignored.
+func (d Downloader) DownloadWithContext(ctx aws.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*Downloader)) (n int64, err error) {
+	impl := downloader{w: w, in: input, cfg: d, ctx: ctx}
+
+	for _, option := range options {
+		option(&impl.cfg)
+	}
+	impl.cfg.RequestOptions = append(impl.cfg.RequestOptions, request.WithAppendUserAgent("S3Manager"))
+
+	if s, ok := d.S3.(maxRetrier); ok {
+		impl.partBodyMaxRetries = s.MaxRetries()
+	}
+
+	impl.totalBytes = -1
+	if impl.cfg.Concurrency == 0 {
+		impl.cfg.Concurrency = DefaultDownloadConcurrency
+	}
+
+	if impl.cfg.PartSize == 0 {
+		impl.cfg.PartSize = DefaultDownloadPartSize
+	}
+
+	return impl.download()
+}
+
+// DownloadWithIterator will download a batched amount of objects in S3 and writes them
+// to the io.WriterAt specificed in the iterator.
+//
+// Example:
+//	svc := s3manager.NewDownloader(session)
+//
+//	fooFile, err := os.Open("/tmp/foo.file")
+//	if err != nil {
+//		return err
+//	}
+//
+//	barFile, err := os.Open("/tmp/bar.file")
+//	if err != nil {
+//		return err
+//	}
+//
+//	objects := []s3manager.BatchDownloadObject {
+//		{
+//			Input: &s3.GetObjectInput {
+//				Bucket: aws.String("bucket"),
+//				Key: aws.String("foo"),
+//			},
+//			Writer: fooFile,
+//		},
+//		{
+//			Input: &s3.GetObjectInput {
+//				Bucket: aws.String("bucket"),
+//				Key: aws.String("bar"),
+//			},
+//			Writer: barFile,
+//		},
+//	}
+//
+//	iter := &s3manager.DownloadObjectsIterator{Objects: objects}
+//	if err := svc.DownloadWithIterator(aws.BackgroundContext(), iter); err != nil {
+//		return err
+//	}
+func (d Downloader) DownloadWithIterator(ctx aws.Context, iter BatchDownloadIterator, opts ...func(*Downloader)) error {
+	var errs []Error
+	for iter.Next() {
+		object := iter.DownloadObject()
+		if _, err := d.DownloadWithContext(ctx, object.Writer, object.Object, opts...); err != nil {
+			errs = append(errs, newError(err, object.Object.Bucket, object.Object.Key))
+		}
+
+		if object.After == nil {
+			continue
+		}
+
+		if err := object.After(); err != nil {
+			errs = append(errs, newError(err, object.Object.Bucket, object.Object.Key))
+		}
+	}
+
+	if len(errs) > 0 {
+		return NewBatchError("BatchedDownloadIncomplete", "some objects have failed to download.", errs)
+	}
+	return nil
+}
+
+// downloader is the implementation structure used internally by Downloader.
+type downloader struct {
+	ctx aws.Context
+	cfg Downloader
+
+	in *s3.GetObjectInput
+	w  io.WriterAt
+
+	wg sync.WaitGroup
+	m  sync.Mutex
+
+	pos        int64
+	totalBytes int64
+	written    int64
+	err        error
+
+	partBodyMaxRetries int
+}
+
+// download performs the implementation of the object download across ranged
+// GETs.
+func (d *downloader) download() (n int64, err error) {
+	// If range is specified fall back to single download of that range
+	// this enables the functionality of ranged gets with the downloader but
+	// at the cost of no multipart downloads.
+	if rng := aws.StringValue(d.in.Range); len(rng) > 0 {
+		d.downloadRange(rng)
+		return d.written, d.err
+	}
+
+	// Spin off first worker to check additional header information
+	d.getChunk()
+
+	if total := d.getTotalBytes(); total >= 0 {
+		// Spin up workers
+		ch := make(chan dlchunk, d.cfg.Concurrency)
+
+		for i := 0; i < d.cfg.Concurrency; i++ {
+			d.wg.Add(1)
+			go d.downloadPart(ch)
+		}
+
+		// Assign work
+		for d.getErr() == nil {
+			if d.pos >= total {
+				break // We're finished queuing chunks
+			}
+
+			// Queue the next range of bytes to read.
+			ch <- dlchunk{w: d.w, start: d.pos, size: d.cfg.PartSize}
+			d.pos += d.cfg.PartSize
+		}
+
+		// Wait for completion
+		close(ch)
+		d.wg.Wait()
+	} else {
+		// Checking if we read anything new
+		for d.err == nil {
+			d.getChunk()
+		}
+
+		// We expect a 416 error letting us know we are done downloading the
+		// total bytes. Since we do not know the content's length, this will
+		// keep grabbing chunks of data until the range of bytes specified in
+		// the request is out of range of the content. Once, this happens, a
+		// 416 should occur.
+		e, ok := d.err.(awserr.RequestFailure)
+		if ok && e.StatusCode() == http.StatusRequestedRangeNotSatisfiable {
+			d.err = nil
+		}
+	}
+
+	// Return error
+	return d.written, d.err
+}
+
+// downloadPart is an individual goroutine worker reading from the ch channel
+// and performing a GetObject request on the data with a given byte range.
+//
+// If this is the first worker, this operation also resolves the total number
+// of bytes to be read so that the worker manager knows when it is finished.
+func (d *downloader) downloadPart(ch chan dlchunk) {
+	defer d.wg.Done()
+	for {
+		chunk, ok := <-ch
+		if !ok {
+			break
+		}
+		if d.getErr() != nil {
+			// Drain the channel if there is an error, to prevent deadlocking
+			// of download producer.
+			continue
+		}
+
+		if err := d.downloadChunk(chunk); err != nil {
+			d.setErr(err)
+		}
+	}
+}
+
+// getChunk grabs a chunk of data from the body.
+// Not thread safe. Should only used when grabbing data on a single thread.
+func (d *downloader) getChunk() {
+	if d.getErr() != nil {
+		return
+	}
+
+	chunk := dlchunk{w: d.w, start: d.pos, size: d.cfg.PartSize}
+	d.pos += d.cfg.PartSize
+
+	if err := d.downloadChunk(chunk); err != nil {
+		d.setErr(err)
+	}
+}
+
+// downloadRange downloads an Object given the passed in Byte-Range value.
+// The chunk used down download the range will be configured for that range.
+func (d *downloader) downloadRange(rng string) {
+	if d.getErr() != nil {
+		return
+	}
+
+	chunk := dlchunk{w: d.w, start: d.pos}
+	// Ranges specified will short circuit the multipart download
+	chunk.withRange = rng
+
+	if err := d.downloadChunk(chunk); err != nil {
+		d.setErr(err)
+	}
+
+	// Update the position based on the amount of data received.
+	d.pos = d.written
+}
+
+// downloadChunk downloads the chunk from s3
+func (d *downloader) downloadChunk(chunk dlchunk) error {
+	in := &s3.GetObjectInput{}
+	awsutil.Copy(in, d.in)
+
+	// Get the next byte range of data
+	in.Range = aws.String(chunk.ByteRange())
+
+	var n int64
+	var err error
+	for retry := 0; retry <= d.partBodyMaxRetries; retry++ {
+		var resp *s3.GetObjectOutput
+		resp, err = d.cfg.S3.GetObjectWithContext(d.ctx, in, d.cfg.RequestOptions...)
+		if err != nil {
+			return err
+		}
+		d.setTotalBytes(resp) // Set total if not yet set.
+
+		n, err = io.Copy(&chunk, resp.Body)
+		resp.Body.Close()
+		if err == nil {
+			break
+		}
+
+		chunk.cur = 0
+		logMessage(d.cfg.S3, aws.LogDebugWithRequestRetries,
+			fmt.Sprintf("DEBUG: object part body download interrupted %s, err, %v, retrying attempt %d",
+				aws.StringValue(in.Key), err, retry))
+	}
+
+	d.incrWritten(n)
+
+	return err
+}
+
+func logMessage(svc s3iface.S3API, level aws.LogLevelType, msg string) {
+	s, ok := svc.(*s3.S3)
+	if !ok {
+		return
+	}
+
+	if s.Config.Logger == nil {
+		return
+	}
+
+	if s.Config.LogLevel.Matches(level) {
+		s.Config.Logger.Log(msg)
+	}
+}
+
+// getTotalBytes is a thread-safe getter for retrieving the total byte status.
+func (d *downloader) getTotalBytes() int64 {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	return d.totalBytes
+}
+
+// setTotalBytes is a thread-safe setter for setting the total byte status.
+// Will extract the object's total bytes from the Content-Range if the file
+// will be chunked, or Content-Length. Content-Length is used when the response
+// does not include a Content-Range. Meaning the object was not chunked. This
+// occurs when the full file fits within the PartSize directive.
+func (d *downloader) setTotalBytes(resp *s3.GetObjectOutput) {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	if d.totalBytes >= 0 {
+		return
+	}
+
+	if resp.ContentRange == nil {
+		// ContentRange is nil when the full file contents is provided, and
+		// is not chunked. Use ContentLength instead.
+		if resp.ContentLength != nil {
+			d.totalBytes = *resp.ContentLength
+			return
+		}
+	} else {
+		parts := strings.Split(*resp.ContentRange, "/")
+
+		total := int64(-1)
+		var err error
+		// Checking for whether or not a numbered total exists
+		// If one does not exist, we will assume the total to be -1, undefined,
+		// and sequentially download each chunk until hitting a 416 error
+		totalStr := parts[len(parts)-1]
+		if totalStr != "*" {
+			total, err = strconv.ParseInt(totalStr, 10, 64)
+			if err != nil {
+				d.err = err
+				return
+			}
+		}
+
+		d.totalBytes = total
+	}
+}
+
+func (d *downloader) incrWritten(n int64) {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	d.written += n
+}
+
+// getErr is a thread-safe getter for the error object
+func (d *downloader) getErr() error {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	return d.err
+}
+
+// setErr is a thread-safe setter for the error object
+func (d *downloader) setErr(e error) {
+	d.m.Lock()
+	defer d.m.Unlock()
+
+	d.err = e
+}
+
+// dlchunk represents a single chunk of data to write by the worker routine.
+// This structure also implements an io.SectionReader style interface for
+// io.WriterAt, effectively making it an io.SectionWriter (which does not
+// exist).
+type dlchunk struct {
+	w     io.WriterAt
+	start int64
+	size  int64
+	cur   int64
+
+	// specifies the byte range the chunk should be downloaded with.
+	withRange string
+}
+
+// Write wraps io.WriterAt for the dlchunk, writing from the dlchunk's start
+// position to its end (or EOF).
+//
+// If a range is specified on the dlchunk the size will be ignored when writing.
+// as the total size may not of be known ahead of time.
+func (c *dlchunk) Write(p []byte) (n int, err error) {
+	if c.cur >= c.size && len(c.withRange) == 0 {
+		return 0, io.EOF
+	}
+
+	n, err = c.w.WriteAt(p, c.start+c.cur)
+	c.cur += int64(n)
+
+	return
+}
+
+// ByteRange returns a HTTP Byte-Range header value that should be used by the
+// client to request the chunk's range.
+func (c *dlchunk) ByteRange() string {
+	if len(c.withRange) != 0 {
+		return c.withRange
+	}
+
+	return fmt.Sprintf("bytes=%d-%d", c.start, c.start+c.size-1)
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/upload.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/s3manager/upload.go
@@ -1,0 +1,797 @@
+package s3manager
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+// MaxUploadParts is the maximum allowed number of parts in a multi-part upload
+// on Amazon S3.
+const MaxUploadParts = 10000
+
+// MinUploadPartSize is the minimum allowed part size when uploading a part to
+// Amazon S3.
+const MinUploadPartSize int64 = 1024 * 1024 * 5
+
+// DefaultUploadPartSize is the default part size to buffer chunks of a
+// payload into.
+const DefaultUploadPartSize = MinUploadPartSize
+
+// DefaultUploadConcurrency is the default number of goroutines to spin up when
+// using Upload().
+const DefaultUploadConcurrency = 5
+
+// A MultiUploadFailure wraps a failed S3 multipart upload. An error returned
+// will satisfy this interface when a multi part upload failed to upload all
+// chucks to S3. In the case of a failure the UploadID is needed to operate on
+// the chunks, if any, which were uploaded.
+//
+// Example:
+//
+//     u := s3manager.NewUploader(opts)
+//     output, err := u.upload(input)
+//     if err != nil {
+//         if multierr, ok := err.(s3manager.MultiUploadFailure); ok {
+//             // Process error and its associated uploadID
+//             fmt.Println("Error:", multierr.Code(), multierr.Message(), multierr.UploadID())
+//         } else {
+//             // Process error generically
+//             fmt.Println("Error:", err.Error())
+//         }
+//     }
+//
+type MultiUploadFailure interface {
+	awserr.Error
+
+	// Returns the upload id for the S3 multipart upload that failed.
+	UploadID() string
+}
+
+// So that the Error interface type can be included as an anonymous field
+// in the multiUploadError struct and not conflict with the error.Error() method.
+type awsError awserr.Error
+
+// A multiUploadError wraps the upload ID of a failed s3 multipart upload.
+// Composed of BaseError for code, message, and original error
+//
+// Should be used for an error that occurred failing a S3 multipart upload,
+// and a upload ID is available. If an uploadID is not available a more relevant
+type multiUploadError struct {
+	awsError
+
+	// ID for multipart upload which failed.
+	uploadID string
+}
+
+// Error returns the string representation of the error.
+//
+// See apierr.BaseError ErrorWithExtra for output format
+//
+// Satisfies the error interface.
+func (m multiUploadError) Error() string {
+	extra := fmt.Sprintf("upload id: %s", m.uploadID)
+	return awserr.SprintError(m.Code(), m.Message(), extra, m.OrigErr())
+}
+
+// String returns the string representation of the error.
+// Alias for Error to satisfy the stringer interface.
+func (m multiUploadError) String() string {
+	return m.Error()
+}
+
+// UploadID returns the id of the S3 upload which failed.
+func (m multiUploadError) UploadID() string {
+	return m.uploadID
+}
+
+// UploadInput contains all input for upload requests to Amazon S3.
+type UploadInput struct {
+	// The canned ACL to apply to the object.
+	ACL *string `location:"header" locationName:"x-amz-acl" type:"string"`
+
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// Specifies caching behavior along the request/reply chain.
+	CacheControl *string `location:"header" locationName:"Cache-Control" type:"string"`
+
+	// Specifies presentational information for the object.
+	ContentDisposition *string `location:"header" locationName:"Content-Disposition" type:"string"`
+
+	// Specifies what content encodings have been applied to the object and thus
+	// what decoding mechanisms must be applied to obtain the media-type referenced
+	// by the Content-Type header field.
+	ContentEncoding *string `location:"header" locationName:"Content-Encoding" type:"string"`
+
+	// The language the content is in.
+	ContentLanguage *string `location:"header" locationName:"Content-Language" type:"string"`
+
+	// The base64-encoded 128-bit MD5 digest of the part data.
+	ContentMD5 *string `location:"header" locationName:"Content-MD5" type:"string"`
+
+	// A standard MIME type describing the format of the object data.
+	ContentType *string `location:"header" locationName:"Content-Type" type:"string"`
+
+	// The date and time at which the object is no longer cacheable.
+	Expires *time.Time `location:"header" locationName:"Expires" type:"timestamp" timestampFormat:"rfc822"`
+
+	// Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.
+	GrantFullControl *string `location:"header" locationName:"x-amz-grant-full-control" type:"string"`
+
+	// Allows grantee to read the object data and its metadata.
+	GrantRead *string `location:"header" locationName:"x-amz-grant-read" type:"string"`
+
+	// Allows grantee to read the object ACL.
+	GrantReadACP *string `location:"header" locationName:"x-amz-grant-read-acp" type:"string"`
+
+	// Allows grantee to write the ACL for the applicable object.
+	GrantWriteACP *string `location:"header" locationName:"x-amz-grant-write-acp" type:"string"`
+
+	Key *string `location:"uri" locationName:"Key" type:"string" required:"true"`
+
+	// A map of metadata to store with the object in S3.
+	Metadata map[string]*string `location:"headers" locationName:"x-amz-meta-" type:"map"`
+
+	// Confirms that the requester knows that she or he will be charged for the
+	// request. Bucket owners need not specify this parameter in their requests.
+	// Documentation on downloading objects from requester pays buckets can be found
+	// at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html
+	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string"`
+
+	// Specifies the algorithm to use to when encrypting the object (e.g., AES256,
+	// aws:kms).
+	SSECustomerAlgorithm *string `location:"header" locationName:"x-amz-server-side-encryption-customer-algorithm" type:"string"`
+
+	// Specifies the customer-provided encryption key for Amazon S3 to use in encrypting
+	// data. This value is used to store the object and then it is discarded; Amazon
+	// does not store the encryption key. The key must be appropriate for use with
+	// the algorithm specified in the x-amz-server-side​-encryption​-customer-algorithm
+	// header.
+	SSECustomerKey *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key" type:"string"`
+
+	// Specifies the 128-bit MD5 digest of the encryption key according to RFC 1321.
+	// Amazon S3 uses this header for a message integrity check to ensure the encryption
+	// key was transmitted without error.
+	SSECustomerKeyMD5 *string `location:"header" locationName:"x-amz-server-side-encryption-customer-key-MD5" type:"string"`
+
+	// Specifies the AWS KMS key ID to use for object encryption. All GET and PUT
+	// requests for an object protected by AWS KMS will fail if not made via SSL
+	// or using SigV4. Documentation on configuring any of the officially supported
+	// AWS SDKs and CLI can be found at http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version
+	SSEKMSKeyId *string `location:"header" locationName:"x-amz-server-side-encryption-aws-kms-key-id" type:"string"`
+
+	// The Server-side encryption algorithm used when storing this object in S3
+	// (e.g., AES256, aws:kms).
+	ServerSideEncryption *string `location:"header" locationName:"x-amz-server-side-encryption" type:"string"`
+
+	// The type of storage to use for the object. Defaults to 'STANDARD'.
+	StorageClass *string `location:"header" locationName:"x-amz-storage-class" type:"string"`
+
+	// The tag-set for the object. The tag-set must be encoded as URL Query parameters
+	Tagging *string `location:"header" locationName:"x-amz-tagging" type:"string"`
+
+	// If the bucket is configured as a website, redirects requests for this object
+	// to another object in the same bucket or to an external URL. Amazon S3 stores
+	// the value of this header in the object metadata.
+	WebsiteRedirectLocation *string `location:"header" locationName:"x-amz-website-redirect-location" type:"string"`
+
+	// The readable body payload to send to S3.
+	Body io.Reader
+}
+
+// UploadOutput represents a response from the Upload() call.
+type UploadOutput struct {
+	// The URL where the object was uploaded to.
+	Location string
+
+	// The version of the object that was uploaded. Will only be populated if
+	// the S3 Bucket is versioned. If the bucket is not versioned this field
+	// will not be set.
+	VersionID *string
+
+	// The ID for a multipart upload to S3. In the case of an error the error
+	// can be cast to the MultiUploadFailure interface to extract the upload ID.
+	UploadID string
+}
+
+// WithUploaderRequestOptions appends to the Uploader's API request options.
+func WithUploaderRequestOptions(opts ...request.Option) func(*Uploader) {
+	return func(u *Uploader) {
+		u.RequestOptions = append(u.RequestOptions, opts...)
+	}
+}
+
+// The Uploader structure that calls Upload(). It is safe to call Upload()
+// on this structure for multiple objects and across concurrent goroutines.
+// Mutating the Uploader's properties is not safe to be done concurrently.
+type Uploader struct {
+	// The buffer size (in bytes) to use when buffering data into chunks and
+	// sending them as parts to S3. The minimum allowed part size is 5MB, and
+	// if this value is set to zero, the DefaultUploadPartSize value will be used.
+	PartSize int64
+
+	// The number of goroutines to spin up in parallel per call to Upload when
+	// sending parts. If this is set to zero, the DefaultUploadConcurrency value
+	// will be used.
+	//
+	// The concurrency pool is not shared between calls to Upload.
+	Concurrency int
+
+	// Setting this value to true will cause the SDK to avoid calling
+	// AbortMultipartUpload on a failure, leaving all successfully uploaded
+	// parts on S3 for manual recovery.
+	//
+	// Note that storing parts of an incomplete multipart upload counts towards
+	// space usage on S3 and will add additional costs if not cleaned up.
+	LeavePartsOnError bool
+
+	// MaxUploadParts is the max number of parts which will be uploaded to S3.
+	// Will be used to calculate the partsize of the object to be uploaded.
+	// E.g: 5GB file, with MaxUploadParts set to 100, will upload the file
+	// as 100, 50MB parts.
+	// With a limited of s3.MaxUploadParts (10,000 parts).
+	MaxUploadParts int
+
+	// The client to use when uploading to S3.
+	S3 s3iface.S3API
+
+	// List of request options that will be passed down to individual API
+	// operation requests made by the uploader.
+	RequestOptions []request.Option
+}
+
+// NewUploader creates a new Uploader instance to upload objects to S3. Pass In
+// additional functional options to customize the uploader's behavior. Requires a
+// client.ConfigProvider in order to create a S3 service client. The session.Session
+// satisfies the client.ConfigProvider interface.
+//
+// Example:
+//     // The session the S3 Uploader will use
+//     sess := session.Must(session.NewSession())
+//
+//     // Create an uploader with the session and default options
+//     uploader := s3manager.NewUploader(sess)
+//
+//     // Create an uploader with the session and custom options
+//     uploader := s3manager.NewUploader(session, func(u *s3manager.Uploader) {
+//          u.PartSize = 64 * 1024 * 1024 // 64MB per part
+//     })
+func NewUploader(c client.ConfigProvider, options ...func(*Uploader)) *Uploader {
+	u := &Uploader{
+		S3:                s3.New(c),
+		PartSize:          DefaultUploadPartSize,
+		Concurrency:       DefaultUploadConcurrency,
+		LeavePartsOnError: false,
+		MaxUploadParts:    MaxUploadParts,
+	}
+
+	for _, option := range options {
+		option(u)
+	}
+
+	return u
+}
+
+// NewUploaderWithClient creates a new Uploader instance to upload objects to S3. Pass in
+// additional functional options to customize the uploader's behavior. Requires
+// a S3 service client to make S3 API calls.
+//
+// Example:
+//     // The session the S3 Uploader will use
+//     sess := session.Must(session.NewSession())
+//
+//     // S3 service client the Upload manager will use.
+//     s3Svc := s3.New(sess)
+//
+//     // Create an uploader with S3 client and default options
+//     uploader := s3manager.NewUploaderWithClient(s3Svc)
+//
+//     // Create an uploader with S3 client and custom options
+//     uploader := s3manager.NewUploaderWithClient(s3Svc, func(u *s3manager.Uploader) {
+//          u.PartSize = 64 * 1024 * 1024 // 64MB per part
+//     })
+func NewUploaderWithClient(svc s3iface.S3API, options ...func(*Uploader)) *Uploader {
+	u := &Uploader{
+		S3:                svc,
+		PartSize:          DefaultUploadPartSize,
+		Concurrency:       DefaultUploadConcurrency,
+		LeavePartsOnError: false,
+		MaxUploadParts:    MaxUploadParts,
+	}
+
+	for _, option := range options {
+		option(u)
+	}
+
+	return u
+}
+
+// Upload uploads an object to S3, intelligently buffering large files into
+// smaller chunks and sending them in parallel across multiple goroutines. You
+// can configure the buffer size and concurrency through the Uploader's parameters.
+//
+// Additional functional options can be provided to configure the individual
+// upload. These options are copies of the Uploader instance Upload is called from.
+// Modifying the options will not impact the original Uploader instance.
+//
+// Use the WithUploaderRequestOptions helper function to pass in request
+// options that will be applied to all API operations made with this uploader.
+//
+// It is safe to call this method concurrently across goroutines.
+//
+// Example:
+//     // Upload input parameters
+//     upParams := &s3manager.UploadInput{
+//         Bucket: &bucketName,
+//         Key:    &keyName,
+//         Body:   file,
+//     }
+//
+//     // Perform an upload.
+//     result, err := uploader.Upload(upParams)
+//
+//     // Perform upload with options different than the those in the Uploader.
+//     result, err := uploader.Upload(upParams, func(u *s3manager.Uploader) {
+//          u.PartSize = 10 * 1024 * 1024 // 10MB part size
+//          u.LeavePartsOnError = true    // Don't delete the parts if the upload fails.
+//     })
+func (u Uploader) Upload(input *UploadInput, options ...func(*Uploader)) (*UploadOutput, error) {
+	return u.UploadWithContext(aws.BackgroundContext(), input, options...)
+}
+
+// UploadWithContext uploads an object to S3, intelligently buffering large
+// files into smaller chunks and sending them in parallel across multiple
+// goroutines. You can configure the buffer size and concurrency through the
+// Uploader's parameters.
+//
+// UploadWithContext is the same as Upload with the additional support for
+// Context input parameters. The Context must not be nil. A nil Context will
+// cause a panic. Use the context to add deadlining, timeouts, ect. The
+// UploadWithContext may create sub-contexts for individual underlying requests.
+//
+// Additional functional options can be provided to configure the individual
+// upload. These options are copies of the Uploader instance Upload is called from.
+// Modifying the options will not impact the original Uploader instance.
+//
+// Use the WithUploaderRequestOptions helper function to pass in request
+// options that will be applied to all API operations made with this uploader.
+//
+// It is safe to call this method concurrently across goroutines.
+func (u Uploader) UploadWithContext(ctx aws.Context, input *UploadInput, opts ...func(*Uploader)) (*UploadOutput, error) {
+	i := uploader{in: input, cfg: u, ctx: ctx}
+
+	for _, opt := range opts {
+		opt(&i.cfg)
+	}
+	i.cfg.RequestOptions = append(i.cfg.RequestOptions, request.WithAppendUserAgent("S3Manager"))
+
+	return i.upload()
+}
+
+// UploadWithIterator will upload a batched amount of objects to S3. This operation uses
+// the iterator pattern to know which object to upload next. Since this is an interface this
+// allows for custom defined functionality.
+//
+// Example:
+//	svc:= s3manager.NewUploader(sess)
+//
+//	objects := []BatchUploadObject{
+//		{
+//			Object:	&s3manager.UploadInput {
+//				Key: aws.String("key"),
+//				Bucket: aws.String("bucket"),
+//			},
+//		},
+//	}
+//
+//	iter := &s3managee.UploadObjectsIterator{Objects: objects}
+//	if err := svc.UploadWithIterator(aws.BackgroundContext(), iter); err != nil {
+//		return err
+//	}
+func (u Uploader) UploadWithIterator(ctx aws.Context, iter BatchUploadIterator, opts ...func(*Uploader)) error {
+	var errs []Error
+	for iter.Next() {
+		object := iter.UploadObject()
+		if _, err := u.UploadWithContext(ctx, object.Object, opts...); err != nil {
+			s3Err := Error{
+				OrigErr: err,
+				Bucket:  object.Object.Bucket,
+				Key:     object.Object.Key,
+			}
+
+			errs = append(errs, s3Err)
+		}
+
+		if object.After == nil {
+			continue
+		}
+
+		if err := object.After(); err != nil {
+			s3Err := Error{
+				OrigErr: err,
+				Bucket:  object.Object.Bucket,
+				Key:     object.Object.Key,
+			}
+
+			errs = append(errs, s3Err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return NewBatchError("BatchedUploadIncomplete", "some objects have failed to upload.", errs)
+	}
+	return nil
+}
+
+// internal structure to manage an upload to S3.
+type uploader struct {
+	ctx aws.Context
+	cfg Uploader
+
+	in *UploadInput
+
+	readerPos int64 // current reader position
+	totalSize int64 // set to -1 if the size is not known
+
+	bufferPool sync.Pool
+}
+
+// internal logic for deciding whether to upload a single part or use a
+// multipart upload.
+func (u *uploader) upload() (*UploadOutput, error) {
+	u.init()
+
+	if u.cfg.PartSize < MinUploadPartSize {
+		msg := fmt.Sprintf("part size must be at least %d bytes", MinUploadPartSize)
+		return nil, awserr.New("ConfigError", msg, nil)
+	}
+
+	// Do one read to determine if we have more than one part
+	reader, _, part, err := u.nextReader()
+	if err == io.EOF { // single part
+		return u.singlePart(reader)
+	} else if err != nil {
+		return nil, awserr.New("ReadRequestBody", "read upload data failed", err)
+	}
+
+	mu := multiuploader{uploader: u}
+	return mu.upload(reader, part)
+}
+
+// init will initialize all default options.
+func (u *uploader) init() {
+	if u.cfg.Concurrency == 0 {
+		u.cfg.Concurrency = DefaultUploadConcurrency
+	}
+	if u.cfg.PartSize == 0 {
+		u.cfg.PartSize = DefaultUploadPartSize
+	}
+
+	u.bufferPool = sync.Pool{
+		New: func() interface{} { return make([]byte, u.cfg.PartSize) },
+	}
+
+	// Try to get the total size for some optimizations
+	u.initSize()
+}
+
+// initSize tries to detect the total stream size, setting u.totalSize. If
+// the size is not known, totalSize is set to -1.
+func (u *uploader) initSize() {
+	u.totalSize = -1
+
+	switch r := u.in.Body.(type) {
+	case io.Seeker:
+		n, err := aws.SeekerLen(r)
+		if err != nil {
+			return
+		}
+		u.totalSize = n
+
+		// Try to adjust partSize if it is too small and account for
+		// integer division truncation.
+		if u.totalSize/u.cfg.PartSize >= int64(u.cfg.MaxUploadParts) {
+			// Add one to the part size to account for remainders
+			// during the size calculation. e.g odd number of bytes.
+			u.cfg.PartSize = (u.totalSize / int64(u.cfg.MaxUploadParts)) + 1
+		}
+	}
+}
+
+// nextReader returns a seekable reader representing the next packet of data.
+// This operation increases the shared u.readerPos counter, but note that it
+// does not need to be wrapped in a mutex because nextReader is only called
+// from the main thread.
+func (u *uploader) nextReader() (io.ReadSeeker, int, []byte, error) {
+	type readerAtSeeker interface {
+		io.ReaderAt
+		io.ReadSeeker
+	}
+	switch r := u.in.Body.(type) {
+	case readerAtSeeker:
+		var err error
+
+		n := u.cfg.PartSize
+		if u.totalSize >= 0 {
+			bytesLeft := u.totalSize - u.readerPos
+
+			if bytesLeft <= u.cfg.PartSize {
+				err = io.EOF
+				n = bytesLeft
+			}
+		}
+
+		reader := io.NewSectionReader(r, u.readerPos, n)
+		u.readerPos += n
+
+		return reader, int(n), nil, err
+
+	default:
+		part := u.bufferPool.Get().([]byte)
+		n, err := readFillBuf(r, part)
+		u.readerPos += int64(n)
+
+		return bytes.NewReader(part[0:n]), n, part, err
+	}
+}
+
+func readFillBuf(r io.Reader, b []byte) (offset int, err error) {
+	for offset < len(b) && err == nil {
+		var n int
+		n, err = r.Read(b[offset:])
+		offset += n
+	}
+
+	return offset, err
+}
+
+// singlePart contains upload logic for uploading a single chunk via
+// a regular PutObject request. Multipart requests require at least two
+// parts, or at least 5MB of data.
+func (u *uploader) singlePart(buf io.ReadSeeker) (*UploadOutput, error) {
+	params := &s3.PutObjectInput{}
+	awsutil.Copy(params, u.in)
+	params.Body = buf
+
+	// Need to use request form because URL generated in request is
+	// used in return.
+	req, out := u.cfg.S3.PutObjectRequest(params)
+	req.SetContext(u.ctx)
+	req.ApplyOptions(u.cfg.RequestOptions...)
+	if err := req.Send(); err != nil {
+		return nil, err
+	}
+
+	url := req.HTTPRequest.URL.String()
+	return &UploadOutput{
+		Location:  url,
+		VersionID: out.VersionId,
+	}, nil
+}
+
+// internal structure to manage a specific multipart upload to S3.
+type multiuploader struct {
+	*uploader
+	wg       sync.WaitGroup
+	m        sync.Mutex
+	err      error
+	uploadID string
+	parts    completedParts
+}
+
+// keeps track of a single chunk of data being sent to S3.
+type chunk struct {
+	buf  io.ReadSeeker
+	part []byte
+	num  int64
+}
+
+// completedParts is a wrapper to make parts sortable by their part number,
+// since S3 required this list to be sent in sorted order.
+type completedParts []*s3.CompletedPart
+
+func (a completedParts) Len() int           { return len(a) }
+func (a completedParts) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a completedParts) Less(i, j int) bool { return *a[i].PartNumber < *a[j].PartNumber }
+
+// upload will perform a multipart upload using the firstBuf buffer containing
+// the first chunk of data.
+func (u *multiuploader) upload(firstBuf io.ReadSeeker, firstPart []byte) (*UploadOutput, error) {
+	params := &s3.CreateMultipartUploadInput{}
+	awsutil.Copy(params, u.in)
+
+	// Create the multipart
+	resp, err := u.cfg.S3.CreateMultipartUploadWithContext(u.ctx, params, u.cfg.RequestOptions...)
+	if err != nil {
+		return nil, err
+	}
+	u.uploadID = *resp.UploadId
+
+	// Create the workers
+	ch := make(chan chunk, u.cfg.Concurrency)
+	for i := 0; i < u.cfg.Concurrency; i++ {
+		u.wg.Add(1)
+		go u.readChunk(ch)
+	}
+
+	// Send part 1 to the workers
+	var num int64 = 1
+	ch <- chunk{buf: firstBuf, part: firstPart, num: num}
+
+	// Read and queue the rest of the parts
+	for u.geterr() == nil && err == nil {
+		num++
+		// This upload exceeded maximum number of supported parts, error now.
+		if num > int64(u.cfg.MaxUploadParts) || num > int64(MaxUploadParts) {
+			var msg string
+			if num > int64(u.cfg.MaxUploadParts) {
+				msg = fmt.Sprintf("exceeded total allowed configured MaxUploadParts (%d). Adjust PartSize to fit in this limit",
+					u.cfg.MaxUploadParts)
+			} else {
+				msg = fmt.Sprintf("exceeded total allowed S3 limit MaxUploadParts (%d). Adjust PartSize to fit in this limit",
+					MaxUploadParts)
+			}
+			u.seterr(awserr.New("TotalPartsExceeded", msg, nil))
+			break
+		}
+
+		var reader io.ReadSeeker
+		var nextChunkLen int
+		var part []byte
+		reader, nextChunkLen, part, err = u.nextReader()
+
+		if err != nil && err != io.EOF {
+			u.seterr(awserr.New(
+				"ReadRequestBody",
+				"read multipart upload data failed",
+				err))
+			break
+		}
+
+		if nextChunkLen == 0 {
+			// No need to upload empty part, if file was empty to start
+			// with empty single part would of been created and never
+			// started multipart upload.
+			break
+		}
+
+		ch <- chunk{buf: reader, part: part, num: num}
+	}
+
+	// Close the channel, wait for workers, and complete upload
+	close(ch)
+	u.wg.Wait()
+	complete := u.complete()
+
+	if err := u.geterr(); err != nil {
+		return nil, &multiUploadError{
+			awsError: awserr.New(
+				"MultipartUpload",
+				"upload multipart failed",
+				err),
+			uploadID: u.uploadID,
+		}
+	}
+	return &UploadOutput{
+		Location:  aws.StringValue(complete.Location),
+		VersionID: complete.VersionId,
+		UploadID:  u.uploadID,
+	}, nil
+}
+
+// readChunk runs in worker goroutines to pull chunks off of the ch channel
+// and send() them as UploadPart requests.
+func (u *multiuploader) readChunk(ch chan chunk) {
+	defer u.wg.Done()
+	for {
+		data, ok := <-ch
+
+		if !ok {
+			break
+		}
+
+		if u.geterr() == nil {
+			if err := u.send(data); err != nil {
+				u.seterr(err)
+			}
+		}
+	}
+}
+
+// send performs an UploadPart request and keeps track of the completed
+// part information.
+func (u *multiuploader) send(c chunk) error {
+	params := &s3.UploadPartInput{
+		Bucket:               u.in.Bucket,
+		Key:                  u.in.Key,
+		Body:                 c.buf,
+		UploadId:             &u.uploadID,
+		SSECustomerAlgorithm: u.in.SSECustomerAlgorithm,
+		SSECustomerKey:       u.in.SSECustomerKey,
+		PartNumber:           &c.num,
+	}
+	resp, err := u.cfg.S3.UploadPartWithContext(u.ctx, params, u.cfg.RequestOptions...)
+	// put the byte array back into the pool to conserve memory
+	u.bufferPool.Put(c.part)
+	if err != nil {
+		return err
+	}
+
+	n := c.num
+	completed := &s3.CompletedPart{ETag: resp.ETag, PartNumber: &n}
+
+	u.m.Lock()
+	u.parts = append(u.parts, completed)
+	u.m.Unlock()
+
+	return nil
+}
+
+// geterr is a thread-safe getter for the error object
+func (u *multiuploader) geterr() error {
+	u.m.Lock()
+	defer u.m.Unlock()
+
+	return u.err
+}
+
+// seterr is a thread-safe setter for the error object
+func (u *multiuploader) seterr(e error) {
+	u.m.Lock()
+	defer u.m.Unlock()
+
+	u.err = e
+}
+
+// fail will abort the multipart unless LeavePartsOnError is set to true.
+func (u *multiuploader) fail() {
+	if u.cfg.LeavePartsOnError {
+		return
+	}
+
+	params := &s3.AbortMultipartUploadInput{
+		Bucket:   u.in.Bucket,
+		Key:      u.in.Key,
+		UploadId: &u.uploadID,
+	}
+	_, err := u.cfg.S3.AbortMultipartUploadWithContext(u.ctx, params, u.cfg.RequestOptions...)
+	if err != nil {
+		logMessage(u.cfg.S3, aws.LogDebug, fmt.Sprintf("failed to abort multipart upload, %v", err))
+	}
+}
+
+// complete successfully completes a multipart upload and returns the response.
+func (u *multiuploader) complete() *s3.CompleteMultipartUploadOutput {
+	if u.geterr() != nil {
+		u.fail()
+		return nil
+	}
+
+	// Parts must be sorted in PartNumber order.
+	sort.Sort(u.parts)
+
+	params := &s3.CompleteMultipartUploadInput{
+		Bucket:          u.in.Bucket,
+		Key:             u.in.Key,
+		UploadId:        &u.uploadID,
+		MultipartUpload: &s3.CompletedMultipartUpload{Parts: u.parts},
+	}
+	resp, err := u.cfg.S3.CompleteMultipartUploadWithContext(u.ctx, params, u.cfg.RequestOptions...)
+	if err != nil {
+		u.seterr(err)
+		u.fail()
+	}
+
+	return resp
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,10 +21,10 @@
 			"revisionTime": "2018-03-13T10:32:54Z"
 		},
 		{
-			"checksumSHA1": "wG6mM4297ueY26qk4SRRnSJEMW0=",
+			"checksumSHA1": "kp/pQVUk5O36tg/7pxAlUPGgwAA=",
 			"path": "github.com/ONSdigital/s3crypto",
-			"revision": "c7df2630d43da22e6d45017a1339717e8428c5fa",
-			"revisionTime": "2018-02-28T08:48:36Z"
+			"revision": "f566045122cf53e8ebaf1055bffd50ab213181a7",
+			"revisionTime": "2018-03-16T09:39:29Z"
 		},
 		{
 			"checksumSHA1": "kMfAFLobZymMrCOm/Xi/g9gnJOU=",
@@ -33,10 +33,10 @@
 			"revisionTime": "2016-08-22T23:00:20Z"
 		},
 		{
-			"checksumSHA1": "sApdWt8nEtaTapjFMDHLRo/8zUs=",
+			"checksumSHA1": "Mn7rZP6y2VKFyogE4/J/uvfHR7E=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "52bbb79f3236949cc20bdac413da6f5102c3fe0c",
-			"revisionTime": "2017-11-30T03:17:26Z"
+			"revision": "57564ea051fab8ccbb8cac2aff285647a1aeefd1",
+			"revisionTime": "2018-04-10T22:21:59Z"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
@@ -129,6 +129,12 @@
 			"revisionTime": "2017-11-30T03:17:26Z"
 		},
 		{
+			"checksumSHA1": "wjxQlU1PYxrDRFoL1Vek8Wch7jk=",
+			"path": "github.com/aws/aws-sdk-go/internal/sdkio",
+			"revision": "57564ea051fab8ccbb8cac2aff285647a1aeefd1",
+			"revisionTime": "2018-04-10T22:21:59Z"
+		},
+		{
 			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
 			"revision": "52bbb79f3236949cc20bdac413da6f5102c3fe0c",
@@ -181,6 +187,12 @@
 			"path": "github.com/aws/aws-sdk-go/service/s3/s3iface",
 			"revision": "52bbb79f3236949cc20bdac413da6f5102c3fe0c",
 			"revisionTime": "2017-11-30T03:17:26Z"
+		},
+		{
+			"checksumSHA1": "cblWrM4Jg9n5/g9cd5Mp84I+XBU=",
+			"path": "github.com/aws/aws-sdk-go/service/s3/s3manager",
+			"revision": "57564ea051fab8ccbb8cac2aff285647a1aeefd1",
+			"revisionTime": "2018-04-10T22:21:59Z"
 		},
 		{
 			"checksumSHA1": "d9vR1rl8kmJxJBwe00byziVFR/o=",


### PR DESCRIPTION
### What

* Update s3cypto lib allowing files to be decrypted from S3
* Add test for creating a filter job before a version is published
* Replace `os.Exit` calls with `t.FailNow`, allowing the test output to be written to console when a test fails
* Remove nest 'conveys' as they were adding no value, and cannot be put alongside each other

(note the test currently fails because of keys being overwritten in vault)

### How to review

Review changes / test

### Who can review

Anyone
