### PR TITLE
Update tests for new event structure

### DIFF
--- a/publishing/filterAPI/expectedTestData/filterJobWithDimensions.go
+++ b/publishing/filterAPI/expectedTestData/filterJobWithDimensions.go
@@ -147,6 +147,11 @@ func ExpectedFilterOutput(host, instanceID, filterOutputID, filterBlueprintID st
 		},
 		Published: &mongo.Published,
 		State:     "created",
+		Events: []*mongo.Event{
+			{
+				Type:"FilterOutputCreated",
+			},
+		},
 	}
 }
 
@@ -187,6 +192,11 @@ func ExpectedFilterOutputOnPost(host, datasetID, edition, instanceID, filterOutp
 		},
 		Published: &mongo.Published,
 		State:     "created",
+		Events: []*mongo.Event{
+			{
+				Type:"FilterOutputCreated",
+			},
+		},
 	}
 }
 

--- a/publishing/filterAPI/json.go
+++ b/publishing/filterAPI/json.go
@@ -548,15 +548,6 @@ func GetValidPUTFilterBlueprintJSON(version int, time time.Time) string {
 	return `{
 	  "dataset": {
 			"version": ` + strconv.Itoa(version) + `
-		},
-	  "events": {
-		  "info": [
-		    {
-		      "message": "blueprint has created filter output resource",
-					"time": "` + time.String() + `",
-					"type": "info"
-	      }
-	    ]
 		}
   }`
 }

--- a/publishing/filterAPI/put_filter_blueprint_test.go
+++ b/publishing/filterAPI/put_filter_blueprint_test.go
@@ -99,12 +99,6 @@ func TestSuccessfulPutFilterBlueprint(t *testing.T) {
 				response.Value("links").Object().Value("version").Object().Value("id").Equal("1")
 				response.NotContainsKey("last_updated")
 				response.NotContainsKey("downloads")
-
-				info := response.Value("events").Object().Value("info").Array()
-				info.Length().Equal(1)
-				info.Element(0).Object().Value("message").Equal("blueprint has created filter output resource")
-				info.Element(0).Object().Value("time").Equal(time.String())
-				info.Element(0).Object().Value("type").Equal("info")
 			})
 		})
 

--- a/testDataSetup/mongo/mongo.go
+++ b/testDataSetup/mongo/mongo.go
@@ -3,7 +3,7 @@ package mongo
 import (
 	"time"
 
-	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
 	importAPIModel "github.com/ONSdigital/dp-import-api/models"
@@ -352,12 +352,8 @@ type IDLink struct {
 	HRef string `bson:"href,omitempty" json:"href,omitempty"`
 }
 
-// Event which has happened to an instance
 type Event struct {
-	Type          string     `bson:"type,omitempty"           json:"type"`
-	Time          *time.Time `bson:"time,omitempty"           json:"time"`
-	Message       string     `bson:"message,omitempty"        json:"message"`
-	MessageOffset string     `bson:"message_offset,omitempty" json:"message_offset"`
+	Type string    `bson:"type,omitempty" json:"type"`
 }
 
 // GetDataset retrieves a dataset document from mongo
@@ -433,7 +429,7 @@ type Filter struct {
 	UniqueTimestamp bson.MongoTimestamp `bson:"unique_timestamp"     json:"-"`
 	Dimensions      []Dimension         `bson:"dimensions,omitempty" json:"dimensions,omitempty"`
 	Downloads       *Downloads          `bson:"downloads,omitempty"  json:"downloads,omitempty"`
-	Events          *Events             `bson:"events,omitempty"     json:"events,omitempty"`
+	Events          []*Event            `bson:"events,omitempty"     json:"events,omitempty"`
 	FilterID        string              `bson:"filter_id"            json:"filter_id,omitempty"`
 	State           string              `bson:"state,omitempty"      json:"state,omitempty"`
 	Links           LinkMap             `bson:"links"                json:"links,omitempty"`
@@ -467,19 +463,6 @@ type DownloadItem struct {
 	Private string `bson:"private,omitempty" json:"private,omitempty"`
 	Public  string `bson:"public,omitempty"  json:"public,omitempty"`
 	Size    string `bson:"size,omitempty"    json:"size,omitempty"`
-}
-
-// Events represents a list of array objects containing event information against the filter blueprint or output
-type Events struct {
-	Error *[]EventItem `bson:"error,omitempty" json:"error,omitempty"`
-	Info  *[]EventItem `bson:"info,omitempty"  json:"info,omitempty"`
-}
-
-// EventItem represents an event object containing event information
-type EventItem struct {
-	Message string `bson:"message,omitempty" json:"message,omitempty"`
-	Time    string `bson:"time,omitempty"    json:"time,omitempty"`
-	Type    string `bson:"type,omitempty"    json:"type,omitempty"`
 }
 
 // GetFilter retrieves a filter document from mongo

--- a/web/filterAPI/expectedTestData/filterJobWithDimensions.go
+++ b/web/filterAPI/expectedTestData/filterJobWithDimensions.go
@@ -147,6 +147,11 @@ func ExpectedFilterOutput(host, instanceID, filterOutputID, filterBlueprintID st
 		},
 		Published: &mongo.Published,
 		State:     "created",
+		Events: []*mongo.Event{
+			{
+				Type:"FilterOutputCreated",
+			},
+		},
 	}
 }
 
@@ -187,6 +192,11 @@ func ExpectedFilterOutputOnPost(host, datasetID, edition, instanceID, filterOutp
 		},
 		Published: &mongo.Published,
 		State:     "created",
+		Events: []*mongo.Event{
+			{
+				Type:"FilterOutputCreated",
+			},
+		},
 	}
 }
 

--- a/web/filterAPI/json.go
+++ b/web/filterAPI/json.go
@@ -576,15 +576,6 @@ func GetValidPUTFilterBlueprintJSON(version int, time time.Time) string {
 	return `{
 	  "dataset": {
 			"version": ` + strconv.Itoa(version) + `
-		},
-	  "events": {
-		  "info": [
-		    {
-		      "message": "blueprint has created filter output resource",
-					"time": "` + time.String() + `",
-					"type": "info"
-	      }
-	    ]
 		}
   }`
 }

--- a/web/filterAPI/put_filter_blueprint_test.go
+++ b/web/filterAPI/put_filter_blueprint_test.go
@@ -98,12 +98,6 @@ func TestSuccessfulPutFilterBlueprint(t *testing.T) {
 				response.Value("links").Object().Value("version").Object().Value("id").Equal("1")
 				response.NotContainsKey("last_updated")
 				response.NotContainsKey("downloads")
-
-				info := response.Value("events").Object().Value("info").Array()
-				info.Length().Equal(1)
-				info.Element(0).Object().Value("message").Equal("blueprint has created filter output resource")
-				info.Element(0).Object().Value("time").Equal(time.String())
-				info.Element(0).Object().Value("type").Equal("info")
 			})
 		})
 


### PR DESCRIPTION
### What

* Events are no longer added via the put filter output endpoint, so removed related assertions and updated test data
* Test that events are added when a filter output is created

### How to review

Test against https://github.com/ONSdigital/dp-filter-api/pull/97

### Who can review

Anyone
