### PR TITLE
Fix tests for updated responses from filter API

### DIFF
--- a/publishing/datasetAPI/get_observation_test.go
+++ b/publishing/datasetAPI/get_observation_test.go
@@ -283,7 +283,7 @@ func TestFailureToGetObservationForVersion(t *testing.T) {
 							WithQueryString("time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 							WithHeader(florenceTokenName, florenceToken).
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("Version not found")
+							Body().Contains("version not found")
 					})
 				})
 			})

--- a/publishing/filterAPI/delete_dimension_option_test.go
+++ b/publishing/filterAPI/delete_dimension_option_test.go
@@ -119,12 +119,12 @@ func TestFailureToDeleteDimensionOptions(t *testing.T) {
 
 	Convey("Given filter job does not exist", t, func() {
 		Convey("When requesting to delete an option from the filter job", func() {
-			Convey("Then the response returns status not found (404)", func() {
+			Convey("Then the response returns status 400 bad request", func() {
 
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/wages/options/27000", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).
-					Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).
+					Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -142,7 +142,7 @@ func TestFailureToDeleteDimensionOptions(t *testing.T) {
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/wages/options/27000", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusNotFound).
-						Body().Contains("Dimension not found")
+						Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 
@@ -152,7 +152,7 @@ func TestFailureToDeleteDimensionOptions(t *testing.T) {
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/age/options/44", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusNotFound).
-						Body().Contains("Option not found")
+						Body().Contains(optionNotFoundResponse)
 			})
 		})
 

--- a/publishing/filterAPI/delete_dimension_test.go
+++ b/publishing/filterAPI/delete_dimension_test.go
@@ -105,12 +105,12 @@ func TestFailureToDeleteDimension(t *testing.T) {
 
 	Convey("Given filter blueprint does not exist", t, func() {
 		Convey("When requesting to delete a dimension from filter blueprint", func() {
-			Convey("Then response returns status not found (404)", func() {
+			Convey("Then response returns status 400 bad request", func() {
 
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/age", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).
-					Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).
+					Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -127,7 +127,7 @@ func TestFailureToDeleteDimension(t *testing.T) {
 
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/wage", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 

--- a/publishing/filterAPI/get_dimension_option_test.go
+++ b/publishing/filterAPI/get_dimension_option_test.go
@@ -118,11 +118,11 @@ func TestFailureToGetDimensionOption(t *testing.T) {
 
 	Convey("Given a filter blueprint does not exist", t, func() {
 		Convey("When a request to get a dimension option against filter blueprint", func() {
-			Convey("Then return a status not found (404)", func() {
+			Convey("Then return a status 400 bad request", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/age/options/27", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -139,7 +139,7 @@ func TestFailureToGetDimensionOption(t *testing.T) {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/ages/options/27", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 
@@ -148,7 +148,7 @@ func TestFailureToGetDimensionOption(t *testing.T) {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/sex/options/unknown", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Option not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(optionNotFoundResponse)
 			})
 		})
 	})

--- a/publishing/filterAPI/get_dimension_options_test.go
+++ b/publishing/filterAPI/get_dimension_options_test.go
@@ -133,7 +133,7 @@ func TestFailureToGetListOfDimensionOptions(t *testing.T) {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/age/options", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -150,7 +150,7 @@ func TestFailureToGetListOfDimensionOptions(t *testing.T) {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/wages/options", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 	})

--- a/publishing/filterAPI/get_dimension_test.go
+++ b/publishing/filterAPI/get_dimension_test.go
@@ -96,11 +96,11 @@ func TestFailureToGetDimension(t *testing.T) {
 
 	Convey("Given filter blueprint does not exist", t, func() {
 		Convey("When a request is made to get a dimension for filter blueprint", func() {
-			Convey("Then the response returns status not found (404)", func() {
+			Convey("Then the response returns status 400 - bad request", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/age", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -117,7 +117,7 @@ func TestFailureToGetDimension(t *testing.T) {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/wage", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 

--- a/publishing/filterAPI/get_dimensions_test.go
+++ b/publishing/filterAPI/get_dimensions_test.go
@@ -75,7 +75,7 @@ func TestFailureToGetListOfDimensions(t *testing.T) {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})

--- a/publishing/filterAPI/get_filter_blueprint_test.go
+++ b/publishing/filterAPI/get_filter_blueprint_test.go
@@ -156,7 +156,7 @@ func TestFailureToGetFilterBlueprint(t *testing.T) {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}", filterID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})

--- a/publishing/filterAPI/get_filter_output_test.go
+++ b/publishing/filterAPI/get_filter_output_test.go
@@ -217,7 +217,7 @@ func TestFailureToGetFilterOutput(t *testing.T) {
 
 				filterAPI.GET("/filter-outputs/{filter_output_id}", filterID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter output not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterOutputNotFoundResponse)
 			})
 		})
 	})

--- a/publishing/filterAPI/initialise.go
+++ b/publishing/filterAPI/initialise.go
@@ -17,6 +17,12 @@ const (
 	serviceAuthToken        = "Bearer FD0108EA-825D-411C-9B1D-41EF7727F465"
 	downloadServiceToken    = "QB0108EZ-825D-412C-9B1D-41EF7747F462"
 	invalidServiceAuthToken = "invalid-auth-token"
+
+	filterNotFoundResponse = "filter blueprint not found\n"
+	filterOutputNotFoundResponse = "filter output not found\n"
+	versionNotFoundResponse = "version not found\n"
+	dimensionNotFoundResponse = "dimension not found\n"
+	optionNotFoundResponse = "option not found\n"
 )
 
 func init() {

--- a/publishing/filterAPI/post_dimension_option_test.go
+++ b/publishing/filterAPI/post_dimension_option_test.go
@@ -123,11 +123,11 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 		invalidfilterBlueprintID := uuid.NewV4().String()
 
 		Convey("When a post request to add an option to a dimension for that filter blueprint", func() {
-			Convey("Then return status not found (404)", func() {
+			Convey("Then return status bad request", func() {
 
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/age/options/30", invalidfilterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -145,7 +145,7 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/sex/options/male", filterBlueprintID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusUnprocessableEntity).
-						Body().Contains("Unprocessable entity - version for filter blueprint no longer exists\n")
+						Body().Contains("version for filter blueprint no longer exists\n")
 			})
 		})
 
@@ -161,7 +161,7 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/sex/options/male", filterBlueprintID).
 						WithHeader(serviceAuthTokenName, serviceAuthToken).
 						Expect().Status(http.StatusBadRequest).
-						Body().Contains("Bad request - incorrect dimensions chosen: [sex]\n")
+						Body().Contains("incorrect dimensions chosen: [sex]\n")
 				})
 			})
 
@@ -175,7 +175,7 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/age/options/75", filterBlueprintID).
 						WithHeader(serviceAuthTokenName, serviceAuthToken).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimension options chosen: [75]\n")
+						Expect().Status(http.StatusBadRequest).Body().Contains("incorrect dimension options chosen: [75]\n")
 				})
 			})
 		})

--- a/publishing/filterAPI/post_dimension_test.go
+++ b/publishing/filterAPI/post_dimension_test.go
@@ -151,7 +151,7 @@ func TestFailureToPostDimension(t *testing.T) {
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "Residence Type").
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -179,7 +179,7 @@ func TestFailureToPostDimension(t *testing.T) {
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "Residence Type").
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("Unprocessable entity - version for filter blueprint no longer exists\n")
+					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("version for filter blueprint no longer exists\n")
 			})
 		})
 
@@ -196,7 +196,7 @@ func TestFailureToPostDimension(t *testing.T) {
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "foobar").
 						WithHeader(serviceAuthTokenName, serviceAuthToken).
 						WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Dimension not found\n")
+						Expect().Status(http.StatusBadRequest).Body().Contains(dimensionNotFoundResponse)
 				})
 			})
 
@@ -212,7 +212,7 @@ func TestFailureToPostDimension(t *testing.T) {
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "age").
 						WithHeader(serviceAuthTokenName, serviceAuthToken).
 						WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimension options chosen: [Lives in a communal establishment Lives in a household]\n")
+						Expect().Status(http.StatusBadRequest).Body().Contains("incorrect dimension options chosen: [Lives in a communal establishment Lives in a household]\n")
 				})
 			})
 		})

