### PR TITLE
Feature/update dataset api tests

### DIFF
--- a/publishing/datasetAPI/get_dataset_dimensions_test.go
+++ b/publishing/datasetAPI/get_dataset_dimensions_test.go
@@ -141,7 +141,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 			})
 		})
 
@@ -152,7 +152,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Edition not found")
+					Body().Contains("edition not found")
 			})
 		})
 
@@ -162,7 +162,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Version not found")
+					Body().Contains("version not found")
 			})
 		})
 
@@ -209,7 +209,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).
 					WithHeader(florenceTokenName, florenceToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimensions not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("dimensions not found")
 			})
 		})
 

--- a/publishing/datasetAPI/get_dataset_test.go
+++ b/publishing/datasetAPI/get_dataset_test.go
@@ -97,7 +97,7 @@ func TestFailureToGetADataset(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}", datasetID).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 			})
 		})
 	})

--- a/publishing/datasetAPI/get_dimension_options_test.go
+++ b/publishing/datasetAPI/get_dimension_options_test.go
@@ -189,7 +189,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -201,7 +201,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Edition not found")
+					Body().Contains("edition not found")
 			})
 		})
 	})
@@ -213,7 +213,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Version not found")
+					Body().Contains("version not found")
 			})
 		})
 	})

--- a/publishing/datasetAPI/get_edition_test.go
+++ b/publishing/datasetAPI/get_edition_test.go
@@ -125,7 +125,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
 					WithHeader(florenceTokenName, florenceToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -142,7 +142,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
 						WithHeader(florenceTokenName, florenceToken).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
+						Expect().Status(http.StatusNotFound).Body().Contains("edition not found")
 				})
 			})
 		})

--- a/publishing/datasetAPI/get_editions_test.go
+++ b/publishing/datasetAPI/get_editions_test.go
@@ -127,7 +127,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 
 					datasetAPI.GET("/datasets/{id}/editions", datasetID).
 						WithHeader(florenceTokenName, florenceToken).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
+						Expect().Status(http.StatusNotFound).Body().Contains("edition not found")
 				})
 			})
 		})

--- a/publishing/datasetAPI/get_instance_dimension_options_test.go
+++ b/publishing/datasetAPI/get_instance_dimension_options_test.go
@@ -90,11 +90,11 @@ func TestFailureToGetInstanceDimensionOptions(t *testing.T) {
 		})
 
 		Convey("When an authenticated user sends a GET request for an instances dimension options", func() {
-			Convey("Then return status not found (404) with a message `Instance not found`", func() {
+			Convey("Then return status not found (404) with a message `instance not found`", func() {
 
 				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).
 					WithHeader(florenceTokenName, florenceToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("instance not found")
 			})
 		})
 	})
