### PR TITLE
Update search tests to test publishing mode with forced auth

### DIFF
--- a/searchAPI/delete_search_Index_test.go
+++ b/searchAPI/delete_search_Index_test.go
@@ -13,7 +13,10 @@ import (
 )
 
 // this is to cover "Resource" and "resource" not found
-const resourceNotFound = "esource not found"
+const (
+	resourceNotFound = "esource not found"
+	unauthorizedReq  = "unauthorized request"
+)
 
 func TestSuccessfullyDeleteSearchIndex(t *testing.T) {
 	searchAPI := httpexpect.New(t, cfg.SearchAPIURL)
@@ -28,7 +31,7 @@ func TestSuccessfullyDeleteSearchIndex(t *testing.T) {
 			Convey("Then the index is removed and response returns status ok (200)", func() {
 
 				searchAPI.DELETE("/search/instances/{instanceID}/dimensions/{dimension}", instanceID, dimensionKeyAggregate).
-					WithHeader(common.AuthHeaderKey, internalTokenID).Expect().Status(http.StatusOK)
+					WithHeader(common.AuthHeaderKey, serviceToken).Expect().Status(http.StatusOK)
 			})
 		})
 	})
@@ -51,7 +54,7 @@ func TestFailToDeleteSearchIndex(t *testing.T) {
 			Convey("Then the response returns status not found (404)", func() {
 
 				searchAPI.DELETE("/search/instances/{instanceID}/dimensions/{dimension}", instanceID, dimensionKeyAggregate).
-					WithHeader(common.AuthHeaderKey, internalTokenID).Expect().Status(http.StatusNotFound).Body().Contains(resourceNotFound)
+					WithHeader(common.AuthHeaderKey, serviceToken).Expect().Status(http.StatusNotFound).Body().Contains(resourceNotFound)
 			})
 		})
 	})
@@ -62,18 +65,20 @@ func TestFailToDeleteSearchIndex(t *testing.T) {
 			os.Exit(1)
 		}
 		Convey("When a DELETE request is made to search API without an authentication header", func() {
-			Convey("Then the response returns status not found (404)", func() {
+			Convey("Then the response returns status unauthorized (401)", func() {
 
 				searchAPI.DELETE("/search/instances/{instanceID}/dimensions/{dimension}", instanceID, dimensionKeyAggregate).
-					Expect().Status(http.StatusNotFound).Body().Contains(resourceNotFound)
+					Expect().Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When a DELETE request is made to search API with Invalid authentication header", func() {
-			Convey("Then the response returns status not found (404)", func() {
+			Convey("Then the response returns status unauthorized (401)", func() {
 
 				searchAPI.DELETE("/search/instances/{instanceID}/dimensions/{dimension}", instanceID, dimensionKeyAggregate).
-					WithHeader(common.AuthHeaderKey, "grey").Expect().Status(http.StatusUnauthorized)
+					WithHeader(common.AuthHeaderKey, "grey").
+					Expect().
+					Status(http.StatusUnauthorized)
 			})
 		})
 	})

--- a/searchAPI/initialise.go
+++ b/searchAPI/initialise.go
@@ -13,10 +13,9 @@ var cfg *config.Config
 const (
 	collection = "datasets"
 
-	instanceID             = "123789"
-	internalTokenID        = "Bearer a507f722-f25a-4889-9653-23a2655b925c"
-	invalidInternalTokenID = "SD0108EA-825D-411C-45J3-41EF7727F123A"
-	skipTeardown           = false
+	instanceID   = "123789"
+	serviceToken = "Bearer a507f722-f25a-4889-9653-23a2655b925c"
+	skipTeardown = false
 )
 
 func init() {

--- a/searchAPI/put_search_index_test.go
+++ b/searchAPI/put_search_index_test.go
@@ -21,7 +21,7 @@ func TestSuccessfullyCreateSearchIndex(t *testing.T) {
 			Convey("Then a message is sent to kafka to create an index and the response returns status ok (200)", func() {
 
 				searchAPI.PUT("/search/instances/{instanceID}/dimensions/{dimension}", instanceID, dimensionKeyAggregate).
-					WithHeader(common.AuthHeaderKey, internalTokenID).Expect().Status(http.StatusOK)
+					WithHeader(common.AuthHeaderKey, serviceToken).Expect().Status(http.StatusOK)
 			})
 		})
 	})
@@ -40,19 +40,21 @@ func TestFailToCreateSearchIndex(t *testing.T) {
 		deleteIndex(instanceID, dimension)
 
 		Convey("When a PUT request is made to search API without an authentication header", func() {
-			Convey("Then the response returns status not found (404)", func() {
+			Convey("Then the response returns status unauthorized (401)", func() {
 
 				searchAPI.PUT("/search/instances/{instanceID}/dimensions/{dimension}", instanceID, dimensionKeyAggregate).
-					Expect().Status(http.StatusNotFound).Body().Contains(resourceNotFound)
+					Expect().
+					Status(http.StatusUnauthorized)
 			})
 		})
 
 		Convey("When a PUT request is made to search API with Invalid authentication header", func() {
-			Convey("Then the response returns status not found (404)", func() {
+			Convey("Then the response returns status unauthorized (401)", func() {
 
 				searchAPI.PUT("/search/instances/{instanceID}/dimensions/{dimension}", instanceID, dimensionKeyAggregate).
 					WithHeader(common.AuthHeaderKey, "grey").
-					Expect().Status(http.StatusUnauthorized)
+					Expect().
+					Status(http.StatusUnauthorized)
 			})
 		})
 	})


### PR DESCRIPTION
### What

Update search tests to test publishing mode with forced auth. Public endpoints now require authentication when running in publishing mode as the middleware authenticates every request.

### How to review

Review changes / test against https://github.com/ONSdigital/dp-search-api/pull/26

### Who can review

Anyone