--- a/publishing/filterAPI/post_filter_blueprint_test.go
+++ b/publishing/filterAPI/post_filter_blueprint_test.go
@@ -187,7 +187,7 @@ func TestFailureToPostfilterBlueprintForPublishedInstance(t *testing.T) {
 
 				filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(datasetID, edition, version))).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(versionNotFoundResponse)
 			})
 		})
 	})
@@ -204,7 +204,7 @@ func TestFailureToPostfilterBlueprintForPublishedInstance(t *testing.T) {
 
 				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidDimensionJSON(datasetID, edition, version))).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimensions chosen: [weight]\n")
+					Expect().Status(http.StatusBadRequest).Body().Contains("incorrect dimensions chosen: [weight]\n")
 			})
 		})
 
@@ -213,7 +213,7 @@ func TestFailureToPostfilterBlueprintForPublishedInstance(t *testing.T) {
 
 				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidDimensionOptionJSON(datasetID, edition, version))).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimension options chosen: [33]\n")
+					Expect().Status(http.StatusBadRequest).Body().Contains("incorrect dimension options chosen: [33]\n")
 			})
 		})
 

--- a/publishing/filterAPI/put_filter_blueprint_test.go
+++ b/publishing/filterAPI/put_filter_blueprint_test.go
@@ -181,7 +181,7 @@ func TestFailureToPutFilterBlueprint(t *testing.T) {
 
 				filterAPI.PUT("/filters/{filter_blueprint_id}", filterBlueprintID).WithBytes([]byte(GetValidPUTUpdateFilterBlueprintJSON(instanceID))).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -231,7 +231,7 @@ func TestFailureToPutFilterBlueprint(t *testing.T) {
 				newVersion := 2
 				filterAPI.PUT("/filters/{filter_blueprint_id}", filterBlueprintID).WithBytes([]byte(GetValidPUTFilterBlueprintJSON(newVersion, time.Now()))).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - version not found\n")
+					Expect().Status(http.StatusBadRequest).Body().Contains(versionNotFoundResponse)
 			})
 		})
 

