### PR TITLE
updated expected error to match latest delete dataset endpoint

### DIFF
--- a/publishing/datasetAPI/delete_dataset_test.go
+++ b/publishing/datasetAPI/delete_dataset_test.go
@@ -95,7 +95,7 @@ func TestFailureToDeleteDataset(t *testing.T) {
 				WithHeader(florenceTokenName, florenceToken)
 
 			Convey("Then the expected response is returned", func() {
-				request.Expect().Status(http.StatusForbidden).Body().Contains("forbidden - a published dataset cannot be deleted")
+				request.Expect().Status(http.StatusForbidden).Body().Contains("a published dataset cannot be deleted")
 			})
 		})
 


### PR DESCRIPTION
### What

Updated expected error message for delete dataset endpoint to align with latest implementation.

### How to review

Run the latest version of the dataset API with private endpoints enabled and run the publishing dataset API tests.

### Who can review

Anyone.