@@ -132,12 +132,12 @@ func TestFailureToGetInstanceDimensionOptions(t *testing.T) {
 		})
 
 		Convey("When an authenticated user sends a GET request for an instances dimension options", func() {
-			Convey("Then return status not found (404) with a message `Dimension node not found`", func() {
+			Convey("Then return status not found (404) with a message `dimension node not found`", func() {
 
 				datasetAPI.GET("/instances/{id}/dimensions/time/options", instanceID).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dimension node not found\n")
+					Body().Contains("dimension node not found\n")
 			})
 		})
 

--- a/publishing/datasetAPI/get_instance_dimensions_test.go
+++ b/publishing/datasetAPI/get_instance_dimensions_test.go
@@ -160,11 +160,11 @@ func TestFailureToGetInstanceDimensions(t *testing.T) {
 		})
 
 		Convey("When an authenticated user sends a GET request of a list of dimensions for instance", func() {
-			Convey("Then return status not found (404) with a message `Instance not found`", func() {
+			Convey("Then return status not found (404) with a message `instance not found`", func() {
 
 				datasetAPI.GET("/instances/{id}/dimensions", instanceID).
 					WithHeader(florenceTokenName, florenceToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Instance not found\n")
+					Expect().Status(http.StatusNotFound).Body().Contains("instance not found\n")
 			})
 		})
 	})

--- a/publishing/datasetAPI/get_instance_test.go
+++ b/publishing/datasetAPI/get_instance_test.go
@@ -108,12 +108,12 @@ func TestFailureToGetInstance(t *testing.T) {
 
 	Convey("Given an instance resource does not exist", t, func() {
 		Convey("When an authorised request is made to get instance", func() {
-			Convey("Then return a status not found (404) with message `Instance not found`", func() {
+			Convey("Then return a status not found (404) with message `instance not found`", func() {
 
 				datasetAPI.GET("/instances/{id}", instanceID).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Instance not found")
+					Body().Contains("instance not found")
 
 			})
 		})

--- a/publishing/datasetAPI/get_metadata_test.go
+++ b/publishing/datasetAPI/get_metadata_test.go
@@ -195,9 +195,9 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When an authorised request to get the metadata relevant to a version", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).WithHeader(florenceTokenName, florenceToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -210,9 +210,9 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 
 		Convey("but an edition and version do not exist", func() {
 			Convey("When a request to get the metadata relevant to a version", func() {
-				Convey("Then return status not found (404) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).WithHeader(florenceTokenName, florenceToken).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
+						Expect().Status(http.StatusNotFound).Body().Contains("edition not found")
 				})
 			})
 		})
@@ -225,9 +225,9 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 
 			Convey("but a version does not exist", func() {
 				Convey("When a request to get the metadata relevant to a version", func() {
-					Convey("Then return status bad request (404) with message `Version not found`", func() {
+					Convey("Then return status bad request (404) with message `version not found`", func() {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).WithHeader(florenceTokenName, florenceToken).
-							Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
+							Expect().Status(http.StatusNotFound).Body().Contains("version not found")
 					})
 				})
 			})

--- a/publishing/datasetAPI/get_observations_test.go
+++ b/publishing/datasetAPI/get_observations_test.go
@@ -217,12 +217,12 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When an authorised request to get an observation for a version of a dataset", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/observations", datasetID, edition).
 					WithQueryString("time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -259,12 +259,12 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 
 		Convey("but edition and version do not exist", func() {
 			Convey("When a request to get an observation for a version of a dataset", func() {
-				Convey("Then return status not found (404) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/observations", datasetID, edition).
 						WithQueryString("time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 						WithHeader(florenceTokenName, florenceToken).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 				})
 			})
 		})
@@ -278,12 +278,12 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 
 			Convey("but a version does not exist", func() {
 				Convey("When a request to get an observation for a version of a dataset", func() {
-					Convey("Then return status not found (404) with message `Version not found`", func() {
+					Convey("Then return status not found (404) with message `version not found`", func() {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/observations", datasetID, edition).
 							WithQueryString("time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 							WithHeader(florenceTokenName, florenceToken).
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("Version not found")
+							Body().Contains("version not found")
 					})
 				})
 			})
@@ -301,7 +301,7 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 							WithHeader(florenceTokenName, florenceToken).
 							WithQueryString("age=24&gender=male&time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 							Expect().Status(http.StatusBadRequest).
-							Body().Match(`Incorrect selection of query parameters: \[(age gender|gender age)\], these dimensions do not exist for this version of the dataset`)
+							Body().Match(`incorrect selection of query parameters: \[(age gender|gender age)\], these dimensions do not exist for this version of the dataset`)
 					})
 				})
 
@@ -311,7 +311,7 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 							WithHeader(florenceTokenName, florenceToken).
 							WithQueryString("geography=K02000001").
 							Expect().Status(http.StatusBadRequest).
-							Body().Match(`Missing query parameters for the following dimensions: \[(time aggregate|aggregate time)\]`)
+							Body().Match(`missing query parameters for the following dimensions: \[(time aggregate|aggregate time)\]`)
 					})
 				})
 
@@ -331,17 +331,17 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 							WithHeader(florenceTokenName, florenceToken).
 							WithQueryString("time=Aug-16&time=Aug-17&geography=K02000001&geography=*&aggregate=cpi1dim1S40403").
 							Expect().Status(http.StatusBadRequest).
-							Body().Match(`Multi-valued query parameters for the following dimensions: \[(time geography|geography time)\]`)
+							Body().Match(`multi-valued query parameters for the following dimensions: \[(time geography|geography time)\]`)
 					})
 				})
 
 				Convey("When a request to get an observation for an unpublished version of a dataset with the correct query parameters but the values don't exist", func() {
-					Convey("Then return status not found (404) with message `No observations found`", func() {
+					Convey("Then return status not found (404) with message `no observations found`", func() {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/observations", datasetID, edition).
 							WithHeader(florenceTokenName, florenceToken).
 							WithQueryString("time=Aug-17&geography=K02000001&aggregate=cpi1dim1S40403").
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("No observations found")
+							Body().Contains("no observations found")
 					})
 				})
 			})

--- a/publishing/datasetAPI/get_version_test.go
+++ b/publishing/datasetAPI/get_version_test.go
@@ -213,9 +213,9 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When an authorised request to get the version of the dataset edition", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).WithHeader(florenceTokenName, florenceToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -228,9 +228,9 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 		Convey("but an edition and version do not exist", func() {
 			Convey("When a request to get the version of the dataset edition", func() {
-				Convey("Then return status not found (404) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", unpublishedDatasetID, edition).WithHeader(florenceTokenName, florenceToken).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
+						Expect().Status(http.StatusNotFound).Body().Contains("edition not found")
 				})
 			})
 		})
