### PR TITLE
Avoid running datastore services on conflicting local ports

### DIFF
--- a/automation/docker-compose.yml
+++ b/automation/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         hostname: zookeeper
         container_name: zookeeper
         ports:
-            - "2181:2181"
+            - "2182:2181"
         environment:
             ZOO_MY_ID: 1
             ZOO_PORT: 2181
@@ -19,7 +19,7 @@ services:
         image: confluentinc/cp-kafka:3.2.0
         hostname: kafka
         ports:
-            - "9092:9092"
+            - "9093:9092"
         environment:
             KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
             KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
@@ -48,7 +48,7 @@ services:
     vault:
         image: 'vault:0.9.5'
         ports:
-            - "127.0.0.1:8200:8200"
+            - "127.0.0.1:8201:8200"
         container_name: 'vault'
     
     elasticsearch:


### PR DESCRIPTION
### What

Don't map datastore ports to the default ports to avoid local conflicts when running services

### How to review

Verify the datastores are not being mapped to default ports locally

### Who can review

Anyone