### PR TITLE
Clean up import api tests

### DIFF
--- a/publishing/importAPI/get_jobs_test.go
+++ b/publishing/importAPI/get_jobs_test.go
@@ -61,7 +61,7 @@ func TestSuccessfullyGetListOfImportJobs(t *testing.T) {
 	}
 }
 
-func TestGetListOfImportJobsUnauthorised(t *testing.T) {
+func TestFailureToGetListOfImportJobs(t *testing.T) {
 
 	var docs []*mongo.Doc
 
@@ -96,6 +96,17 @@ func TestGetListOfImportJobsUnauthorised(t *testing.T) {
 				importAPI.GET("/jobs").
 					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
 					Expect().Status(http.StatusUnauthorized)
+			})
+		})
+	})
+
+	Convey("Given no import job are in a state of submitted", t, func() {
+		Convey("When get jobs is called with an authenticated request", func() {
+			Convey("Then the response returns status not found (404)", func() {
+				importAPI.GET("/jobs?state=submitted").
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					Expect().Status(http.StatusNotFound).
+					Body().Contains("requested resource not found")
 			})
 		})
 	})

--- a/publishing/importAPI/json.go
+++ b/publishing/importAPI/json.go
@@ -91,7 +91,6 @@ var validCreatedImportJobData = bson.M{
 
 var validSubmittedImportJobData = bson.M{
 	"$set": bson.M{
-
 		"id":              "01C24F0D-24BE-479F-962B-C76BCCD0AD00",
 		"recipe":          "6C9D2696-131F-40C3-B598-12200C90415C",
 		"state":           "Submitted",

--- a/publishing/importAPI/post_job_test.go
+++ b/publishing/importAPI/post_job_test.go
@@ -49,7 +49,6 @@ func TestSuccessfullyPostImportJob(t *testing.T) {
 				}
 
 				So(job.UniqueTimestamp, ShouldNotBeEmpty)
-				log.Trace("jon id", log.Data{"import job id": importJobID})
 
 				importJob := &mongo.Doc{
 					Database:   cfg.MongoImportsDB,

--- a/publishing/importAPI/post_job_test.go
+++ b/publishing/importAPI/post_job_test.go
@@ -49,6 +49,7 @@ func TestSuccessfullyPostImportJob(t *testing.T) {
 				}
 
 				So(job.UniqueTimestamp, ShouldNotBeEmpty)
+				log.Trace("jon id", log.Data{"import job id": importJobID})
 
 				importJob := &mongo.Doc{
 					Database:   cfg.MongoImportsDB,
@@ -57,7 +58,14 @@ func TestSuccessfullyPostImportJob(t *testing.T) {
 					Value:      importJobID,
 				}
 
-				if err := mongo.Teardown(importJob); err != nil {
+				importInstance := &mongo.Doc{
+					Database:   cfg.MongoDB,
+					Collection: "instances",
+					Key:        "links.job.id",
+					Value:      importJobID,
+				}
+
+				if err := mongo.Teardown(importJob, importInstance); err != nil {
 					if err != mgo.ErrNotFound {
 						log.ErrorC("Failed to tear down test data", err, nil)
 						os.Exit(1)
@@ -72,26 +80,9 @@ func TestFailureToPostImportJob(t *testing.T) {
 
 	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
-	Convey("Given an invalid JSON request", t, func() {
-		Convey("When create job is called", func() {
-			Convey("Then the response returns bad request (400)", func() {
-
-				importAPI.POST("/jobs").
-					WithHeader(serviceAuthTokenName, serviceAuthToken).
-					WithBytes([]byte("{")).
-					Expect().Status(http.StatusBadRequest)
-			})
-		})
-	})
-}
-
-func TestPostImportJobWithNoAuthentication(t *testing.T) {
-
-	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
-
 	Convey("Given a request with no Authorization header", t, func() {
 		Convey("When create job is called", func() {
-			Convey("Then the response returns not found (404)", func() {
+			Convey("Then the response returns unauthorized (401)", func() {
 
 				importAPI.POST("/jobs").
 					WithBytes([]byte(validPOSTCreateJobJSON)).
@@ -99,11 +90,6 @@ func TestPostImportJobWithNoAuthentication(t *testing.T) {
 			})
 		})
 	})
-}
-
-func TestPostImportJobUnauthorised(t *testing.T) {
-
-	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
 
 	Convey("Given a request with an unauthorised Authorization header", t, func() {
 		Convey("When create job is called", func() {
@@ -113,6 +99,32 @@ func TestPostImportJobUnauthorised(t *testing.T) {
 					WithBytes([]byte(validPOSTCreateJobJSON)).
 					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
 					Expect().Status(http.StatusUnauthorized)
+			})
+		})
+	})
+
+	Convey("Given an invalid JSON request", t, func() {
+		Convey("When create job is called", func() {
+			Convey("Then the response returns bad request (400)", func() {
+
+				importAPI.POST("/jobs").
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					WithBytes([]byte("{")).
+					Expect().Status(http.StatusBadRequest).
+					Body().Contains("failed to parse json body")
+			})
+		})
+	})
+
+	Convey("Given request is missing a mandatory field, ", t, func() {
+		Convey("When create job is called", func() {
+			Convey("Then the response returns bad request (400)", func() {
+
+				importAPI.POST("/jobs").
+					WithHeader(serviceAuthTokenName, serviceAuthToken).
+					WithBytes([]byte("{\"number_of_instances\": 1}")).
+					Expect().Status(http.StatusBadRequest).
+					Body().Contains("the provided Job is not valid")
 			})
 		})
 	})

--- a/publishing/importAPI/put_job_test.go
+++ b/publishing/importAPI/put_job_test.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/mgo.v2"
 )
 
-func TestUpdateImportJobState(t *testing.T) {
+func TestSuccessfullyUpdateImportJobState(t *testing.T) {
 
 	importJob := &mongo.Doc{
 		Database:   cfg.MongoImportsDB,
@@ -70,7 +70,7 @@ func TestUpdateImportJobState(t *testing.T) {
 	}
 }
 
-func TestUpdateImportJobStateUnauthorised(t *testing.T) {
+func TestFailureToUpdateImportJobState(t *testing.T) {
 
 	importJob := &mongo.Doc{
 		Database:   cfg.MongoImportsDB,
@@ -97,7 +97,7 @@ func TestUpdateImportJobStateUnauthorised(t *testing.T) {
 
 	Convey("Given a request with no Authorization header", t, func() {
 		Convey("When update job is called", func() {
-			Convey("Then the response returns status 404 not found", func() {
+			Convey("Then the response returns status unauthorized (401)", func() {
 				importAPI.PUT("/jobs/{id}", jobID).
 					WithBytes([]byte(validPUTJobJSON)).
 					Expect().Status(http.StatusUnauthorized).
@@ -108,7 +108,7 @@ func TestUpdateImportJobStateUnauthorised(t *testing.T) {
 
 	Convey("Given a request with an unauthorised Authorization header", t, func() {
 		Convey("When update job is called", func() {
-			Convey("Then the response returns status 401 unauthorised", func() {
+			Convey("Then the response returns status unauthorized (401)", func() {
 
 				importAPI.PUT("/jobs/{id}", jobID).
 					WithHeader(serviceAuthTokenName, unauthorisedServiceAuthToken).
@@ -119,31 +119,6 @@ func TestUpdateImportJobStateUnauthorised(t *testing.T) {
 		})
 	})
 
-	if err := mongo.Teardown(importJob, instance); err != nil {
-		if err != mgo.ErrNotFound {
-			log.ErrorC("Failed to tear down test data", err, nil)
-			os.Exit(1)
-		}
-	}
-}
-
-func TestFailureToUpdateAnImportJob(t *testing.T) {
-
-	importJob := &mongo.Doc{
-		Database:   cfg.MongoImportsDB,
-		Collection: collection,
-		Key:        "id",
-		Value:      jobID,
-		Update:     validCreatedImportJobData,
-	}
-
-	if err := mongo.Setup(importJob); err != nil {
-		log.ErrorC("Failed to set up test data", err, nil)
-		os.Exit(1)
-	}
-
-	importAPI := httpexpect.New(t, cfg.ImportAPIURL)
-
 	Convey("Given a request for a job that does not exist", t, func() {
 		Convey("When update job is called", func() {
 			Convey("Then the response returns status not found (404)", func() {
@@ -151,7 +126,7 @@ func TestFailureToUpdateAnImportJob(t *testing.T) {
 					WithBytes([]byte(validPUTJobJSON)).
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("resource not found")
+					Body().Contains("job not found")
 			})
 		})
 	})
@@ -163,12 +138,12 @@ func TestFailureToUpdateAnImportJob(t *testing.T) {
 					WithHeader(serviceAuthTokenName, serviceAuthToken).
 					WithBytes([]byte("{")).
 					Expect().Status(http.StatusBadRequest).
-					Body().Contains("invalid request")
+					Body().Contains("failed to parse json body")
 			})
 		})
 	})
 
-	if err := mongo.Teardown(importJob); err != nil {
+	if err := mongo.Teardown(importJob, instance); err != nil {
 		if err != mgo.ErrNotFound {
 			log.ErrorC("Failed to tear down test data", err, nil)
 			os.Exit(1)


### PR DESCRIPTION
### What

Tidy import api tests.

Include missing tests and make sure all test data is removed from test
databases.

### How to review

Check changes make sense, tests should be easier to read/follow. Make sure tests pass by doing the following:

1) Run `dp-auth-api-stub` on branch `cmd-develop`; with `make debug`
2) Run `dp-dataset-api` on branch `cmd-develop`; with `make acceptance-publishing`
3) Run `dp-recipe-api` on branch `cmd-develop`; with `make debug`
4) Run `dp-import-api` on branch `feature/update-go-ns-dependencies`; with `make acceptance`
5) Run import API acceptance tests with the following command:

 `cd publishing/importAPI; go test ./...; cd ../..` 

at root level of repository.

### Who can review

Anyone