@@ -243,9 +243,9 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 			Convey("but a version does not exist", func() {
 				Convey("When a request to get the version of the dataset edition", func() {
-					Convey("Then return status bad request (404) with message `Version not found`", func() {
+					Convey("Then return status bad request (404) with message `version not found`", func() {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", unpublishedDatasetID, edition).WithHeader(florenceTokenName, florenceToken).
-							Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
+							Expect().Status(http.StatusNotFound).Body().Contains("version not found")
 					})
 				})
 			})

--- a/publishing/datasetAPI/get_versions_test.go
+++ b/publishing/datasetAPI/get_versions_test.go
@@ -144,9 +144,9 @@ func TestGetVersions_Failed(t *testing.T) {
 
 	Convey("Given the dataset and subsequently the edition does not exist", t, func() {
 		Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(florenceTokenName, florenceToken).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -159,9 +159,9 @@ func TestGetVersions_Failed(t *testing.T) {
 
 		Convey("but the edition does not", func() {
 			Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
-				Convey("Then return status not found (404) with message `EDition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(florenceTokenName, florenceToken).
-						Expect().Status(http.StatusNotFound).Body().Contains("Edition not found")
+						Expect().Status(http.StatusNotFound).Body().Contains("edition not found")
 				})
 			})
 		})
@@ -173,9 +173,9 @@ func TestGetVersions_Failed(t *testing.T) {
 			}
 
 			Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
-				Convey("Then return status not found (404) with message `Version not found`", func() {
+				Convey("Then return status not found (404) with message `version not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).WithHeader(florenceTokenName, florenceToken).
-						Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
+						Expect().Status(http.StatusNotFound).Body().Contains("version not found")
 				})
 			})
 		})