--- a/publishing/filterAPI/put_filter_output_test.go
+++ b/publishing/filterAPI/put_filter_output_test.go
@@ -187,7 +187,7 @@ func TestFailureToPutFilterOutput(t *testing.T) {
 				filterAPI.PUT("/filter-outputs/{filter_output_id}", filterOutputID).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte(GetValidPUTFilterOutputWithCSVDownloadJSON())).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter output not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterOutputNotFoundResponse)
 			})
 		})
 	})

--- a/web/filterAPI/delete_dimension_option_test.go
+++ b/web/filterAPI/delete_dimension_option_test.go
@@ -101,10 +101,10 @@ func TestFailureToDeleteDimensionOptions(t *testing.T) {
 
 	Convey("Given filter job does not exist", t, func() {
 		Convey("When requesting to delete an option from the filter job", func() {
-			Convey("Then the response returns status not found (404)", func() {
+			Convey("Then the response returns status 400 bad request", func() {
 
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/wages/options/27000", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -120,7 +120,7 @@ func TestFailureToDeleteDimensionOptions(t *testing.T) {
 			Convey("Then the response returns status not found (404)", func() {
 
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/wages/options/27000", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 
@@ -128,7 +128,7 @@ func TestFailureToDeleteDimensionOptions(t *testing.T) {
 			Convey("Then the response returns status not found (404)", func() {
 
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/age/options/44", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Option not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(optionNotFoundResponse)
 			})
 		})
 

--- a/web/filterAPI/delete_dimension_test.go
+++ b/web/filterAPI/delete_dimension_test.go
@@ -104,10 +104,10 @@ func TestFailureToDeleteDimension(t *testing.T) {
 
 	Convey("Given filter blueprint does not exist", t, func() {
 		Convey("When requesting to delete a dimension from filter blueprint", func() {
-			Convey("Then response returns status not found (404)", func() {
+			Convey("Then response returns status 400 bad request", func() {
 
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/age", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -123,7 +123,7 @@ func TestFailureToDeleteDimension(t *testing.T) {
 			Convey("Then response returns status not found (404)", func() {
 
 				filterAPI.DELETE("/filters/{filter_blueprint_id}/dimensions/wage", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 

--- a/web/filterAPI/get_dimension_option_test.go
+++ b/web/filterAPI/get_dimension_option_test.go
@@ -107,10 +107,10 @@ func TestFailureToGetDimensionOption(t *testing.T) {
 
 	Convey("Given a filter blueprint does not exist", t, func() {
 		Convey("When a request to get a dimension option against filter blueprint", func() {
-			Convey("Then return a status not found (404)", func() {
+			Convey("Then return a status 400 bad request", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/age/options/27", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -126,7 +126,7 @@ func TestFailureToGetDimensionOption(t *testing.T) {
 			Convey("Then return a status bad request (404)", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/ages/options/27", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 
@@ -134,7 +134,7 @@ func TestFailureToGetDimensionOption(t *testing.T) {
 			Convey("Then return a status not found (404)", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/sex/options/unknown", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Option not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(optionNotFoundResponse)
 			})
 		})
 	})

--- a/web/filterAPI/get_dimension_options_test.go
+++ b/web/filterAPI/get_dimension_options_test.go
@@ -128,7 +128,7 @@ func TestFailureToGetListOfDimensionOptions(t *testing.T) {
 			Convey("Then return status not found (404)", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/age/options", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -144,7 +144,7 @@ func TestFailureToGetListOfDimensionOptions(t *testing.T) {
 			Convey("Then return a status not found (404)", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/wages/options", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 	})

--- a/web/filterAPI/get_dimension_test.go
+++ b/web/filterAPI/get_dimension_test.go
@@ -89,10 +89,10 @@ func TestFailureToGetDimension(t *testing.T) {
 
 	Convey("Given filter blueprint does not exist", t, func() {
 		Convey("When a request is made to get a dimension for filter blueprint", func() {
-			Convey("Then the response returns status not found (404)", func() {
+			Convey("Then the response returns status bad request", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/age", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -108,7 +108,7 @@ func TestFailureToGetDimension(t *testing.T) {
 			Convey("Then the response returns status not found (404)", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions/wage", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimension not found")
+					Expect().Status(http.StatusNotFound).Body().Contains(dimensionNotFoundResponse)
 			})
 		})
 

--- a/web/filterAPI/get_dimensions_test.go
+++ b/web/filterAPI/get_dimensions_test.go
@@ -73,7 +73,7 @@ func TestFailureToGetListOfDimensions(t *testing.T) {
 			Convey("Then return status not found (404)", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}/dimensions", filterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})

--- a/web/filterAPI/get_filter_blueprint_test.go
+++ b/web/filterAPI/get_filter_blueprint_test.go
@@ -137,7 +137,7 @@ func TestFailureToGetFilterBlueprint(t *testing.T) {
 			Convey("Then the response returns status not found (404)", func() {
 
 				filterAPI.GET("/filters/{filter_blueprint_id}", filterID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -152,7 +152,7 @@ func TestFailureToGetFilterBlueprint(t *testing.T) {
 		Convey("When requesting to get filter blueprint without authentication", func() {
 			Convey("Then the response returns status not found (404)", func() {
 				filterAPI.GET("/filters/{filter_blueprint_id}", unpublishedFilterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(versionNotFoundResponse)
 			})
 		})
 

--- a/web/filterAPI/get_filter_output_test.go
+++ b/web/filterAPI/get_filter_output_test.go
@@ -249,7 +249,7 @@ func TestFailureToGetFilterOutput(t *testing.T) {
 			Convey("Then the response returns status not found (404)", func() {
 
 				filterAPI.GET("/filter-outputs/{filter_output_id}", filterID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter output not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterOutputNotFoundResponse)
 			})
 		})
 	})
@@ -265,7 +265,7 @@ func TestFailureToGetFilterOutput(t *testing.T) {
 			Convey("Then the response returns status not found (404)", func() {
 
 				filterAPI.GET("/filter-outputs/{filter_output_id}", filterOutputID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter output not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterOutputNotFoundResponse)
 			})
 		})
 

--- a/web/filterAPI/initialise.go
+++ b/web/filterAPI/initialise.go
@@ -13,6 +13,12 @@ var cfg *config.Config
 const (
 	collection = "filters"
 	downloadServiceToken    = "QB0108EZ-825D-412C-9B1D-41EF7747F462"
+
+	filterNotFoundResponse = "filter blueprint not found\n"
+	filterOutputNotFoundResponse = "filter output not found\n"
+	dimensionNotFoundResponse = "dimension not found\n"
+	versionNotFoundResponse = "version not found\n"
+	optionNotFoundResponse = "option not found\n"
 )
 
 func init() {

--- a/web/filterAPI/post_dimension_option_test.go
+++ b/web/filterAPI/post_dimension_option_test.go
@@ -117,10 +117,10 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 		invalidfilterBlueprintID := uuid.NewV4().String()
 
 		Convey("When a post request to add an option to a dimension for that filter blueprint", func() {
-			Convey("Then return status not found (404)", func() {
+			Convey("Then return status 400 bad request", func() {
 
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/age/options/30", invalidfilterBlueprintID).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found")
+					Expect().Status(http.StatusBadRequest).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -136,7 +136,7 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 			Convey("Then return status unprocessable entity (422)", func() {
 
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/sex/options/male", filterBlueprintID).
-					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("Unprocessable entity - version for filter blueprint no longer exists\n")
+					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("version for filter blueprint no longer exists\n")
 			})
 		})
 
@@ -151,7 +151,7 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/sex/options/male", filterBlueprintID).
 						Expect().Status(http.StatusBadRequest).
-						Body().Contains("Bad request - incorrect dimensions chosen: [sex]\n")
+						Body().Contains("incorrect dimensions chosen: [sex]\n")
 				})
 			})
 
@@ -164,7 +164,7 @@ func TestFailureToPostDimensionOptions(t *testing.T) {
 				Convey("Then return status not found (400)", func() {
 
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/age/options/75", filterBlueprintID).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimension options chosen: [75]\n")
+						Expect().Status(http.StatusBadRequest).Body().Contains("incorrect dimension options chosen: [75]\n")
 				})
 			})
 		})

--- a/web/filterAPI/post_dimension_test.go
+++ b/web/filterAPI/post_dimension_test.go
@@ -148,7 +148,7 @@ func TestFailureToPostDimension(t *testing.T) {
 
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "Residence Type").
 					WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -174,7 +174,7 @@ func TestFailureToPostDimension(t *testing.T) {
 
 				filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "Residence Type").
 					WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("Unprocessable entity - version for filter blueprint no longer exists\n")
+					Expect().Status(http.StatusUnprocessableEntity).Body().Contains("version for filter blueprint no longer exists\n")
 			})
 		})
 
@@ -190,7 +190,7 @@ func TestFailureToPostDimension(t *testing.T) {
 
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "foobar").
 						WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Dimension not found\n")
+						Expect().Status(http.StatusBadRequest).Body().Contains(dimensionNotFoundResponse)
 				})
 			})
 
@@ -205,7 +205,7 @@ func TestFailureToPostDimension(t *testing.T) {
 
 					filterAPI.POST("/filters/{filter_blueprint_id}/dimensions/{dimension}", filterBlueprintID, "age").
 						WithBytes([]byte(GetValidPOSTDimensionToFilterBlueprintJSON())).
-						Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimension options chosen: [Lives in a communal establishment Lives in a household]\n")
+						Expect().Status(http.StatusBadRequest).Body().Contains("incorrect dimension options chosen: [Lives in a communal establishment Lives in a household]\n")
 				})
 			})
 		})

--- a/web/filterAPI/post_filter_blueprint_test.go
+++ b/web/filterAPI/post_filter_blueprint_test.go
@@ -183,7 +183,7 @@ func TestFailureToPostfilterBlueprintForPublishedInstance(t *testing.T) {
 			Convey("Then the response returns status not found (404)", func() {
 
 				filterAPI.POST("/filters").WithBytes([]byte(GetValidPOSTCreateFilterJSON(datasetID, edition, version))).
-					Expect().Status(http.StatusNotFound).Body().Contains("Version not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(versionNotFoundResponse)
 			})
 		})
 	})
@@ -199,7 +199,7 @@ func TestFailureToPostfilterBlueprintForPublishedInstance(t *testing.T) {
 			Convey("Then the response returns status bad request (400)", func() {
 
 				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidDimensionJSON(datasetID, edition, version))).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimensions chosen: [weight]\n")
+					Expect().Status(http.StatusBadRequest).Body().Contains("incorrect dimensions chosen: [weight]\n")
 			})
 		})
 
@@ -207,7 +207,7 @@ func TestFailureToPostfilterBlueprintForPublishedInstance(t *testing.T) {
 			Convey("Then the response returns status bad request (400)", func() {
 
 				filterAPI.POST("/filters").WithBytes([]byte(GetInvalidDimensionOptionJSON(datasetID, edition, version))).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - incorrect dimension options chosen: [33]\n")
+					Expect().Status(http.StatusBadRequest).Body().Contains("incorrect dimension options chosen: [33]\n")
 			})
 		})
 

--- a/web/filterAPI/put_filter_blueprint_test.go
+++ b/web/filterAPI/put_filter_blueprint_test.go
@@ -178,7 +178,7 @@ func TestFailureToPutFilterBlueprint(t *testing.T) {
 			Convey("Then the request fails and returns status not found (404)", func() {
 
 				filterAPI.PUT("/filters/{filter_blueprint_id}", filterBlueprintID).WithBytes([]byte(GetValidPUTUpdateFilterBlueprintJSON(instanceID))).
-					Expect().Status(http.StatusNotFound).Body().Contains("Filter blueprint not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains(filterNotFoundResponse)
 			})
 		})
 	})
@@ -223,7 +223,7 @@ func TestFailureToPutFilterBlueprint(t *testing.T) {
 			Convey("Then fail to update filter blueprint and return status bad request (400)", func() {
 				newVersion := 2
 				filterAPI.PUT("/filters/{filter_blueprint_id}", filterBlueprintID).WithBytes([]byte(GetValidPUTFilterBlueprintJSON(newVersion, time.Now()))).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Bad request - version not found\n")
+					Expect().Status(http.StatusBadRequest).Body().Contains(versionNotFoundResponse)
 			})
 		})
 


### PR DESCRIPTION
### What

The filter API has been updated here: https://github.com/ONSdigital/dp-filter-api/pull/79

The tests have been updated to reflect the changes
 - create common response constants to reduce duplicated string values
 - update responses where capitals and punctuation have been removed
 - fix tests where 400 should be returned instead of 404

### How to review

Review changes / test against  https://github.com/ONSdigital/dp-filter-api/pull/79

### Who can review

Anyone
