### PR TITLE
Rename hardcoded database name in e2e test

### DIFF
--- a/endToEndTests/initialise.go
+++ b/endToEndTests/initialise.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	dropDatabases = []string{"tests"}
+	dropDatabases = []string{"test"}
 	vaultClient   *vault.VaultClient
 
 	headers = map[string]string{


### PR DESCRIPTION
### What

See title

### How to review

Check tests remove test data before running e2e test. Hardcoded variable should match default values in config for databases (e.g. `cfg.MongoDB`, `cfg.MongoImportsDB` & `cfg.MongoFiltersDB`)

### Who can review

Anyone