--- a/publishing/datasetAPI/post_dataset_test.go
+++ b/publishing/datasetAPI/post_dataset_test.go
@@ -89,11 +89,11 @@ func TestFailureToPostDataset(t *testing.T) {
 	Convey("Given the dataset does not already exist", t, func() {
 		Convey("When an authorised POST request is made to create dataset resource with an invalid body", func() {
 
-			Convey("Then return a status of bad request with a message `Failed to parse json body`", func() {
+			Convey("Then return a status of bad request with a message `failed to parse json body`", func() {
 
 				datasetAPI.POST("/datasets/{id}", datasetID).
 					WithHeader(florenceTokenName, florenceToken).WithBytes([]byte("{")).
-					Expect().Status(http.StatusBadRequest).Body().Contains("Failed to parse json body")
+					Expect().Status(http.StatusBadRequest).Body().Contains("failed to parse json body")
 			})
 		})
 

--- a/publishing/datasetAPI/post_instance_dimension_test.go
+++ b/publishing/datasetAPI/post_instance_dimension_test.go
@@ -92,13 +92,13 @@ func TestFailureToPostDimension(t *testing.T) {
 
 	Convey("Given an instance does not exist", t, func() {
 		Convey("When an authorised POST request is made to add dimension option for an instance", func() {
-			Convey("Then the response return a status not found (404) with message `Instance not found`", func() {
+			Convey("Then the response return a status not found (404) with message `instance not found`", func() {
 
 				datasetAPI.POST("/instances/{instance_id}/dimensions", instances["created"]).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validPOSTAgeDimensionJSON)).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Instance not found")
+					Body().Contains("instance not found")
 
 			})
 		})

--- a/publishing/datasetAPI/post_instance_event_test.go
+++ b/publishing/datasetAPI/post_instance_event_test.go
@@ -90,13 +90,13 @@ func TestFailureToPostInstanceEvent(t *testing.T) {
 
 	Convey("Given an instance does not exist", t, func() {
 		Convey("When an authorised POST request to create an event against an instance resource", func() {
-			Convey("Then the response return a status not found (404) with message `Instance not found`", func() {
+			Convey("Then the response return a status not found (404) with message `instance not found`", func() {
 
 				datasetAPI.POST("/instances/{instance_id}/events", instances[submitted]).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes(b).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Instance not found")
+					Body().Contains("instance not found")
 
 			})
 		})
@@ -138,13 +138,13 @@ func TestFailureToPostInstanceEvent(t *testing.T) {
 				instance resource but the json is invalid`, func() {
 
 			Convey(`Then the response return a status bad request (400)
-							with message 'Failed to parse json body'`, func() {
+							with message 'failed to parse json body'`, func() {
 
 				datasetAPI.POST("/instances/{instance_id}/events", instances[submitted]).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte("{")).
 					Expect().Status(http.StatusBadRequest).
-					Body().Contains("Failed to parse json body")
+					Body().Contains("failed to parse json body")
 
 			})
 		})

--- a/publishing/datasetAPI/post_instance_test.go
+++ b/publishing/datasetAPI/post_instance_test.go
@@ -113,24 +113,24 @@ func TestFailureToPostInstance(t *testing.T) {
 
 	Convey("Given an authorised user wants to create an instance", t, func() {
 		Convey("When an authorised POST request is made to create an instance resource with invalid json", func() {
-			Convey("Then fail to create resource and return a status bad request (400) with a message `Failed to parse json body: unexpected end of JSON input`", func() {
+			Convey("Then fail to create resource and return a status bad request (400) with a message `failed to parse json body: unexpected end of JSON input`", func() {
 
 				datasetAPI.POST("/instances").WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(`{`)).
 					Expect().Status(http.StatusBadRequest).
-					Body().Contains("Failed to parse json body: unexpected end of JSON input")
+					Body().Contains("failed to parse json body: unexpected end of JSON input")
 			})
 		})
 	})
 
 	Convey("Given an authorised user wants to create an instance", t, func() {
 		Convey("When an authorised POST request is made to create an instance resource with missing job properties", func() {
-			Convey("Then fail to create resource and return a status bad request (400) with a message `Missing job properties`", func() {
+			Convey("Then fail to create resource and return a status bad request (400) with a message `missing job properties`", func() {
 
 				datasetAPI.POST("/instances").WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(invalidPOSTCreateInstanceJSON)).
 					Expect().Status(http.StatusBadRequest).
-					Body().Contains("Missing job properties")
+					Body().Contains("missing job properties")
 			})
 		})
 	})

--- a/publishing/datasetAPI/put_dataset_test.go
+++ b/publishing/datasetAPI/put_dataset_test.go
@@ -171,12 +171,12 @@ func TestFailureToUpdateDataset(t *testing.T) {
 
 	Convey("Given a published dataset does not exist", t, func() {
 		Convey("When an authorised PUT request is made to update dataset resource", func() {
-			Convey("Then fail to update resource and return a status of not found (404) with a message `Dataset not found`", func() {
+			Convey("Then fail to update resource and return a status of not found (404) with a message `dataset not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}", datasetID).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validPUTUpdateDatasetJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -208,13 +208,13 @@ func TestFailureToUpdateDataset(t *testing.T) {
 		})
 
 		Convey("When an authorised PUT request is made to update dataset resource with an invalid body", func() {
-			Convey("Then fail to update resource and return a status of bad request (400) with a message `Failed to parse json body`", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message `failed to parse json body`", func() {
 
 				datasetAPI.PUT("/datasets/{id}", datasetID).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte("{")).
 					Expect().Status(http.StatusBadRequest).
-					Body().Contains("Failed to parse json body")
+					Body().Contains("failed to parse json body")
 			})
 		})
 

--- a/publishing/datasetAPI/put_instance_dimension_node_id_test.go
+++ b/publishing/datasetAPI/put_instance_dimension_node_id_test.go
@@ -105,12 +105,12 @@ func TestFailureToPutDimensionOptionNodeID(t *testing.T) {
 			with a 'node_id' for an instance`, func() {
 
 			Convey(`Then the response return a status not found (404)
-				with message 'Instance not found'`, func() {
+				with message 'instance not found'`, func() {
 
 				datasetAPI.PUT("/instances/{instance_id}/dimensions/time/options/202.5/node_id/{node_id}", instances[created], nodeID).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Instance not found")
+					Body().Contains("instance not found")
 
 			})
 		})

--- a/publishing/datasetAPI/put_instance_dimension_test.go
+++ b/publishing/datasetAPI/put_instance_dimension_test.go
@@ -84,13 +84,13 @@ func TestFailureToPutInstanceDimension(t *testing.T) {
 
 	Convey("Given an instance does not exist", t, func() {
 		Convey("When an authorised PUT request is made to update dimension on an instance resource", func() {
-			Convey("Then the response return a status not found (404) with message `Instance not found`", func() {
+			Convey("Then the response return a status not found (404) with message `instance not found`", func() {
 
 				datasetAPI.PUT("/instances/{instance_id}/dimensions/geography", instances[submitted]).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validPUTGeographyDimensionJSON)).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Instance not found")
+					Body().Contains("instance not found")
 
 			})
 		})
@@ -161,13 +161,13 @@ func TestFailureToPutInstanceDimension(t *testing.T) {
 			instance resource but the 'dimension' does not exist`, func() {
 
 			Convey(`Then the response return a status not found (404)
-						with message 'missing properties in JSON'`, func() {
+						with message 'dimension not found'`, func() {
 
 				datasetAPI.PUT("/instances/{instance_id}/dimensions/age", instances[submitted]).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validPUTAgeDimensionJSON)).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dimension not found")
+					Body().Contains("dimension not found")
 
 			})
 		})

--- a/publishing/datasetAPI/put_instance_import_tasks_test.go
+++ b/publishing/datasetAPI/put_instance_import_tasks_test.go
@@ -155,13 +155,13 @@ func TestFailureToPutImportTasks(t *testing.T) {
 		Convey(`When an authorised PUT request to update import task against
 			an instance resource`, func() {
 
-			Convey("Then the response return a status not found (404) with message `Instance not found`", func() {
+			Convey("Then the response return a status not found (404) with message `instance not found`", func() {
 
 				datasetAPI.PUT("/instances/{instance_id}/import_tasks", instances[submitted]).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validObservationImportTaskJSON)).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Instance not found")
+					Body().Contains("instance not found")
 
 			})
 		})

--- a/publishing/datasetAPI/put_instance_inserted_observations_test.go
+++ b/publishing/datasetAPI/put_instance_inserted_observations_test.go
@@ -87,12 +87,12 @@ func TestFailureToPutInsertedObservations(t *testing.T) {
 		Convey(`When an authorised PUT request to add the number of inserted
 			observations against an instance resource`, func() {
 
-			Convey("Then the response return a status not found (404) with message `Instance not found`", func() {
+			Convey("Then the response return a status not found (404) with message `instance not found`", func() {
 
 				datasetAPI.PUT("/instances/{instance_id}/inserted_observations/255", instances[submitted]).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Instance not found")
+					Body().Contains("instance not found")
 
 			})
 		})

--- a/publishing/datasetAPI/put_instance_test.go
+++ b/publishing/datasetAPI/put_instance_test.go
@@ -191,13 +191,13 @@ func TestFailureToPutInstance(t *testing.T) {
 	Convey("Given an instance does not exist", t, func() {
 
 		Convey("When an authorised PUT request is made to update instance with meta data", func() {
-			Convey("Then the response return a status not found (404) with message `Instance not found`", func() {
+			Convey("Then the response return a status not found (404) with message `instance not found`", func() {
 
 				datasetAPI.PUT("/instances/{instance_id}", instanceID).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validPUTFullInstanceJSON)).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Instance not found")
+					Body().Contains("instance not found")
 
 			})
 		})
@@ -211,13 +211,13 @@ func TestFailureToPutInstance(t *testing.T) {
 		}
 
 		Convey("When an authorised PUT request is made to update instance with invalid json", func() {
-			Convey("Then the response return a status not found (400) with message `Failed to parse json body: unexpected end of JSON input`", func() {
+			Convey("Then the response return a status not found (400) with message `failed to parse json body: unexpected end of JSON input`", func() {
 
 				datasetAPI.PUT("/instances/{instance_id}", instanceID).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte("{")).
 					Expect().Status(http.StatusBadRequest).
-					Body().Contains("Failed to parse json body: unexpected end of JSON input")
+					Body().Contains("failed to parse json body: unexpected end of JSON input")
 
 			})
 		})

--- a/publishing/datasetAPI/put_version_test.go
+++ b/publishing/datasetAPI/put_version_test.go
@@ -531,7 +531,7 @@ func TestFailureToUpdateVersion(t *testing.T) {
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(`{"state": "associated"}`)).
 					Expect().Status(http.StatusBadRequest).
-					Body().Contains("Missing collection_id for association between version and a collection")
+					Body().Contains("missing collection_id for association between version and a collection")
 
 			})
 		})

--- a/publishing/datasetAPI/put_version_test.go
+++ b/publishing/datasetAPI/put_version_test.go
@@ -364,12 +364,12 @@ func TestFailureToUpdateVersion(t *testing.T) {
 		}
 
 		Convey("When an authorised PUT request is made to update version resource", func() {
-			Convey("Then fail to update resource and return a status of not found (404) with a message `Dataset not found`", func() {
+			Convey("Then fail to update resource and return a status of not found (404) with a message `dataset not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dataset not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("dataset not found")
 
 			})
 		})
@@ -392,13 +392,13 @@ func TestFailureToUpdateVersion(t *testing.T) {
 		}
 
 		Convey("When an authorised PUT request is made to update version resource", func() {
-			Convey("Then fail to update resource and return a status of not found (404) with a message `Edition not found`", func() {
+			Convey("Then fail to update resource and return a status of not found (404) with a message `edition not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Edition not found")
+					Body().Contains("edition not found")
 
 			})
 		})
@@ -421,13 +421,13 @@ func TestFailureToUpdateVersion(t *testing.T) {
 		}
 
 		Convey("When an authorised PUT request is made to update version resource", func() {
-			Convey("Then fail to update resource and return a status of not found (404) with a message `Version not found`", func() {
+			Convey("Then fail to update resource and return a status of not found (404) with a message `version not found`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(validPUTUpdateVersionToPublishedJSON)).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Version not found")
+					Body().Contains("version not found")
 
 			})
 		})
@@ -501,13 +501,13 @@ func TestFailureToUpdateVersion(t *testing.T) {
 	// test for bad request (invalid json)
 	Convey("Given a dataset, edition and version do not exist", t, func() {
 		Convey("When an authorised PUT request is made to update version resource with invalid json", func() {
-			Convey("Then fail to update resource and return a status of bad request (400) with a message ``", func() {
+			Convey("Then fail to update resource and return a status of bad request (400) with a message `failed to parse json body`", func() {
 
 				datasetAPI.PUT("/datasets/{id}/editions/{edition}/versions/{version}", datasetID, edition, version).
 					WithHeader(florenceTokenName, florenceToken).
 					WithBytes([]byte(`{`)).
 					Expect().Status(http.StatusBadRequest).
-					Body().Contains("Failed to parse json body")
+					Body().Contains("failed to parse json body")
 
 			})
 		})

--- a/web/datasetAPI/get_dataset_dimensions_test.go
+++ b/web/datasetAPI/get_dataset_dimensions_test.go
@@ -142,7 +142,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", "1234", "2018").
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -156,7 +156,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, "2018").
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Edition not found")
+					Body().Contains("edition not found")
 
 			})
 		})
@@ -170,7 +170,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Version not found")
+						Body().Contains("version not found")
 
 				})
 			})
@@ -192,7 +192,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/dimensions", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Version not found")
+						Body().Contains("version not found")
 
 				})
 			})
@@ -202,7 +202,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/3/dimensions", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Version not found")
+						Body().Contains("version not found")
 
 				})
 			})
@@ -220,7 +220,7 @@ func TestGetDimensions_Failed(t *testing.T) {
 		Convey("When user makes a request to get the dimensions for version of the dataset edition", func() {
 			Convey("Then return status not found (404)", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions", datasetID, edition).
-					Expect().Status(http.StatusNotFound).Body().Contains("Dimensions not found")
+					Expect().Status(http.StatusNotFound).Body().Contains("dimensions not found")
 			})
 		})
 	})

--- a/web/datasetAPI/get_dataset_test.go
+++ b/web/datasetAPI/get_dataset_test.go
@@ -67,7 +67,7 @@ func TestFailureToGetADataset(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}", datasetID).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -92,7 +92,7 @@ func TestFailureToGetADataset(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}", datasetID).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -103,7 +103,7 @@ func TestFailureToGetADataset(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}", datasetID).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})

--- a/web/datasetAPI/get_dimension_options_test.go
+++ b/web/datasetAPI/get_dimension_options_test.go
@@ -132,7 +132,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", "1234", edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -144,7 +144,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/time/options", datasetID, "2018").
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Edition not found")
+					Body().Contains("edition not found")
 
 			})
 		})
