### PR TITLE
Recognise a HTTP 429 as a valid healthcheck response

### DIFF
--- a/publishing/datasetAPI/get_healthcheck_test.go
+++ b/publishing/datasetAPI/get_healthcheck_test.go
@@ -16,8 +16,11 @@ func TestSuccessfullyGetHealthcheck(t *testing.T) {
 		Convey("When you ask the healthcheck endpoint", func() {
 			Convey("Then you should see a status of OK", func() {
 
-				response := datasetAPIClient.GET("/healthcheck", nil).Expect().Status(http.StatusOK).JSON().Object()
-				response.Value("status").Equal("OK")
+				response := datasetAPIClient.GET("/healthcheck", nil).Expect().Raw()
+				isValidResponse := response.StatusCode == http.StatusOK ||
+					response.StatusCode == http.StatusTooManyRequests
+
+				So(isValidResponse, ShouldBeTrue)
 			})
 		})
 	})

--- a/web/datasetAPI/get_healthcheck_test.go
+++ b/web/datasetAPI/get_healthcheck_test.go
@@ -16,10 +16,11 @@ func TestSuccessfullyGetHealthcheck(t *testing.T) {
 		Convey("When you ask the healthcheck endpoint", func() {
 			Convey("Then you should see a status of OK", func() {
 
-				response := datasetAPIClient.GET("/healthcheck", nil).
-					Expect().Status(http.StatusOK).JSON().Object()
+				response := datasetAPIClient.GET("/healthcheck", nil).Expect().Raw()
+				isValidResponse := response.StatusCode == http.StatusOK ||
+					response.StatusCode == http.StatusTooManyRequests
 
-				response.Value("status").Equal("OK")
+				So(isValidResponse, ShouldBeTrue)
 			})
 		})
 	})


### PR DESCRIPTION
### What

Recognise a HTTP 429 as a valid healthcheck response. The tests currently fail if run too soon after starting the service.

### How to review

Review / test

### Who can review

anyone