@@ -156,7 +156,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/5/dimensions/time/options", datasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Version not found")
+					Body().Contains("version not found")
 
 			})
 		})
@@ -168,7 +168,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/dimensions/time/options", datasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Version not found")
+					Body().Contains("version not found")
 
 			})
 		})
@@ -179,7 +179,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/dimensions/time/options", datasetID, edition).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Version not found")
+					Body().Contains("version not found")
 
 			})
 		})
@@ -191,7 +191,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/dimensions/aggregate/options", datasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dimension not found")
+					Body().Contains("dimension not found")
 
 			})
 		})
@@ -204,7 +204,7 @@ func TestGetDimensionOptions_Failed(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/dimensions/time/options", datasetID, edition).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dimension not found")
+					Body().Contains("dimension not found")
 			})
 		})
 	})

--- a/web/datasetAPI/get_edition_test.go
+++ b/web/datasetAPI/get_edition_test.go
@@ -109,7 +109,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 			})
 		})
 
@@ -123,7 +123,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 
@@ -133,7 +133,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
 						WithHeader(florenceTokenName, florenceToken).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Dataset not found")
+						Body().Contains("dataset not found")
 
 				})
 			})
@@ -156,7 +156,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Edition not found")
+					Body().Contains("edition not found")
 
 			})
 
@@ -166,7 +166,7 @@ func TestFailureToGetDatasetEdition(t *testing.T) {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}", datasetID, unpublishedEdition).
 						WithHeader(florenceTokenName, florenceToken).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 
 				})
 			})

--- a/web/datasetAPI/get_editions_test.go
+++ b/web/datasetAPI/get_editions_test.go
@@ -97,7 +97,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions", datasetID).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -115,7 +115,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 
 					datasetAPI.GET("/datasets/{id}/editions", datasetID).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 				})
 			})
 		})
@@ -132,7 +132,7 @@ func TestFailureToGetListOfDatasetEditions(t *testing.T) {
 
 					datasetAPI.GET("/datasets/{id}/editions", datasetID).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 				})
 			})
 		})

--- a/web/datasetAPI/get_metadata_test.go
+++ b/web/datasetAPI/get_metadata_test.go
@@ -154,11 +154,11 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When a request to get the metadata relevant to a version", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -171,22 +171,22 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 		}
 
 		Convey("When a request to get the metadata relevant to a version", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
 
 		Convey("When a request to get the metadata relevant to an unpublished version with a valid auth header", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", unpublishedDatasetID, edition).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -211,11 +211,11 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 			}
 
 			Convey("When a request to get the metadata relevant to a version", func() {
-				Convey("Then return status bad request (404) with message `Edition not found`", func() {
+				Convey("Then return status bad request (404) with message `edition not found`", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 
 				})
 			})
@@ -228,11 +228,11 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 			}
 
 			Convey("When a request to get the metadata relevant to a version that does not exist", func() {
-				Convey("Then return status bad request (404) with message `Version not found`", func() {
+				Convey("Then return status bad request (404) with message `version not found`", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/metadata", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Version not found")
+						Body().Contains("version not found")
 
 				})
 			})
@@ -244,11 +244,11 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 				}
 
 				Convey("When a request to get the metadata relevant to version", func() {
-					Convey("Then return status bad request (404) with message `Version not found`", func() {
+					Convey("Then return status bad request (404) with message `version not found`", func() {
 
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/metadata", datasetID, edition).
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("Version not found")
+							Body().Contains("version not found")
 
 					})
 				})
@@ -256,12 +256,12 @@ func TestFailureToGetMetadataRelevantToVersion(t *testing.T) {
 				// Check web subnet is unable to authenticated auth tokens
 				// and hence is unable to find unpublished versions
 				Convey("When a request to get the metadata relevant to unpublished version with a valid auth header", func() {
-					Convey("Then return status bad request (404) with message `Version not found`", func() {
+					Convey("Then return status bad request (404) with message `version not found`", func() {
 
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/metadata", datasetID, edition).
 							WithHeader(florenceTokenName, florenceToken).
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("Version not found")
+							Body().Contains("version not found")
 
 					})
 				})

--- a/web/datasetAPI/get_observations_test.go
+++ b/web/datasetAPI/get_observations_test.go
@@ -174,11 +174,11 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When an authorised request to get an observation for a version of a dataset", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/observations", datasetID, edition).
 					WithQueryString("time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -215,11 +215,11 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 
 		Convey("but edition and version do not exist", func() {
 			Convey("When a request to get an observation for a version of a dataset", func() {
-				Convey("Then return status not found (404) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/observations", datasetID, edition).
 						WithQueryString("time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 				})
 			})
 		})
@@ -233,11 +233,11 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 
 			Convey("but a version does not exist", func() {
 				Convey("When a request to get an observation for a version of a dataset", func() {
-					Convey("Then return status not found (404) with message `Version not found`", func() {
+					Convey("Then return status not found (404) with message `version not found`", func() {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/observations", datasetID, edition).
 							WithQueryString("time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("Version not found")
+							Body().Contains("version not found")
 					})
 				})
 			})
@@ -253,7 +253,7 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/observations", datasetID, edition).
 							WithQueryString("age=24&gender=male&time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
 							Expect().Status(http.StatusBadRequest).
-							Body().Match(`Incorrect selection of query parameters: \[(age gender|gender age)\], these dimensions do not exist for this version of the dataset`)
+							Body().Match(`incorrect selection of query parameters: \[(age gender|gender age)\], these dimensions do not exist for this version of the dataset`)
 					})
 				})
 
@@ -262,7 +262,7 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/observations", datasetID, edition).
 							WithQueryString("geography=K02000001").
 							Expect().Status(http.StatusBadRequest).
-							Body().Match(`Missing query parameters for the following dimensions: \[(time aggregate|aggregate time)\]`)
+							Body().Match(`missing query parameters for the following dimensions: \[(time aggregate|aggregate time)\]`)
 					})
 				})
 
@@ -280,16 +280,16 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/observations", datasetID, edition).
 							WithQueryString("time=Aug-16&time=Aug-17&geography=K02000001&geography=*&aggregate=cpi1dim1S40403").
 							Expect().Status(http.StatusBadRequest).
-							Body().Match(`Multi-valued query parameters for the following dimensions: \[(time geography|geography time)\]`)
+							Body().Match(`multi-valued query parameters for the following dimensions: \[(time geography|geography time)\]`)
 					})
 				})
 
 				Convey("When a request to get an observation for a version of a dataset with the correct query parameters but the values don't exist", func() {
-					Convey("Then return status not found (404) with message `No observations found`", func() {
+					Convey("Then return status not found (404) with message `no observations found`", func() {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1/observations", datasetID, edition).
 							WithQueryString("time=Aug-17&geography=K02000001&aggregate=cpi1dim1S40403").
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("No observations found")
+							Body().Contains("no observations found")
 					})
 				})
 			})
@@ -309,10 +309,10 @@ func TestFailureToGetObservationsForVersion(t *testing.T) {
 				}
 
 				Convey("When a request to get an observation for a version of a dataset", func() {
-					Convey("Then return status not found (404) with message `Version not found`", func() {
+					Convey("Then return status not found (404) with message `version not found`", func() {
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/2/observations", datasetID, edition).
 							WithQueryString("time=Aug-16&geography=K02000001&aggregate=cpi1dim1S40403").
-							Expect().Status(http.StatusNotFound).Body().Contains("Version not found")
+							Expect().Status(http.StatusNotFound).Body().Contains("version not found")
 					})
 				})
 

--- a/web/datasetAPI/get_version_test.go
+++ b/web/datasetAPI/get_version_test.go
@@ -154,7 +154,7 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -166,7 +166,7 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -181,11 +181,11 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 	Convey("Given the dataset, edition and version do not exist", t, func() {
 		Convey("When a request to get the version of the dataset edition", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 			})
 		})
 	})
@@ -198,11 +198,11 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 		Convey("but an edition and version do not exist", func() {
 			Convey("When a request to get the version of the dataset edition", func() {
-				Convey("Then return status not found (404) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 
 				})
 			})
@@ -216,11 +216,11 @@ func TestFailureToGetVersionOfADatasetEdition(t *testing.T) {
 
 			Convey("but a version does not exist", func() {
 				Convey("When a request to get the version of the dataset edition", func() {
-					Convey("Then return status bad request (404) with message `Version not found`", func() {
+					Convey("Then return status bad request (404) with message `version not found`", func() {
 
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions/1", datasetID, edition).
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("Version not found")
+							Body().Contains("version not found")
 
 					})
 				})

--- a/web/datasetAPI/get_versions_test.go
+++ b/web/datasetAPI/get_versions_test.go
@@ -129,11 +129,11 @@ func TestGetVersions_Failed(t *testing.T) {
 
 	Convey("Given the dataset and subsequently the edition does not exist", t, func() {
 		Convey("When a request is made to get a list of versions of the dataset edition", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -147,11 +147,11 @@ func TestGetVersions_Failed(t *testing.T) {
 
 		Convey("but the edition does not", func() {
 			Convey("When a request is made to get a list of versions of the dataset edition", func() {
-				Convey("Then return status not found (404) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 
 				})
 			})
@@ -164,11 +164,11 @@ func TestGetVersions_Failed(t *testing.T) {
 			}
 
 			Convey("When a request is made to get a list of versions of the dataset edition", func() {
-				Convey("Then return status not found (404) with message `Version not found`", func() {
+				Convey("Then return status not found (404) with message `version not found`", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Version not found")
+						Body().Contains("version not found")
 
 				})
 			})
@@ -197,22 +197,22 @@ func TestGetVersions_Failed(t *testing.T) {
 		}
 
 		Convey("When a request is made to get a list of versions of the dataset edition", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
 
 		Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
-			Convey("Then return status not found (404) with message `Dataset not found`", func() {
+			Convey("Then return status not found (404) with message `dataset not found`", func() {
 
 				datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 					WithHeader(florenceTokenName, florenceToken).
 					Expect().Status(http.StatusNotFound).
-					Body().Contains("Dataset not found")
+					Body().Contains("dataset not found")
 
 			})
 		})
@@ -236,22 +236,22 @@ func TestGetVersions_Failed(t *testing.T) {
 			}
 
 			Convey("When a request is made to get a list of versions of the dataset edition", func() {
-				Convey("Then return status not found (404) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 
 				})
 			})
 
 			Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
-				Convey("Then return status not found (404) with message `Edition not found`", func() {
+				Convey("Then return status not found (404) with message `edition not found`", func() {
 
 					datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 						WithHeader(florenceTokenName, florenceToken).
 						Expect().Status(http.StatusNotFound).
-						Body().Contains("Edition not found")
+						Body().Contains("edition not found")
 
 				})
 			})
@@ -284,22 +284,22 @@ func TestGetVersions_Failed(t *testing.T) {
 				}
 
 				Convey("When a request is made to get a list of versions of the dataset edition", func() {
-					Convey("Then return status not found (404) with message `Version not found`", func() {
+					Convey("Then return status not found (404) with message `version not found`", func() {
 
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("Version not found")
+							Body().Contains("version not found")
 
 					})
 				})
 
 				Convey("When an authenticated request is made to get a list of versions of the dataset edition", func() {
-					Convey("Then return status not found (404) with message `Version not found`", func() {
+					Convey("Then return status not found (404) with message `version not found`", func() {
 
 						datasetAPI.GET("/datasets/{id}/editions/{edition}/versions", datasetID, edition).
 							WithHeader(florenceTokenName, florenceToken).
 							Expect().Status(http.StatusNotFound).
-							Body().Contains("Version not found")
+							Body().Contains("version not found")
 
 					})
 				})


### PR DESCRIPTION
### What

Expected error messages in response body is always lower cased for dataset API, acceptance test updated to reflect this.

### How to review

Make sure acceptance tests for dataset API (publishing and web) pass.

For acceptance tests to pass:
1) Make sure neo4j, mongo db and kafka & zookeeper are running
2) Run `dp-auth-api-stub` with `make debug`
3) Checkout `dp-dataset-api` on `feature/audit-get-unique-instance`
  a) Run: `make acceptance-publishing`
  b) Run: `make acceptance-web`
4) Run `dp-api-tests`
  a) Run: `cd publishing/datasetAPI; go test ./...; cd ../..`
  b) Run: `cd web/datasetAPI; go test ./...; cd ../..`

See dataset api pr [here](https://github.com/ONSdigital/dp-dataset-api/pull/156)

### Who can review

Anyone